### PR TITLE
Setup Home Assistant alarm system automations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+## Entity IDs
+- Door sensors: binary_sensor.main_panel_{front_door,garage_door,basement_door,sliding_door}
+- Motion sensors: binary_sensor.main_panel_{office_motion,family_room_motion}
+- Siren: switch.alarm_panel_56ac70_siren
+- Alarm panel: alarm_control_panel.home_alarm
+- Buzzer play: esphome.konnected_56a4fa_play_rtttl
+- Buzzer stop: esphome.konnected_56a4fa_stop_rtttl
+
+## Automation IDs
+- alarm_door_trigger, alarm_motion_trigger
+- alarm_exit_delay_beep, alarm_entry_delay_beep
+- alarm_triggered_siren, alarm_disarmed, alarm_armed_confirmation
+- door_chime

--- a/automations.yaml
+++ b/automations.yaml
@@ -1,0 +1,194 @@
+# automations.yaml — Home Alarm System
+# All automations defined in YAML. No UI-created automations.
+#
+# Alarm behavior:
+#   armed_away: all doors + motion sensors active
+#   armed_home: all doors active, motion sensors ignored
+#   All doors use entry/exit delay (no instant zones)
+#   Piezo buzzer provides audible feedback for all state transitions
+#   Siren activates only on triggered state
+#   Door chime plays when any door opens while disarmed
+
+# ============================================================
+# SENSOR TRIGGERS
+# ============================================================
+
+# Any door opened while armed → starts entry delay
+- id: alarm_door_trigger
+  alias: "Alarm: Door opened while armed"
+  description: >
+    Fires alarm_trigger when any door sensor goes ON while the alarm
+    is in armed_away or armed_home. The manual alarm platform handles
+    the pending → triggered state transition with the configured delay_time.
+  mode: single
+  trigger:
+    - platform: state
+      entity_id:
+        - binary_sensor.main_panel_front_door
+        - binary_sensor.main_panel_garage_door
+        - binary_sensor.main_panel_basement_door
+        - binary_sensor.main_panel_sliding_door
+      to: "on"
+  condition:
+    - condition: state
+      entity_id: alarm_control_panel.home_alarm
+      state:
+        - armed_away
+        - armed_home
+  action:
+    - action: alarm_control_panel.alarm_trigger
+      entity_id: alarm_control_panel.home_alarm
+
+# Motion detected while armed_away only → starts entry delay
+# Ignored in armed_home so you can move around the house at night.
+- id: alarm_motion_trigger
+  alias: "Alarm: Motion detected while armed away"
+  mode: single
+  trigger:
+    - platform: state
+      entity_id:
+        - binary_sensor.main_panel_office_motion
+        - binary_sensor.main_panel_family_room_motion
+      to: "on"
+  condition:
+    - condition: state
+      entity_id: alarm_control_panel.home_alarm
+      state: armed_away
+  action:
+    - action: alarm_control_panel.alarm_trigger
+      entity_id: alarm_control_panel.home_alarm
+
+# ============================================================
+# EXIT DELAY — beeping while arming (leaving the house)
+# ============================================================
+
+# Slow beep every 1.5s while alarm is in "arming" state.
+# Loop exits automatically when state changes.
+- id: alarm_exit_delay_beep
+  alias: "Alarm: Exit delay beeping"
+  mode: restart
+  trigger:
+    - platform: state
+      entity_id: alarm_control_panel.home_alarm
+      to: arming
+  action:
+    - repeat:
+        while:
+          - condition: state
+            entity_id: alarm_control_panel.home_alarm
+            state: arming
+        sequence:
+          - action: esphome.konnected_56a4fa_play_rtttl
+            data:
+              song_str: "exit:d=16,o=5,b=100:c,p"
+          - delay:
+              milliseconds: 1500
+
+# ============================================================
+# ENTRY DELAY — faster beeping while pending
+# ============================================================
+
+# Faster beep every 0.7s, higher pitch. Urgency signal:
+# "you have seconds to disarm."
+- id: alarm_entry_delay_beep
+  alias: "Alarm: Entry delay beeping"
+  mode: restart
+  trigger:
+    - platform: state
+      entity_id: alarm_control_panel.home_alarm
+      to: pending
+  action:
+    - repeat:
+        while:
+          - condition: state
+            entity_id: alarm_control_panel.home_alarm
+            state: pending
+        sequence:
+          - action: esphome.konnected_56a4fa_play_rtttl
+            data:
+              song_str: "entry:d=16,o=6,b=100:c,p"
+          - delay:
+              milliseconds: 700
+
+# ============================================================
+# TRIGGERED — siren activation
+# ============================================================
+
+# Entry delay expired without disarming. Bell goes off.
+- id: alarm_triggered_siren
+  alias: "Alarm: Triggered — activate siren"
+  mode: single
+  trigger:
+    - platform: state
+      entity_id: alarm_control_panel.home_alarm
+      to: triggered
+  action:
+    - action: esphome.konnected_56a4fa_stop_rtttl
+    - action: switch.turn_on
+      entity_id: switch.alarm_panel_56ac70_siren
+
+# ============================================================
+# DISARMED — silence everything
+# ============================================================
+
+# Kill siren, stop beeping, play descending confirmation tone.
+- id: alarm_disarmed
+  alias: "Alarm: Disarmed — all clear"
+  mode: single
+  trigger:
+    - platform: state
+      entity_id: alarm_control_panel.home_alarm
+      to: disarmed
+  action:
+    - action: switch.turn_off
+      entity_id: switch.alarm_panel_56ac70_siren
+    - action: esphome.konnected_56a4fa_stop_rtttl
+    - delay:
+        milliseconds: 300
+    - action: esphome.konnected_56a4fa_play_rtttl
+      data:
+        song_str: "disarm:d=8,o=5,b=200:e,c"
+
+# ============================================================
+# ARMED — confirmation tone
+# ============================================================
+
+# Ascending chirp when alarm reaches armed state.
+- id: alarm_armed_confirmation
+  alias: "Alarm: Armed — confirmation tone"
+  mode: single
+  trigger:
+    - platform: state
+      entity_id: alarm_control_panel.home_alarm
+      to:
+        - armed_away
+        - armed_home
+  action:
+    - action: esphome.konnected_56a4fa_play_rtttl
+      data:
+        song_str: "armed:d=8,o=5,b=200:c,e"
+
+# ============================================================
+# DOOR CHIME — when disarmed
+# ============================================================
+
+# Two-note chime when any door opens while disarmed.
+- id: door_chime
+  alias: "Door chime when disarmed"
+  mode: single
+  trigger:
+    - platform: state
+      entity_id:
+        - binary_sensor.main_panel_front_door
+        - binary_sensor.main_panel_garage_door
+        - binary_sensor.main_panel_basement_door
+        - binary_sensor.main_panel_sliding_door
+      to: "on"
+  condition:
+    - condition: state
+      entity_id: alarm_control_panel.home_alarm
+      state: disarmed
+  action:
+    - action: esphome.konnected_56a4fa_play_rtttl
+      data:
+        song_str: "chime:d=8,o=6,b=160:e,g"

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -17,19 +17,24 @@ scene: !include scenes.yaml
 # Cloud config
 cloud:
 
-# Alarm panel
+# Alarm panel — manual platform, all logic driven by automations
+# States: disarmed → arming (exit delay) → armed_away/armed_home
+#         armed → pending (entry delay) → triggered → (auto-disarm after trigger_time)
 alarm_control_panel:
   - platform: manual
     name: Home Alarm
     # code: !secret alarm_code
+    # Exit delay — time to leave after arming
     arming_time: 30
-    delay_time: 20
-    trigger_time: 4
+    # Entry delay — time to disarm after a sensor trips
+    delay_time: 30
+    # How long the siren sounds before auto-resetting (4 minutes)
+    trigger_time: 240
     disarmed:
       trigger_time: 0
     armed_home:
-      arming_time: 5
-      delay_time: 5
+      arming_time: 10
+      delay_time: 15
 
 # Prometheus
 prometheus:

--- a/groups.yaml
+++ b/groups.yaml
@@ -1,13 +1,15 @@
+# groups.yaml — Sensor groups for alarm panel and dashboard use
+
+doors:
+  name: Door Sensors
+  entities:
+    - binary_sensor.main_panel_front_door
+    - binary_sensor.main_panel_garage_door
+    - binary_sensor.main_panel_basement_door
+    - binary_sensor.main_panel_sliding_door
+
 motion:
   name: Motion Sensors
   entities:
-    - binary_sensor.family_room_motion
-    - binary_sensor.office_motion
-doors:
-  name: doors
-  entities:
-    - binary_sensor.front_door
-    - binary_sensor.basement_door
-    - binary_sensor.garage_door
-    - binary_sensor.sliding_door
-    - binary_sensor.ecolink_open_closed_side_door_contact
+    - binary_sensor.main_panel_office_motion
+    - binary_sensor.main_panel_family_room_motion


### PR DESCRIPTION
## Summary
- Add 8 alarm automations: door/motion triggers, exit/entry delay beeps, siren activation, disarm/arm confirmation tones, and door chime
- Update alarm panel timing: 30s entry/exit delay, 4-minute trigger duration, tuned armed_home delays
- Update groups.yaml entity IDs to match new ESPHome naming (`binary_sensor.main_panel_*`)
- Add CLAUDE.md with entity and automation ID quick reference

## Changes
| File | What changed |
|---|---|
| `automations.yaml` | All 8 alarm automations (was empty) |
| `configuration.yaml` | Alarm panel timing: `delay_time` 20→30, `trigger_time` 4→240, `armed_home` delays increased |
| `groups.yaml` | Entity IDs updated to ESPHome names, removed stale `ecolink` side door |
| `CLAUDE.md` | New — entity and automation ID quick reference |

## Test plan
- [ ] Run `ha core check` to validate YAML
- [ ] Restart HA with `ha core restart`
- [ ] Verify `alarm_control_panel.home_alarm` shows `disarmed` in Developer Tools → States
- [ ] Open a door while disarmed → door chime plays
- [ ] Arm away → slow beep for 30s exit delay → armed confirmation chirp
- [ ] Open a door while armed → fast beep for 30s entry delay → siren activates
- [ ] Disarm → siren stops, descending tone plays
- [ ] **Disarm after testing!**

https://claude.ai/code/session_012GWQ8MiZvikD5Skvk42ftG