### PR TITLE
Add home control dashboard with YAML-based Lovelace configuration

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -37,5 +37,15 @@ alarm_control_panel:
       arming_time: 10
       delay_time: 15
 
+# Dashboards — YAML-managed, git-tracked
+lovelace:
+  dashboards:
+    dashboard-home:
+      mode: yaml
+      filename: dashboards/home.yaml
+      title: Home
+      icon: mdi:home
+      show_in_sidebar: true
+
 # Prometheus
 prometheus:

--- a/dashboards/home.yaml
+++ b/dashboards/home.yaml
@@ -1,0 +1,272 @@
+# Home Control Dashboard
+# Designed for mobile device and wall-mounted tablet in kiosk mode.
+# Single-page layout: alarm → active music → lights → outdoor → sprinkler
+
+views:
+  - title: Home
+    path: home
+    icon: mdi:home
+    cards:
+
+      # ============================================================
+      # ALARM PANEL
+      # ============================================================
+
+      - type: alarm-panel
+        entity: alarm_control_panel.home_alarm
+        name: Home Alarm
+        states:
+          - arm_away
+          - arm_home
+
+      # Door and motion sensor status — compact glance card
+      - type: glance
+        title: Sensors
+        show_state: true
+        columns: 3
+        entities:
+          - entity: binary_sensor.main_panel_front_door
+            name: Front
+          - entity: binary_sensor.main_panel_garage_door
+            name: Garage
+          - entity: binary_sensor.main_panel_basement_door
+            name: Basement
+          - entity: binary_sensor.main_panel_sliding_door
+            name: Sliding
+          - entity: binary_sensor.main_panel_office_motion
+            name: Office
+          - entity: binary_sensor.main_panel_family_room_motion
+            name: Family Rm
+
+      # ============================================================
+      # NOW PLAYING — Sonos (conditional, only active speakers)
+      # ============================================================
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: media_player.office
+            state_not: idle
+          - condition: state
+            entity: media_player.office
+            state_not: unavailable
+        card:
+          type: media-control
+          entity: media_player.office
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: media_player.kitchen
+            state_not: idle
+          - condition: state
+            entity: media_player.kitchen
+            state_not: unavailable
+        card:
+          type: media-control
+          entity: media_player.kitchen
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: media_player.dining_room
+            state_not: idle
+          - condition: state
+            entity: media_player.dining_room
+            state_not: unavailable
+        card:
+          type: media-control
+          entity: media_player.dining_room
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: media_player.master_bedroom
+            state_not: idle
+          - condition: state
+            entity: media_player.master_bedroom
+            state_not: unavailable
+        card:
+          type: media-control
+          entity: media_player.master_bedroom
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: media_player.basement
+            state_not: idle
+          - condition: state
+            entity: media_player.basement
+            state_not: unavailable
+        card:
+          type: media-control
+          entity: media_player.basement
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: media_player.roam_2
+            state_not: idle
+          - condition: state
+            entity: media_player.roam_2
+            state_not: unavailable
+        card:
+          type: media-control
+          entity: media_player.roam_2
+
+      # ============================================================
+      # LIGHTS — grouped by room
+      # ============================================================
+
+      - type: entities
+        title: Kitchen
+        icon: mdi:silverware-fork-knife
+        show_header_toggle: true
+        entities:
+          - entity: light.kitchen_main
+            name: Main
+          - entity: light.kitchen_island
+            name: Island
+          - entity: light.kitchen_table
+            name: Table
+          - entity: light.kitchen_sink
+            name: Sink
+
+      - type: entities
+        title: Office
+        icon: mdi:desk
+        show_header_toggle: true
+        entities:
+          - entity: light.office
+            name: Main
+          - entity: light.office_lamp
+            name: Lamp
+          - entity: light.office_bookcase
+            name: Bookcase
+          - entity: light.office_corner
+            name: Corner
+          - entity: light.office_back_corner
+            name: Back Corner
+          - entity: light.office_door
+            name: Door
+          - entity: light.desk_lamp
+            name: Desk Lamp
+          - entity: light.desk_lamp_2
+            name: Desk Lamp 2
+
+      - type: entities
+        title: Play Room
+        icon: mdi:puzzle
+        show_header_toggle: true
+        entities:
+          - entity: light.play_room
+            name: Main
+          - entity: light.play_room_1
+            name: Light 1
+          - entity: light.play_room_2
+            name: Light 2
+          - entity: light.play_room_3
+            name: Light 3
+          - entity: light.play_room_4
+            name: Light 4
+
+      - type: entities
+        title: Family Room
+        icon: mdi:sofa
+        show_header_toggle: true
+        entities:
+          - entity: light.family_room
+            name: Main
+          - entity: light.family_room_2
+            name: Light 2
+          - entity: light.floor_lamp
+            name: Floor Lamp
+
+      - type: entities
+        title: Rest of House
+        icon: mdi:home-floor-1
+        show_header_toggle: false
+        entities:
+          - entity: light.entry_1
+            name: Entry 1
+          - entity: light.entry_2
+            name: Entry 2
+          - entity: light.upstairs_hallway_light
+            name: Upstairs Hallway
+          - entity: light.garage_front
+            name: Garage Front
+          - entity: light.garage_side
+            name: Garage Side
+          - entity: light.shed
+            name: Shed
+
+      # ============================================================
+      # OUTDOOR & UTILITY
+      # ============================================================
+
+      - type: entities
+        title: Outdoor
+        icon: mdi:tree
+        show_header_toggle: false
+        entities:
+          - entity: switch.back_porch
+            name: Back Porch
+          - entity: switch.garden
+            name: Garden
+
+      - type: entities
+        title: Indoor Switches
+        icon: mdi:power-socket-us
+        show_header_toggle: false
+        entities:
+          - entity: switch.family_room_outlets
+            name: Family Room Outlets
+          - entity: switch.play_room_outlet
+            name: Play Room Outlet
+          - entity: switch.bonus_room
+            name: Bonus Room
+          - entity: switch.basement_1
+            name: Basement
+
+      - type: entities
+        title: Workstation
+        icon: mdi:monitor
+        show_header_toggle: false
+        entities:
+          - entity: switch.workstation_1_switch_1
+            name: WS1 Switch 1
+          - entity: switch.workstation_1_switch_2
+            name: WS1 Switch 2
+          - entity: switch.workstation_2_switch_1
+            name: WS2 Switch 1
+          - entity: switch.workstation_2_switch_2
+            name: WS2 Switch 2
+
+      # ============================================================
+      # SPRINKLER — Rachio
+      # ============================================================
+
+      - type: entities
+        title: Sprinkler
+        icon: mdi:sprinkler-variant
+        show_header_toggle: false
+        entities:
+          - entity: switch.rachio_lawn_schedule
+            name: Lawn Schedule
+          - entity: switch.rachio_standby
+            name: Standby
+          - entity: switch.rachio_rain_delay
+            name: Rain Delay
+          - type: divider
+          - entity: switch.rachio_front_yard
+            name: Front Yard
+          - entity: switch.rachio_main_yard
+            name: Main Yard
+          - entity: switch.rachio_mid_yard
+            name: Mid Yard
+          - entity: switch.rachio_side_yard
+            name: Side Yard
+          - entity: switch.rachio_side_strip
+            name: Side Strip
+          - entity: switch.rachio_drip_lines
+            name: Drip Lines


### PR DESCRIPTION
## Summary
This PR introduces a new YAML-managed home control dashboard designed for mobile devices and wall-mounted tablets in kiosk mode. The dashboard is integrated into Home Assistant's Lovelace UI through configuration updates.

## Key Changes
- **New dashboard file** (`dashboards/home.yaml`): A comprehensive single-page home control interface featuring:
  - Alarm panel with arm_away and arm_home states
  - Door and motion sensor status glance card
  - Conditional media control cards for 6 Sonos speakers (office, kitchen, dining room, master bedroom, basement, roam_2)
  - Room-grouped lighting controls (kitchen, office, play room, family room, rest of house)
  - Outdoor switches (back porch, garden)
  - Indoor utility switches (outlets, bonus room, basement)
  - Workstation power management (2 workstations with 2 switches each)
  - Rachio sprinkler system controls with zone management

- **Configuration update** (`configuration.yaml`): Added Lovelace dashboard configuration to register the new YAML-based dashboard with:
  - YAML mode enabled for git-tracked dashboard management
  - Dashboard titled "Home" with home icon
  - Sidebar visibility enabled

## Implementation Details
- The dashboard uses conditional cards to display media players only when actively playing (not idle/unavailable)
- Lights are organized by room with header toggles for convenient bulk control
- Sprinkler controls include a divider to separate schedule/standby controls from individual zone switches
- The layout follows a logical flow: security → entertainment → lighting → utilities → irrigation

https://claude.ai/code/session_01RoWiX9ZJgcc5572Dc8meDt