### PR TITLE
Add Sonos group-aware dashboard with coordinator detection

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -49,3 +49,72 @@ lovelace:
 
 # Prometheus
 prometheus:
+
+# Template sensors for Sonos group-aware dashboard
+template:
+  - binary_sensor:
+      - name: "Sonos Office Leader"
+        unique_id: sonos_office_leader
+        state: >
+          {{ not is_state('media_player.office', 'idle')
+             and not is_state('media_player.office', 'unavailable')
+             and state_attr('media_player.office', 'group_members') is not none
+             and state_attr('media_player.office', 'group_members')[0] == 'media_player.office' }}
+        attributes:
+          group_count: >
+            {{ state_attr('media_player.office', 'group_members') | length if state_attr('media_player.office', 'group_members') is not none else 0 }}
+
+      - name: "Sonos Kitchen Leader"
+        unique_id: sonos_kitchen_leader
+        state: >
+          {{ not is_state('media_player.kitchen', 'idle')
+             and not is_state('media_player.kitchen', 'unavailable')
+             and state_attr('media_player.kitchen', 'group_members') is not none
+             and state_attr('media_player.kitchen', 'group_members')[0] == 'media_player.kitchen' }}
+        attributes:
+          group_count: >
+            {{ state_attr('media_player.kitchen', 'group_members') | length if state_attr('media_player.kitchen', 'group_members') is not none else 0 }}
+
+      - name: "Sonos Dining Room Leader"
+        unique_id: sonos_dining_room_leader
+        state: >
+          {{ not is_state('media_player.dining_room', 'idle')
+             and not is_state('media_player.dining_room', 'unavailable')
+             and state_attr('media_player.dining_room', 'group_members') is not none
+             and state_attr('media_player.dining_room', 'group_members')[0] == 'media_player.dining_room' }}
+        attributes:
+          group_count: >
+            {{ state_attr('media_player.dining_room', 'group_members') | length if state_attr('media_player.dining_room', 'group_members') is not none else 0 }}
+
+      - name: "Sonos Master Bedroom Leader"
+        unique_id: sonos_master_bedroom_leader
+        state: >
+          {{ not is_state('media_player.master_bedroom', 'idle')
+             and not is_state('media_player.master_bedroom', 'unavailable')
+             and state_attr('media_player.master_bedroom', 'group_members') is not none
+             and state_attr('media_player.master_bedroom', 'group_members')[0] == 'media_player.master_bedroom' }}
+        attributes:
+          group_count: >
+            {{ state_attr('media_player.master_bedroom', 'group_members') | length if state_attr('media_player.master_bedroom', 'group_members') is not none else 0 }}
+
+      - name: "Sonos Basement Leader"
+        unique_id: sonos_basement_leader
+        state: >
+          {{ not is_state('media_player.basement', 'idle')
+             and not is_state('media_player.basement', 'unavailable')
+             and state_attr('media_player.basement', 'group_members') is not none
+             and state_attr('media_player.basement', 'group_members')[0] == 'media_player.basement' }}
+        attributes:
+          group_count: >
+            {{ state_attr('media_player.basement', 'group_members') | length if state_attr('media_player.basement', 'group_members') is not none else 0 }}
+
+      - name: "Sonos Roam Leader"
+        unique_id: sonos_roam_leader
+        state: >
+          {{ not is_state('media_player.roam_2', 'idle')
+             and not is_state('media_player.roam_2', 'unavailable')
+             and state_attr('media_player.roam_2', 'group_members') is not none
+             and state_attr('media_player.roam_2', 'group_members')[0] == 'media_player.roam_2' }}
+        attributes:
+          group_count: >
+            {{ state_attr('media_player.roam_2', 'group_members') | length if state_attr('media_player.roam_2', 'group_members') is not none else 0 }}

--- a/dashboards/home.yaml
+++ b/dashboards/home.yaml
@@ -39,17 +39,14 @@ views:
             name: Family Rm
 
       # ============================================================
-      # NOW PLAYING — Sonos (conditional, only active speakers)
+      # NOW PLAYING — Sonos (group-aware, only coordinators shown)
       # ============================================================
 
       - type: conditional
         conditions:
           - condition: state
-            entity: media_player.office
-            state_not: idle
-          - condition: state
-            entity: media_player.office
-            state_not: unavailable
+            entity: binary_sensor.sonos_office_leader
+            state: "on"
         card:
           type: media-control
           entity: media_player.office
@@ -57,11 +54,8 @@ views:
       - type: conditional
         conditions:
           - condition: state
-            entity: media_player.kitchen
-            state_not: idle
-          - condition: state
-            entity: media_player.kitchen
-            state_not: unavailable
+            entity: binary_sensor.sonos_kitchen_leader
+            state: "on"
         card:
           type: media-control
           entity: media_player.kitchen
@@ -69,11 +63,8 @@ views:
       - type: conditional
         conditions:
           - condition: state
-            entity: media_player.dining_room
-            state_not: idle
-          - condition: state
-            entity: media_player.dining_room
-            state_not: unavailable
+            entity: binary_sensor.sonos_dining_room_leader
+            state: "on"
         card:
           type: media-control
           entity: media_player.dining_room
@@ -81,11 +72,8 @@ views:
       - type: conditional
         conditions:
           - condition: state
-            entity: media_player.master_bedroom
-            state_not: idle
-          - condition: state
-            entity: media_player.master_bedroom
-            state_not: unavailable
+            entity: binary_sensor.sonos_master_bedroom_leader
+            state: "on"
         card:
           type: media-control
           entity: media_player.master_bedroom
@@ -93,11 +81,8 @@ views:
       - type: conditional
         conditions:
           - condition: state
-            entity: media_player.basement
-            state_not: idle
-          - condition: state
-            entity: media_player.basement
-            state_not: unavailable
+            entity: binary_sensor.sonos_basement_leader
+            state: "on"
         card:
           type: media-control
           entity: media_player.basement
@@ -105,11 +90,8 @@ views:
       - type: conditional
         conditions:
           - condition: state
-            entity: media_player.roam_2
-            state_not: idle
-          - condition: state
-            entity: media_player.roam_2
-            state_not: unavailable
+            entity: binary_sensor.sonos_roam_leader
+            state: "on"
         card:
           type: media-control
           entity: media_player.roam_2
@@ -173,12 +155,15 @@ views:
       - type: entities
         title: Family Room
         icon: mdi:sofa
-        show_header_toggle: true
+        show_header_toggle: false
         entities:
           - entity: light.family_room
             name: Main
           - entity: light.family_room_2
             name: Light 2
+          - type: divider
+          - entity: switch.family_room_outlets
+            name: Outlets (powers floor lamp)
           - entity: light.floor_lamp
             name: Floor Lamp
 
@@ -219,8 +204,6 @@ views:
         icon: mdi:power-socket-us
         show_header_toggle: false
         entities:
-          - entity: switch.family_room_outlets
-            name: Family Room Outlets
           - entity: switch.play_room_outlet
             name: Play Room Outlet
           - entity: switch.bonus_room


### PR DESCRIPTION
## Summary
Refactored the Sonos media player dashboard to be group-aware by introducing template binary sensors that detect when a Sonos speaker is the group coordinator. This prevents duplicate now-playing cards from appearing when speakers are grouped together.

## Key Changes
- **Added template binary sensors** in `configuration.yaml` for each Sonos speaker (office, kitchen, dining room, master bedroom, basement, roam) that:
  - Detect if a speaker is actively playing (not idle/unavailable)
  - Check if the speaker is the first member of its group (coordinator)
  - Include a `group_count` attribute showing how many speakers are in the group
  
- **Updated dashboard conditionals** in `dashboards/home.yaml` to:
  - Replace dual state conditions (not idle AND not unavailable) with single binary sensor conditions
  - Only display media control cards when a speaker is the group coordinator
  - Simplifies conditional logic from 2 conditions per speaker to 1

- **Minor UI improvements**:
  - Changed Family Room entities card header toggle from `true` to `false`
  - Added divider and reorganized Family Room outlets switch placement for better visual hierarchy
  - Moved Family Room Outlets from the Outlets section to the Family Room section for logical grouping

## Implementation Details
The template sensors use Jinja2 templating to evaluate the `group_members` attribute from each media player, checking if the current speaker is at index 0 (the coordinator). This approach leverages Home Assistant's native Sonos group detection rather than implementing custom logic.

https://claude.ai/code/session_01R6JXdzizw1Ymujyiq5Sg1D