### PR TITLE
Add paused state handling to Sonos dashboard with resume buttons

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -53,68 +53,90 @@ prometheus:
 # Template sensors for Sonos group-aware dashboard
 template:
   - binary_sensor:
+      # --- Playing + group coordinator sensors ---
+
       - name: "Sonos Office Leader"
         unique_id: sonos_office_leader
         state: >
-          {{ not is_state('media_player.office', 'idle')
-             and not is_state('media_player.office', 'unavailable')
+          {{ is_state('media_player.office', 'playing')
              and state_attr('media_player.office', 'group_members') is not none
              and state_attr('media_player.office', 'group_members')[0] == 'media_player.office' }}
-        attributes:
-          group_count: >
-            {{ state_attr('media_player.office', 'group_members') | length if state_attr('media_player.office', 'group_members') is not none else 0 }}
 
       - name: "Sonos Kitchen Leader"
         unique_id: sonos_kitchen_leader
         state: >
-          {{ not is_state('media_player.kitchen', 'idle')
-             and not is_state('media_player.kitchen', 'unavailable')
+          {{ is_state('media_player.kitchen', 'playing')
              and state_attr('media_player.kitchen', 'group_members') is not none
              and state_attr('media_player.kitchen', 'group_members')[0] == 'media_player.kitchen' }}
-        attributes:
-          group_count: >
-            {{ state_attr('media_player.kitchen', 'group_members') | length if state_attr('media_player.kitchen', 'group_members') is not none else 0 }}
 
       - name: "Sonos Dining Room Leader"
         unique_id: sonos_dining_room_leader
         state: >
-          {{ not is_state('media_player.dining_room', 'idle')
-             and not is_state('media_player.dining_room', 'unavailable')
+          {{ is_state('media_player.dining_room', 'playing')
              and state_attr('media_player.dining_room', 'group_members') is not none
              and state_attr('media_player.dining_room', 'group_members')[0] == 'media_player.dining_room' }}
-        attributes:
-          group_count: >
-            {{ state_attr('media_player.dining_room', 'group_members') | length if state_attr('media_player.dining_room', 'group_members') is not none else 0 }}
 
       - name: "Sonos Master Bedroom Leader"
         unique_id: sonos_master_bedroom_leader
         state: >
-          {{ not is_state('media_player.master_bedroom', 'idle')
-             and not is_state('media_player.master_bedroom', 'unavailable')
+          {{ is_state('media_player.master_bedroom', 'playing')
              and state_attr('media_player.master_bedroom', 'group_members') is not none
              and state_attr('media_player.master_bedroom', 'group_members')[0] == 'media_player.master_bedroom' }}
-        attributes:
-          group_count: >
-            {{ state_attr('media_player.master_bedroom', 'group_members') | length if state_attr('media_player.master_bedroom', 'group_members') is not none else 0 }}
 
       - name: "Sonos Basement Leader"
         unique_id: sonos_basement_leader
         state: >
-          {{ not is_state('media_player.basement', 'idle')
-             and not is_state('media_player.basement', 'unavailable')
+          {{ is_state('media_player.basement', 'playing')
              and state_attr('media_player.basement', 'group_members') is not none
              and state_attr('media_player.basement', 'group_members')[0] == 'media_player.basement' }}
-        attributes:
-          group_count: >
-            {{ state_attr('media_player.basement', 'group_members') | length if state_attr('media_player.basement', 'group_members') is not none else 0 }}
 
       - name: "Sonos Roam Leader"
         unique_id: sonos_roam_leader
         state: >
-          {{ not is_state('media_player.roam_2', 'idle')
-             and not is_state('media_player.roam_2', 'unavailable')
+          {{ is_state('media_player.roam_2', 'playing')
              and state_attr('media_player.roam_2', 'group_members') is not none
              and state_attr('media_player.roam_2', 'group_members')[0] == 'media_player.roam_2' }}
-        attributes:
-          group_count: >
-            {{ state_attr('media_player.roam_2', 'group_members') | length if state_attr('media_player.roam_2', 'group_members') is not none else 0 }}
+
+      # --- Paused + group coordinator sensors ---
+
+      - name: "Sonos Office Paused"
+        unique_id: sonos_office_paused
+        state: >
+          {{ is_state('media_player.office', 'paused')
+             and state_attr('media_player.office', 'group_members') is not none
+             and state_attr('media_player.office', 'group_members')[0] == 'media_player.office' }}
+
+      - name: "Sonos Kitchen Paused"
+        unique_id: sonos_kitchen_paused
+        state: >
+          {{ is_state('media_player.kitchen', 'paused')
+             and state_attr('media_player.kitchen', 'group_members') is not none
+             and state_attr('media_player.kitchen', 'group_members')[0] == 'media_player.kitchen' }}
+
+      - name: "Sonos Dining Room Paused"
+        unique_id: sonos_dining_room_paused
+        state: >
+          {{ is_state('media_player.dining_room', 'paused')
+             and state_attr('media_player.dining_room', 'group_members') is not none
+             and state_attr('media_player.dining_room', 'group_members')[0] == 'media_player.dining_room' }}
+
+      - name: "Sonos Master Bedroom Paused"
+        unique_id: sonos_master_bedroom_paused
+        state: >
+          {{ is_state('media_player.master_bedroom', 'paused')
+             and state_attr('media_player.master_bedroom', 'group_members') is not none
+             and state_attr('media_player.master_bedroom', 'group_members')[0] == 'media_player.master_bedroom' }}
+
+      - name: "Sonos Basement Paused"
+        unique_id: sonos_basement_paused
+        state: >
+          {{ is_state('media_player.basement', 'paused')
+             and state_attr('media_player.basement', 'group_members') is not none
+             and state_attr('media_player.basement', 'group_members')[0] == 'media_player.basement' }}
+
+      - name: "Sonos Roam Paused"
+        unique_id: sonos_roam_paused
+        state: >
+          {{ is_state('media_player.roam_2', 'paused')
+             and state_attr('media_player.roam_2', 'group_members') is not none
+             and state_attr('media_player.roam_2', 'group_members')[0] == 'media_player.roam_2' }}

--- a/dashboards/home.yaml
+++ b/dashboards/home.yaml
@@ -39,8 +39,13 @@ views:
             name: Family Rm
 
       # ============================================================
-      # NOW PLAYING — Sonos (group-aware, only coordinators shown)
+      # NOW PLAYING — Sonos (group-aware)
+      # Playing speakers: full media-control card (coordinator only)
+      # Paused speakers: compact resume button (coordinator only)
+      # Idle/unavailable: hidden
       # ============================================================
+
+      # --- Playing: full media controls ---
 
       - type: conditional
         conditions:
@@ -95,6 +100,111 @@ views:
         card:
           type: media-control
           entity: media_player.roam_2
+
+      # --- Paused: compact resume buttons ---
+      # Tap to resume playback. Button disappears, full card appears.
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: binary_sensor.sonos_office_paused
+            state: "on"
+        card:
+          type: button
+          entity: media_player.office
+          name: Office (Paused)
+          icon: mdi:play-circle-outline
+          show_state: false
+          tap_action:
+            action: call-service
+            service: media_player.media_play
+            target:
+              entity_id: media_player.office
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: binary_sensor.sonos_kitchen_paused
+            state: "on"
+        card:
+          type: button
+          entity: media_player.kitchen
+          name: Kitchen (Paused)
+          icon: mdi:play-circle-outline
+          show_state: false
+          tap_action:
+            action: call-service
+            service: media_player.media_play
+            target:
+              entity_id: media_player.kitchen
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: binary_sensor.sonos_dining_room_paused
+            state: "on"
+        card:
+          type: button
+          entity: media_player.dining_room
+          name: Dining Room (Paused)
+          icon: mdi:play-circle-outline
+          show_state: false
+          tap_action:
+            action: call-service
+            service: media_player.media_play
+            target:
+              entity_id: media_player.dining_room
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: binary_sensor.sonos_master_bedroom_paused
+            state: "on"
+        card:
+          type: button
+          entity: media_player.master_bedroom
+          name: Master Bedroom (Paused)
+          icon: mdi:play-circle-outline
+          show_state: false
+          tap_action:
+            action: call-service
+            service: media_player.media_play
+            target:
+              entity_id: media_player.master_bedroom
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: binary_sensor.sonos_basement_paused
+            state: "on"
+        card:
+          type: button
+          entity: media_player.basement
+          name: Basement (Paused)
+          icon: mdi:play-circle-outline
+          show_state: false
+          tap_action:
+            action: call-service
+            service: media_player.media_play
+            target:
+              entity_id: media_player.basement
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: binary_sensor.sonos_roam_paused
+            state: "on"
+        card:
+          type: button
+          entity: media_player.roam_2
+          name: Roam (Paused)
+          icon: mdi:play-circle-outline
+          show_state: false
+          tap_action:
+            action: call-service
+            service: media_player.media_play
+            target:
+              entity_id: media_player.roam_2
 
       # ============================================================
       # LIGHTS — grouped by room


### PR DESCRIPTION
## Summary
Enhanced the Sonos dashboard to display paused speakers with compact resume buttons, improving the user experience by showing all active speaker states (playing and paused) while hiding idle/unavailable speakers.

## Key Changes

- **Updated dashboard layout**: Reorganized the NOW PLAYING section with clear comments distinguishing between playing speakers (full media-control cards) and paused speakers (compact resume buttons)

- **Added paused state sensors**: Created 6 new binary sensors in `configuration.yaml` to detect when each Sonos speaker is paused and is a group coordinator:
  - `binary_sensor.sonos_office_paused`
  - `binary_sensor.sonos_kitchen_paused`
  - `binary_sensor.sonos_dining_room_paused`
  - `binary_sensor.sonos_master_bedroom_paused`
  - `binary_sensor.sonos_basement_paused`
  - `binary_sensor.sonos_roam_paused`

- **Added paused speaker cards**: Implemented 6 conditional button cards in the dashboard that appear when speakers are paused, allowing users to tap to resume playback with a single action

- **Refined playing state sensors**: Updated existing "Leader" sensors to explicitly check for `playing` state instead of checking for "not idle and not unavailable", making the logic more precise and maintainable

- **Removed unused attributes**: Cleaned up `group_count` attributes from all leader sensors as they were not being used in the UI

## Implementation Details

- Paused buttons use `mdi:play-circle-outline` icon for visual consistency
- Resume action calls `media_player.media_play` service directly on the coordinator speaker
- All paused/playing sensors only trigger for group coordinators, maintaining the group-aware behavior
- Idle and unavailable speakers remain hidden from the dashboard

https://claude.ai/code/session_01LHf5s5AQsYcoKYqTcQmfZ4