### PR TITLE
Dark mode kiosk display with HACS kiosk-mode

### DIFF
--- a/themes/kiosk_dark.yaml
+++ b/themes/kiosk_dark.yaml
@@ -1,43 +1,23 @@
 kiosk_dark:
-  # Base
-  modes:
-    dark:
-      # Primary colors
-      primary-color: "#4fc3f7"
-      accent-color: "#4fc3f7"
-
-      # Background
-      primary-background-color: "#0d1117"
-      secondary-background-color: "#161b22"
-      card-background-color: "#1c2128"
-
-      # Text
-      primary-text-color: "#e6edf3"
-      secondary-text-color: "#8b949e"
-
-      # Header
-      app-header-background-color: "#0d1117"
-      app-header-text-color: "#e6edf3"
-
-      # Cards
-      ha-card-background: "#1c2128"
-      ha-card-border-color: "#30363d"
-      ha-card-border-width: "1px"
-      ha-card-border-radius: "8px"
-      ha-card-box-shadow: "none"
-
-      # States
-      state-icon-active-color: "#f0b429"
-      state-icon-color: "#8b949e"
-
-      # Tile card specific
-      state-light-active-color: "#f0b429"
-      state-binary_sensor-active-color: "#f85149"
-      state-switch-active-color: "#4fc3f7"
-
-      # Dividers
-      divider-color: "#30363d"
-
-      # Sidebar (hidden in kiosk, but just in case)
-      sidebar-background-color: "#0d1117"
-      sidebar-text-color: "#e6edf3"
+  primary-color: "#4fc3f7"
+  accent-color: "#4fc3f7"
+  primary-background-color: "#0d1117"
+  secondary-background-color: "#161b22"
+  card-background-color: "#1c2128"
+  primary-text-color: "#e6edf3"
+  secondary-text-color: "#8b949e"
+  app-header-background-color: "#0d1117"
+  app-header-text-color: "#e6edf3"
+  ha-card-background: "#1c2128"
+  ha-card-border-color: "#30363d"
+  ha-card-border-width: "1px"
+  ha-card-border-radius: "8px"
+  ha-card-box-shadow: "none"
+  state-icon-active-color: "#f0b429"
+  state-icon-color: "#8b949e"
+  state-light-active-color: "#f0b429"
+  state-binary_sensor-active-color: "#f85149"
+  state-switch-active-color: "#4fc3f7"
+  divider-color: "#30363d"
+  sidebar-background-color: "#0d1117"
+  sidebar-text-color: "#e6edf3"


### PR DESCRIPTION
## Summary
- Add `kiosk_dark` theme (GitHub Dark palette): charcoal background, amber active lights, red door alerts, blue switches, muted gray inactive
- Register HACS kiosk-mode plugin in `configuration.yaml` to hide header/sidebar for non-admin users
- Add `kiosk_mode` config to dashboard with dedicated "Kiosk" user support for full chrome-free display
- Update kiosk view with dark theme assignment and vertical tile layout for compact security strip

## Manual steps after merge
1. Install HACS on the HA instance (`wget -O - https://get.hacs.xyz | bash -`)
2. Install **kiosk-mode** plugin via HACS Frontend
3. Create a non-admin "Kiosk" user (Settings → People → Add Person)
4. Point the wall display Chromium to `/dashboard-home/kiosk`
5. `ha core check && ha core restart`

## Color reference
| Element | Hex |
|---------|-----|
| Background | `#0d1117` |
| Card bg | `#1c2128` |
| Active light | `#f0b429` |
| Active sensor | `#f85149` |
| Active switch | `#4fc3f7` |

https://claude.ai/code/session_01VBt7dhKkUioCt3DGnUVY5j