### PR TITLE
Enhance home dashboard with weather widget and outdoor lights

### DIFF
--- a/dashboards/home.yaml
+++ b/dashboards/home.yaml
@@ -65,6 +65,15 @@ views:
             icon: mdi:motion-sensor
 
       # ============================================================
+      # WEATHER
+      # ============================================================
+
+      - type: weather-forecast
+        entity: weather.forecast_home
+        show_forecast: true
+        forecast_type: daily
+
+      # ============================================================
       # NOW PLAYING — Sonos (group-aware, coordinators only)
       # ============================================================
 
@@ -234,6 +243,9 @@ views:
             entity: light.entry_2
             name: Entry 2
           - type: tile
+            entity: light.downstairs_hallway
+            name: Downstairs Hall
+          - type: tile
             entity: light.upstairs_hallway_light
             name: Upstairs Hall
 
@@ -246,6 +258,14 @@ views:
         columns: 2
         square: false
         cards:
+          - type: tile
+            entity: light.front_door
+            name: Front Door
+            icon: mdi:coach-lamp
+          - type: tile
+            entity: light.front_lantern
+            name: Front Lantern
+            icon: mdi:lamp-outline
           - type: tile
             entity: light.garage_front
             name: Garage Front
@@ -318,7 +338,7 @@ views:
 
   # =================================================================
   # KIOSK VIEW — 65" 1080p wall display
-  # Dark theme, no sidebar, no header, full-screen panel layout
+  # Dark theme, panel layout, three columns
   # URL: /dashboard-home/kiosk
   # =================================================================
   - title: Kiosk
@@ -367,11 +387,11 @@ views:
                 icon: mdi:motion-sensor
                 vertical: true
 
-          # ---- ROW 2+: Three-column layout ----
+          # ---- ROW 2: Three-column layout ----
           - type: horizontal-stack
             cards:
 
-              # ===== COLUMN 1 =====
+              # ===== COLUMN 1: Kitchen + Play Room + Family Room =====
               - type: vertical-stack
                 cards:
                   - type: grid
@@ -432,7 +452,7 @@ views:
                         entity: light.floor_lamp
                         name: Floor Lamp
 
-              # ===== COLUMN 2 =====
+              # ===== COLUMN 2: Office + Entry/Upstairs + Switches =====
               - type: vertical-stack
                 cards:
                   - type: grid
@@ -477,17 +497,50 @@ views:
                         entity: light.entry_2
                         name: Entry 2
                       - type: tile
+                        entity: light.downstairs_hallway
+                        name: Downstairs Hall
+                      - type: tile
                         entity: light.upstairs_hallway_light
                         name: Upstairs Hall
 
-              # ===== COLUMN 3 =====
+                  - type: grid
+                    title: Switches
+                    columns: 2
+                    square: false
+                    cards:
+                      - type: tile
+                        entity: switch.play_room_outlet
+                        name: Play Room
+                        icon: mdi:power-plug
+                      - type: tile
+                        entity: switch.bonus_room
+                        name: Bonus Room
+                      - type: tile
+                        entity: switch.basement_1
+                        name: Basement
+
+              # ===== COLUMN 3: Weather + Outdoor + Sonos (bottom-anchored) =====
               - type: vertical-stack
                 cards:
+                  # --- Weather ---
+                  - type: weather-forecast
+                    entity: weather.forecast_home
+                    show_forecast: true
+                    forecast_type: daily
+
                   - type: grid
                     title: Outdoor
                     columns: 2
                     square: false
                     cards:
+                      - type: tile
+                        entity: light.front_door
+                        name: Front Door
+                        icon: mdi:coach-lamp
+                      - type: tile
+                        entity: light.front_lantern
+                        name: Front Lantern
+                        icon: mdi:lamp-outline
                       - type: tile
                         entity: light.garage_front
                         name: Garage Front
@@ -509,23 +562,11 @@ views:
                         name: Garden
                         icon: mdi:flower
 
-                  - type: grid
-                    title: Switches
-                    columns: 2
-                    square: false
-                    cards:
-                      - type: tile
-                        entity: switch.play_room_outlet
-                        name: Play Room
-                        icon: mdi:power-plug
-                      - type: tile
-                        entity: switch.bonus_room
-                        name: Bonus Room
-                      - type: tile
-                        entity: switch.basement_1
-                        name: Basement
-
-                  # Sonos: conditional, playing coordinators only
+                  # --- Sonos: bottom-anchored ---
+                  # These are at the bottom of Column 3.
+                  # When nothing is playing, the column just ends shorter.
+                  # When music starts, cards appear here without shifting
+                  # anything in Columns 1 or 2.
                   - type: conditional
                     conditions:
                       - condition: state


### PR DESCRIPTION
## Summary
This PR improves the home dashboard layout and adds missing light controls and weather information across both the main and kiosk views.

## Key Changes

- **Added weather forecast widget** to the main dashboard and kiosk view's Column 3 for at-a-glance weather information
- **Added outdoor light controls** (Front Door and Front Lantern) to both the main Outdoor section and kiosk view
- **Added Downstairs Hallway light** to the main dashboard's hallway lights section and kiosk view's Column 2
- **Reorganized kiosk view layout** for better information hierarchy:
  - Moved Switches grid from Column 3 to Column 2 (with Entry/Upstairs lights)
  - Moved Weather widget to top of Column 3
  - Repositioned Outdoor lights in Column 3 (now includes Front Door and Front Lantern)
  - Anchored Sonos player to bottom of Column 3 to prevent layout shift when playback starts
- **Updated kiosk view documentation** to reflect the three-column layout structure with clearer section headers

## Implementation Details

- Weather widget uses `weather.forecast_home` entity with daily forecast display
- Outdoor lights use appropriate Material Design icons (coach-lamp for front door, lamp-outline for lantern)
- Kiosk view reorganization maintains responsive grid layout while improving visual flow
- Added clarifying comments in kiosk view to document the three-column structure and Sonos conditional behavior

https://claude.ai/code/session_01WsADTWq2xv9Mi7Q1R7WEYg