### PR TITLE
Add section headers and "all off" states for lights and switches

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -96,3 +96,25 @@ template:
              and state_attr('media_player.roam_2', 'group_members') is not none
              and state_attr('media_player.roam_2', 'group_members')[0] == 'media_player.roam_2' }}
 
+      # --- Lights activity ---
+      - name: "Any Light On"
+        unique_id: any_light_on
+        icon: mdi:lightbulb-group
+        state: >
+          {{ states.light
+             | selectattr('state', 'eq', 'on')
+             | rejectattr('entity_id', 'search', 'alarm_panel')
+             | list | count > 0 }}
+
+      # --- Switches activity ---
+      - name: "Any Switch On"
+        unique_id: any_switch_on
+        icon: mdi:power-plug
+        state: >
+          {{ is_state('switch.back_porch', 'on')
+             or is_state('switch.garden', 'on')
+             or is_state('switch.family_room_outlets', 'on')
+             or is_state('switch.play_room_outlet', 'on')
+             or is_state('switch.bonus_room', 'on')
+             or is_state('switch.basement_1', 'on') }}
+

--- a/dashboards/home.yaml
+++ b/dashboards/home.yaml
@@ -114,7 +114,18 @@ views:
           type: media-control
           entity: media_player.roam_2
 
-      # --- Lights: show only when ON ---
+      # --- Lights section ---
+      - type: markdown
+        content: "## Lights"
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: binary_sensor.any_light_on
+            state: "off"
+        card:
+          type: markdown
+          content: "All lights off"
 
       # Kitchen
       - type: conditional
@@ -417,7 +428,19 @@ views:
           name: Shed
           icon: mdi:shed
 
-      # Switches — show only when ON
+      # --- Switches section ---
+      - type: markdown
+        content: "## Switches"
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: binary_sensor.any_switch_on
+            state: "off"
+        card:
+          type: markdown
+          content: "All switches off"
+
       - type: conditional
         conditions:
           - condition: state
@@ -590,7 +613,18 @@ views:
           type: media-control
           entity: media_player.roam_2
 
-      # --- Lights: show only when ON ---
+      # --- Lights section ---
+      - type: markdown
+        content: "## Lights"
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: binary_sensor.any_light_on
+            state: "off"
+        card:
+          type: markdown
+          content: "All lights off"
 
       - type: conditional
         conditions:
@@ -886,6 +920,19 @@ views:
           entity: light.shed
           name: Shed
           icon: mdi:shed
+
+      # --- Switches section ---
+      - type: markdown
+        content: "## Switches"
+
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: binary_sensor.any_switch_on
+            state: "off"
+        card:
+          type: markdown
+          content: "All switches off"
 
       - type: conditional
         conditions:


### PR DESCRIPTION
## Summary
Enhanced the home dashboard UI with section headers and conditional "all off" messages for lights and switches, while adding template sensors to track their activity states.

## Key Changes
- **Dashboard UI improvements**: Added markdown section headers ("## Lights" and "## Switches") to organize dashboard cards across multiple views
- **Conditional "all off" messages**: Implemented conditional cards that display "All lights off" and "All switches off" messages when no devices are active, improving visual feedback
- **Template sensors**: Created two new binary template sensors in `configuration.yaml`:
  - `binary_sensor.any_light_on`: Dynamically detects if any light is on (excluding alarm panel entities)
  - `binary_sensor.any_switch_on`: Tracks if any of the monitored switches are on (back porch, garden, family room outlets, play room outlet, bonus room, basement)
- **Consistent implementation**: Applied the same pattern across multiple dashboard views for consistency

## Implementation Details
- The "any light on" sensor uses a Jinja2 template with `selectattr` and `rejectattr` filters for flexible light detection
- The "any switch on" sensor uses explicit state checks for the specific switches being monitored
- Conditional cards reference these sensors to show/hide the "all off" messages based on device activity

https://claude.ai/code/session_01LKQRRmZpB8Gsdyepi2ebNt