### PR TITLE
Add card-mod for visible room borders on kiosk view

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -5,6 +5,7 @@ frontend:
   themes: !include_dir_merge_named themes
   extra_module_url:
     - /hacsfiles/kiosk-mode/kiosk-mode.js
+    - /hacsfiles/card-mod/card-mod.js
 
 # Text to speech
 tts:

--- a/dashboards/home.yaml
+++ b/dashboards/home.yaml
@@ -604,6 +604,13 @@ views:
                     title: Kitchen
                     columns: 2
                     square: false
+                    card_mod:
+                      style: |
+                        ha-card {
+                          border: 2px solid #484f58 !important;
+                          border-radius: 12px !important;
+                          padding: 8px !important;
+                        }
                     cards:
                       - type: tile
                         entity: light.kitchen_main
@@ -622,6 +629,13 @@ views:
                     title: Play Room
                     columns: 2
                     square: false
+                    card_mod:
+                      style: |
+                        ha-card {
+                          border: 2px solid #484f58 !important;
+                          border-radius: 12px !important;
+                          padding: 8px !important;
+                        }
                     cards:
                       - type: tile
                         entity: light.play_room
@@ -643,6 +657,13 @@ views:
                     title: Family Room
                     columns: 2
                     square: false
+                    card_mod:
+                      style: |
+                        ha-card {
+                          border: 2px solid #484f58 !important;
+                          border-radius: 12px !important;
+                          padding: 8px !important;
+                        }
                     cards:
                       - type: tile
                         entity: light.family_room
@@ -665,6 +686,13 @@ views:
                     title: Office
                     columns: 2
                     square: false
+                    card_mod:
+                      style: |
+                        ha-card {
+                          border: 2px solid #484f58 !important;
+                          border-radius: 12px !important;
+                          padding: 8px !important;
+                        }
                     cards:
                       - type: tile
                         entity: light.office
@@ -695,6 +723,13 @@ views:
                     title: Entry & Upstairs
                     columns: 2
                     square: false
+                    card_mod:
+                      style: |
+                        ha-card {
+                          border: 2px solid #484f58 !important;
+                          border-radius: 12px !important;
+                          padding: 8px !important;
+                        }
                     cards:
                       - type: tile
                         entity: light.entry_1
@@ -713,6 +748,13 @@ views:
                     title: Switches
                     columns: 2
                     square: false
+                    card_mod:
+                      style: |
+                        ha-card {
+                          border: 2px solid #484f58 !important;
+                          border-radius: 12px !important;
+                          padding: 8px !important;
+                        }
                     cards:
                       - type: tile
                         entity: switch.play_room_outlet
@@ -732,6 +774,13 @@ views:
                     title: Outdoor
                     columns: 2
                     square: false
+                    card_mod:
+                      style: |
+                        ha-card {
+                          border: 2px solid #484f58 !important;
+                          border-radius: 12px !important;
+                          padding: 8px !important;
+                        }
                     cards:
                       - type: tile
                         entity: light.front_door


### PR DESCRIPTION
- Register card-mod.js in frontend extra_module_url
- Add card_mod style to all 7 room grid cards in kiosk view
- 2px solid #484f58 border, 12px radius, 8px padding
- Requires HA restart for extra_module_url change

https://claude.ai/code/session_013YcGe7Cx57bXvUMkviPMt5