### PR TITLE
Polish: Noctis theme, hide unavailable, room borders

### DIFF
--- a/dashboards/home.yaml
+++ b/dashboards/home.yaml
@@ -538,13 +538,14 @@ views:
               name: Basement
 
   # =================================================================
-  # KIOSK VIEW — 65" 1080p wall display, dark theme
+  # KIOSK VIEW — 65" 1080p wall display, Noctis theme
   # Grid layout, four columns, alarm chip animation
+  # Unavailable entities hidden via conditional wrapping
   # URL: /dashboard-home/kiosk
   # =================================================================
   - title: Kiosk
     path: kiosk
-    theme: kiosk_dark
+    theme: Noctis
     type: custom:grid-layout
     icon: mdi:monitor
     layout:
@@ -661,23 +662,47 @@ views:
             card_mod:
               style: |
                 ha-card {
-                  border: 2px solid #484f58 !important;
+                  border: 1px solid rgba(255, 255, 255, 0.1) !important;
                   border-radius: 12px !important;
                   padding: 8px !important;
                 }
             cards:
-              - type: tile
-                entity: light.kitchen_main
-                name: Main
-              - type: tile
-                entity: light.kitchen_island
-                name: Island
-              - type: tile
-                entity: light.kitchen_table
-                name: Table
-              - type: tile
-                entity: light.kitchen_sink
-                name: Sink
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.kitchen_main
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.kitchen_main
+                  name: Main
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.kitchen_island
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.kitchen_island
+                  name: Island
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.kitchen_table
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.kitchen_table
+                  name: Table
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.kitchen_sink
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.kitchen_sink
+                  name: Sink
 
           - type: grid
             title: Play Room
@@ -686,26 +711,56 @@ views:
             card_mod:
               style: |
                 ha-card {
-                  border: 2px solid #484f58 !important;
+                  border: 1px solid rgba(255, 255, 255, 0.1) !important;
                   border-radius: 12px !important;
                   padding: 8px !important;
                 }
             cards:
-              - type: tile
-                entity: light.play_room
-                name: Main
-              - type: tile
-                entity: light.play_room_1
-                name: Light 1
-              - type: tile
-                entity: light.play_room_2
-                name: Light 2
-              - type: tile
-                entity: light.play_room_3
-                name: Light 3
-              - type: tile
-                entity: light.play_room_4
-                name: Light 4
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.play_room
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.play_room
+                  name: Main
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.play_room_1
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.play_room_1
+                  name: Light 1
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.play_room_2
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.play_room_2
+                  name: Light 2
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.play_room_3
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.play_room_3
+                  name: Light 3
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.play_room_4
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.play_room_4
+                  name: Light 4
 
       # ============================================================
       # COLUMN 2 — Office (grid area: col2)
@@ -721,35 +776,83 @@ views:
             card_mod:
               style: |
                 ha-card {
-                  border: 2px solid #484f58 !important;
+                  border: 1px solid rgba(255, 255, 255, 0.1) !important;
                   border-radius: 12px !important;
                   padding: 8px !important;
                 }
             cards:
-              - type: tile
-                entity: light.office
-                name: Main
-              - type: tile
-                entity: light.office_lamp
-                name: Lamp
-              - type: tile
-                entity: light.office_bookcase
-                name: Bookcase
-              - type: tile
-                entity: light.office_corner
-                name: Corner
-              - type: tile
-                entity: light.office_back_corner
-                name: Back Corner
-              - type: tile
-                entity: light.office_door
-                name: Door
-              - type: tile
-                entity: light.desk_lamp
-                name: Desk Lamp
-              - type: tile
-                entity: light.desk_lamp_2
-                name: Desk Lamp 2
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.office
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.office
+                  name: Main
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.office_lamp
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.office_lamp
+                  name: Lamp
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.office_bookcase
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.office_bookcase
+                  name: Bookcase
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.office_corner
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.office_corner
+                  name: Corner
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.office_back_corner
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.office_back_corner
+                  name: Back Corner
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.office_door
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.office_door
+                  name: Door
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.desk_lamp
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.desk_lamp
+                  name: Desk Lamp
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.desk_lamp_2
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.desk_lamp_2
+                  name: Desk Lamp 2
 
       # ============================================================
       # COLUMN 3 — Family Room + Entry + Switches (grid area: col3)
@@ -765,24 +868,48 @@ views:
             card_mod:
               style: |
                 ha-card {
-                  border: 2px solid #484f58 !important;
+                  border: 1px solid rgba(255, 255, 255, 0.1) !important;
                   border-radius: 12px !important;
                   padding: 8px !important;
                 }
             cards:
-              - type: tile
-                entity: light.family_room
-                name: Main
-              - type: tile
-                entity: light.family_room_2
-                name: Light 2
-              - type: tile
-                entity: switch.family_room_outlets
-                name: Outlets
-                icon: mdi:power-plug
-              - type: tile
-                entity: light.floor_lamp
-                name: Floor Lamp
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.family_room
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.family_room
+                  name: Main
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.family_room_2
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.family_room_2
+                  name: Light 2
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: switch.family_room_outlets
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: switch.family_room_outlets
+                  name: Outlets
+                  icon: mdi:power-plug
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.floor_lamp
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.floor_lamp
+                  name: Floor Lamp
 
           - type: grid
             title: Entry & Upstairs
@@ -791,23 +918,47 @@ views:
             card_mod:
               style: |
                 ha-card {
-                  border: 2px solid #484f58 !important;
+                  border: 1px solid rgba(255, 255, 255, 0.1) !important;
                   border-radius: 12px !important;
                   padding: 8px !important;
                 }
             cards:
-              - type: tile
-                entity: light.entry_1
-                name: Entry 1
-              - type: tile
-                entity: light.entry_2
-                name: Entry 2
-              - type: tile
-                entity: light.downstairs_hallway
-                name: Downstairs Hall
-              - type: tile
-                entity: light.upstairs_hallway_light
-                name: Upstairs Hall
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.entry_1
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.entry_1
+                  name: Entry 1
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.entry_2
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.entry_2
+                  name: Entry 2
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.downstairs_hallway
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.downstairs_hallway
+                  name: Downstairs Hall
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.upstairs_hallway_light
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: light.upstairs_hallway_light
+                  name: Upstairs Hall
 
           - type: grid
             title: Switches
@@ -816,21 +967,39 @@ views:
             card_mod:
               style: |
                 ha-card {
-                  border: 2px solid #484f58 !important;
+                  border: 1px solid rgba(255, 255, 255, 0.1) !important;
                   border-radius: 12px !important;
                   padding: 8px !important;
                 }
             cards:
-              - type: tile
-                entity: switch.play_room_outlet
-                name: Play Room Outlet
-                icon: mdi:power-plug
-              - type: tile
-                entity: switch.bonus_room
-                name: Bonus Room
-              - type: tile
-                entity: switch.basement_1
-                name: Basement
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: switch.play_room_outlet
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: switch.play_room_outlet
+                  name: Play Room Outlet
+                  icon: mdi:power-plug
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: switch.bonus_room
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: switch.bonus_room
+                  name: Bonus Room
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: switch.basement_1
+                    state_not: unavailable
+                card:
+                  type: tile
+                  entity: switch.basement_1
+                  name: Basement
 
       # ============================================================
       # COLUMN 4 — Weather + Outdoor + Sonos (grid area: col4)
@@ -856,52 +1025,101 @@ views:
           - type: grid
             columns: 2
             square: false
+            card_mod:
+              style: |
+                ha-card {
+                  border: 1px solid rgba(255, 255, 255, 0.1) !important;
+                  border-radius: 12px !important;
+                  padding: 8px !important;
+                }
             cards:
-              - type: custom:mushroom-light-card
-                entity: light.front_door
-                name: Front Door
-                icon: mdi:coach-lamp
-                layout: horizontal
-                use_light_color: true
-                show_brightness_control: false
-              - type: custom:mushroom-light-card
-                entity: light.front_lantern
-                name: Lantern
-                icon: mdi:lamp-outline
-                layout: horizontal
-                use_light_color: true
-                show_brightness_control: false
-              - type: custom:mushroom-light-card
-                entity: light.garage_front
-                name: Garage Fr
-                icon: mdi:garage
-                layout: horizontal
-                use_light_color: true
-                show_brightness_control: false
-              - type: custom:mushroom-light-card
-                entity: light.garage_side
-                name: Garage Sd
-                icon: mdi:garage
-                layout: horizontal
-                use_light_color: true
-                show_brightness_control: false
-              - type: custom:mushroom-light-card
-                entity: light.shed
-                name: Shed
-                icon: mdi:shed
-                layout: horizontal
-                use_light_color: true
-                show_brightness_control: false
-              - type: custom:mushroom-entity-card
-                entity: switch.back_porch
-                name: Porch
-                icon: mdi:outdoor-lamp
-                layout: horizontal
-              - type: custom:mushroom-entity-card
-                entity: switch.garden
-                name: Garden
-                icon: mdi:flower
-                layout: horizontal
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.front_door
+                    state_not: unavailable
+                card:
+                  type: custom:mushroom-light-card
+                  entity: light.front_door
+                  name: Front Door
+                  icon: mdi:coach-lamp
+                  layout: horizontal
+                  use_light_color: true
+                  show_brightness_control: false
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.front_lantern
+                    state_not: unavailable
+                card:
+                  type: custom:mushroom-light-card
+                  entity: light.front_lantern
+                  name: Lantern
+                  icon: mdi:lamp-outline
+                  layout: horizontal
+                  use_light_color: true
+                  show_brightness_control: false
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.garage_front
+                    state_not: unavailable
+                card:
+                  type: custom:mushroom-light-card
+                  entity: light.garage_front
+                  name: Garage Fr
+                  icon: mdi:garage
+                  layout: horizontal
+                  use_light_color: true
+                  show_brightness_control: false
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.garage_side
+                    state_not: unavailable
+                card:
+                  type: custom:mushroom-light-card
+                  entity: light.garage_side
+                  name: Garage Sd
+                  icon: mdi:garage
+                  layout: horizontal
+                  use_light_color: true
+                  show_brightness_control: false
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: light.shed
+                    state_not: unavailable
+                card:
+                  type: custom:mushroom-light-card
+                  entity: light.shed
+                  name: Shed
+                  icon: mdi:shed
+                  layout: horizontal
+                  use_light_color: true
+                  show_brightness_control: false
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: switch.back_porch
+                    state_not: unavailable
+                card:
+                  type: custom:mushroom-entity-card
+                  entity: switch.back_porch
+                  name: Porch
+                  icon: mdi:outdoor-lamp
+                  layout: horizontal
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: switch.garden
+                    state_not: unavailable
+                card:
+                  type: custom:mushroom-entity-card
+                  entity: switch.garden
+                  name: Garden
+                  icon: mdi:flower
+                  layout: horizontal
 
           # Sonos — conditional, bottom of Column 4
           - type: conditional


### PR DESCRIPTION
- Noctis dark blue theme replaces custom kiosk_dark
- All entity cards wrapped in conditional state_not: unavailable (offline devices silently disappear instead of showing broken state)
- Subtle room grid borders (rgba white glow on navy)
- Broken bonus_room warning triangle eliminated
- Alarm armed animation preserved

https://claude.ai/code/session_013YcGe7Cx57bXvUMkviPMt5