### PR TITLE
Fix double-loaded HACS cards, remove dead switch entities

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -6,10 +6,6 @@ frontend:
   extra_module_url:
     - /hacsfiles/kiosk-mode/kiosk-mode.js
     - /hacsfiles/card-mod/card-mod.js
-    - /hacsfiles/lovelace-mushroom/mushroom.js
-    - /hacsfiles/clock-weather-card/clock-weather-card.js
-    - /hacsfiles/mini-media-player/mini-media-player-bundle.js
-    - /hacsfiles/lovelace-layout-card/layout-card.js
 
 # Text to speech
 tts:
@@ -161,7 +157,5 @@ template:
       - name: "Any Switch On"
         unique_id: any_switch_on
         state: >
-          {{ is_state('switch.play_room_outlet', 'on')
-             or is_state('switch.bonus_room', 'on')
-             or is_state('switch.basement_1', 'on') }}
+          {{ is_state('switch.play_room_outlet', 'on') }}
 

--- a/dashboards/home.yaml
+++ b/dashboards/home.yaml
@@ -982,24 +982,6 @@ views:
                   entity: switch.play_room_outlet
                   name: Play Room Outlet
                   icon: mdi:power-plug
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: switch.bonus_room
-                    state_not: unavailable
-                card:
-                  type: tile
-                  entity: switch.bonus_room
-                  name: Bonus Room
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: switch.basement_1
-                    state_not: unavailable
-                card:
-                  type: tile
-                  entity: switch.basement_1
-                  name: Basement
 
       # ============================================================
       # COLUMN 4 — Weather + Outdoor + Sonos (grid area: col4)


### PR DESCRIPTION
- Remove mushroom, clock-weather, mini-media-player, layout-card from extra_module_url (HACS handles their registration automatically)
- Keep kiosk-mode and card-mod (require manual extra_module_url)
- Remove switch.bonus_room and switch.basement_1 cards from kiosk view
- Remove bonus_room and basement_1 from any_switch_on template sensor
- Requires HA restart for configuration.yaml change

https://claude.ai/code/session_013YcGe7Cx57bXvUMkviPMt5