### PR TITLE
Add yamllint CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  yamllint:
+    name: YAML Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install yamllint
+        run: pip install yamllint
+
+      - name: Run yamllint
+        run: yamllint -c .yamllint.yml .

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,37 @@
+extends: default
+
+rules:
+  # HA Jinja2 templates and base64 keys create long lines
+  line-length:
+    max: 250
+    allow-non-breakable-inline-mappings: true
+
+  # HA uses !include, !include_dir_merge_named, !secret, !lambda
+  # yamllint flags these as unknown tags by default
+  truthy:
+    allowed-values: ["true", "false", "yes", "no"]
+
+  # HA convention allows both 2-space and context-dependent indentation
+  indentation:
+    spaces: 2
+    indent-sequences: whatever
+
+  # Don't require document start markers (---) — HA files omit them
+  document-start: disable
+
+  # Allow blank lines for readability in long files
+  empty-lines:
+    max: 2
+
+  # Comments need a space after # but don't require them at specific indentation
+  comments:
+    require-starting-space: true
+    ignore-shebangs: true
+    min-spaces-from-content: 1
+
+  # ESPHome uses !lambda and !secret which trigger this
+  quoted-strings: disable
+
+ignore: |
+  # ESPHome build artifacts (shouldn't be committed, but belt and suspenders)
+  esphome/.esphome/

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -158,4 +158,3 @@ template:
         unique_id: any_switch_on
         state: >
           {{ is_state('switch.play_room_outlet', 'on') }}
-


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow running yamllint on push/PR to main
- Add `.yamllint.yml` tuned for HA conventions (relaxed line length, no document-start requirement, custom tags allowed)
- Fix trailing blank line in `configuration.yaml`

Tested locally — all YAML files pass clean.

## Test plan
- [ ] Verify Actions workflow runs and passes on this PR
- [ ] After merge, add "YAML Lint" as required status check in branch protection settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)