### PR TITLE
Add authentication configuration with trusted networks support

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,3 +1,12 @@
+# Core config
+homeassistant:
+  auth_providers:
+    - type: homeassistant
+    - type: trusted_networks
+      trusted_networks:
+        - 192.168.139.0/24
+      allow_bypass_login: true
+
 # Configure a default setup of Home Assistant (frontend, api, etc)
 default_config:
 


### PR DESCRIPTION
## Summary
Added explicit authentication provider configuration to Home Assistant, enabling both standard homeassistant authentication and trusted networks-based authentication for local network access.

## Key Changes
- Configured homeassistant authentication provider as the primary auth method
- Added trusted networks authentication provider for the local network subnet (192.168.139.0/24)
- Enabled login bypass for trusted networks to allow seamless local access without authentication

## Implementation Details
The authentication configuration includes:
- Two auth providers: the standard homeassistant provider and a trusted_networks provider
- Trusted networks configured for the 192.168.139.0/24 subnet with `allow_bypass_login: true` to permit automatic authentication for devices on the local network
- This setup maintains security for remote access while improving usability for local network clients

https://claude.ai/code/session_01NEBHyq1okmytGvdoPDNN9d