### PR TITLE
feat: add GitOps auto-sync loop (poll, validate, restart, rollback)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ blueprints/
 # ESPHome build artifacts and development archives
 esphome/.esphome/
 esphome/archive/
+
+# GitOps sync artifacts
+.gitops-sync.lock

--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ This workflow is optimized for a single-maintainer project. For a team, I'd add:
 - **Automated deployment** via GitHub Actions — webhook on merge triggers `git pull` + `ha core check` + `ha core restart` on the HA VM, with rollback on check failure.
 - **Environment promotion** — a staging HA instance for testing dashboard changes before they hit the production wall display.
 
+## GitOps Auto-Deploy
+
+Config changes merge to `main` and deploy automatically — no SSH required.
+
+A `time_pattern` automation (`GitOps: Poll and deploy`) triggers `shell_command.gitops_sync` every 5 minutes. The script fetches `origin/main`, compares it to `HEAD`, and if diverged: resets to the latest commits, validates via the Supervisor API (`POST /core/check`), and restarts HA Core on success. On validation failure, it rolls back to the pre-sync SHA without restarting.
+
+**Upper-bound deployment time:** 5 minutes from merge to running config.
+
+**Logs:** `/config/gitops-sync.log` — timestamped, leveled entries; rotates at 1 MB to `gitops-sync.log.1`.
+
+**Rollback:** Automatic on failure. If config check returns non-200, the working tree resets to the pre-sync commit and HA Core is not restarted. A mobile notification is sent on both success and failure. No-op polls (already up to date) are silent.
+
+**Disable:** Developer Tools → Automations → `GitOps: Poll and deploy` → toggle off.
+
+**Force sync:** Developer Tools → Services → `shell_command.gitops_sync` → Call Service.
+
 ## Design Decisions
 
 **Why ESPHome over stock Konnected firmware?** Full local control, no cloud dependency, custom GPIO repurposing (the secondary panel's Zone 1 became a piezo output), and the ability to define RTTTL services for granular tone control from HA automations.

--- a/automations.yaml
+++ b/automations.yaml
@@ -317,3 +317,18 @@
     - action: switch.turn_off
       target:
         entity_id: switch.meeting_button_in_meeting
+
+# ============================================================
+# GITOPS SYNC — poll and deploy
+# ============================================================
+
+- id: gitops_sync_poll
+  alias: "GitOps: Poll and deploy"
+  description: "Fetch repo every 5 min; validate and restart HA on change"
+  trigger:
+    - platform: time_pattern
+      minutes: "/5"
+  action:
+    - service: shell_command.gitops_sync
+  mode: single
+  max_exceeded: silent

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -25,6 +25,7 @@ group: !include groups.yaml
 automation: !include automations.yaml
 script: !include scripts.yaml
 scene: !include scenes.yaml
+shell_command: !include shell_commands.yaml
 
 # Cloud config
 cloud:

--- a/scripts/gitops-sync.sh
+++ b/scripts/gitops-sync.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly LOCK_FILE="/config/.gitops-sync.lock"
+readonly LOG_FILE="/config/gitops-sync.log"
+readonly LOG_MAX_BYTES=1048576
+readonly SUPERVISOR_BASE="http://supervisor"
+readonly NOTIFY_TARGET="mobile_app_sm_s926u1"
+
+log() {
+  local level="$1"
+  shift
+  local ts line
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  line="[$ts] [$level] $*"
+  printf '%s\n' "$line"
+  printf '%s\n' "$line" >> "$LOG_FILE"
+}
+
+rotate_log() {
+  if [[ -f "$LOG_FILE" ]]; then
+    local size
+    size=$(stat -c%s "$LOG_FILE")
+    if (( size >= LOG_MAX_BYTES )); then
+      mv "$LOG_FILE" "${LOG_FILE}.1"
+    fi
+  fi
+}
+
+ha_notify() {
+  local body
+  body=$(jq -n --arg msg "$1" '{"message": $msg}')
+  curl -s -X POST \
+    -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$body" \
+    "${SUPERVISOR_BASE}/core/api/services/notify/${NOTIFY_TARGET}" \
+    > /dev/null || true
+}
+
+main() {
+  rotate_log
+
+  if [[ -z "${SUPERVISOR_TOKEN:-}" ]]; then
+    log ERROR "SUPERVISOR_TOKEN is not set. HA must expose it to shell_command context."
+    log ERROR "See: https://www.home-assistant.io/integrations/shell_command/"
+    exit 1
+  fi
+
+  cd /config
+
+  local current_branch
+  current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+  if [[ "$current_branch" != "main" ]]; then
+    log ERROR "Expected branch 'main', got '${current_branch}'. Aborting to avoid deploying wrong branch."
+    exit 1
+  fi
+
+  local rollback_sha
+  rollback_sha=$(git rev-parse HEAD)
+
+  if ! git fetch --quiet origin; then
+    log ERROR "git fetch failed — check network or SSH access"
+    ha_notify "⚠️ GitOps fetch failed. See /config/gitops-sync.log"
+    exit 1
+  fi
+
+  if ! git rev-parse --verify "origin/main" > /dev/null 2>&1; then
+    log ERROR "origin/main not found after fetch. Default branch may not be 'main'."
+    exit 1
+  fi
+
+  local remote_sha
+  remote_sha=$(git rev-parse origin/main)
+
+  if [[ "$rollback_sha" == "$remote_sha" ]]; then
+    log INFO "no-op, up to date at ${rollback_sha:0:7}"
+    exit 0
+  fi
+
+  local commit_count delta
+  commit_count=$(git rev-list --count HEAD..origin/main)
+  delta=$(git log --oneline HEAD..origin/main)
+  log INFO "Applying ${commit_count} commit(s):"
+  log INFO "${delta}"
+
+  git reset --hard origin/main
+
+  local new_sha
+  new_sha=$(git rev-parse HEAD)
+  log INFO "Reset to ${new_sha:0:7}, running Supervisor config check"
+
+  local tmp_resp http_code check_body
+  tmp_resp=$(mktemp)
+  http_code=$(curl -s -X POST \
+    -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -o "$tmp_resp" \
+    -w "%{http_code}" \
+    "${SUPERVISOR_BASE}/core/check")
+  check_body=$(cat "$tmp_resp")
+  rm -f "$tmp_resp"
+
+  if [[ "$http_code" == "200" ]]; then
+    local commit_info
+    commit_info=$(git log -1 --pretty=format:'%h %s')
+    log INFO "Config validated. Restarting HA Core."
+    ha_notify "HA config deployed: ${commit_info}"
+    curl -s -X POST \
+      -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+      -H "Content-Type: application/json" \
+      "${SUPERVISOR_BASE}/core/restart" \
+      > /dev/null || true
+    exit 0
+  else
+    local truncated
+    truncated=$(printf '%s' "$check_body" | head -c 2048)
+    log ERROR "Config check failed (HTTP ${http_code}): ${truncated}"
+    log INFO "Rolling back to ${rollback_sha:0:7}"
+    git reset --hard "$rollback_sha"
+    log INFO "Rollback complete"
+    ha_notify "⚠️ HA config validation FAILED — rolled back to ${rollback_sha:0:7}. See /config/gitops-sync.log"
+    exit 1
+  fi
+}
+
+# Acquire exclusive lock — exit silently if a previous run is still in progress
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  exit 0
+fi
+
+main

--- a/shell_commands.yaml
+++ b/shell_commands.yaml
@@ -1,0 +1,1 @@
+gitops_sync: "bash /config/scripts/gitops-sync.sh"


### PR DESCRIPTION
Closes #44

Implements the GitOps auto-sync loop: poll origin/main every 5 minutes, validate config via Supervisor API, restart HA Core on success, roll back on failure.

Generated with [Claude Code](https://claude.ai/code)