### PR TITLE
Modernize automation syntax (triggers/actions plural)

### DIFF
--- a/packages/ha_version_sync.yaml
+++ b/packages/ha_version_sync.yaml
@@ -28,9 +28,9 @@ rest_command:
 automation:
   - id: ha_version_sync_on_start
     alias: "HA Version Sync: Dispatch on Start"
-    trigger:
-      - platform: homeassistant
+    triggers:
+      - trigger: homeassistant
         event: start
-    action:
-      - service: rest_command.github_dispatch_version
+    actions:
+      - action: rest_command.github_dispatch_version
     mode: single


### PR DESCRIPTION
Fix deprecation and possibly sidestep check_config KeyError on 2026.4.1. @claude