### PR TITLE
Document architecture: add READMEs and expand CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,11 @@ Two Konnected ESP8266 alarm panels running custom ESPHome firmware (fully inline
 - All 4 doors are entry-delay (no instant zones)
 - Motion: active in armed_away only, ignored in armed_home
 
-### Automations (`/config/automations.yaml`)
+### Automations
 
-7 alarm automations + 1 door chime:
+Automations are split across two locations with different governance models:
+
+**`/config/automations.yaml`** — UI-authored. HA editor writes here; git is updated manually on drift. 8 alarm/chime automations + 1 GitOps poller:
 
 | ID | Description |
 |----|-------------|
@@ -59,8 +61,15 @@ Two Konnected ESP8266 alarm panels running custom ESPHome firmware (fully inline
 | `alarm_disarmed` | Disarm → siren OFF, triple tick confirmation |
 | `alarm_armed_confirmation` | Armed → double tick confirmation |
 | `door_chime` | Door opens while disarmed → double tick |
+| `gitops_sync_poll` | `time_pattern` every 5 min → `shell_command.gitops_sync` |
 
 **RTTTL tone formula:** `d=32,o=4,b=100` — short ticks at octave 4. Differentiation by tick count (1=delay, 2=armed/chime, 3=disarm) and repeat interval.
+
+**`/config/automations/`** — Git-authored. Managed entirely via PR; never touched by the HA UI editor. HA merges these at startup via `!include_dir_merge_list`. Adding a new YAML file here is sufficient — no changes needed to `configuration.yaml`.
+
+| File | Automations |
+|------|-------------|
+| `meeting.yaml` | 4 automations: meeting button ON/OFF → hallway light red/off; button unavailable → light off; reconnect → re-sync state |
 
 ### Template Sensors (`/config/configuration.yaml`)
 
@@ -134,19 +143,11 @@ Two Konnected ESP8266 alarm panels running custom ESPHome firmware (fully inline
 
 ---
 
-## Dashboard Architecture (`/config/dashboards/home.yaml`)
+## Dashboard Architecture
 
-Registered as a named YAML dashboard in `configuration.yaml`:
-```yaml
-lovelace:
-  dashboards:
-    dashboard-home:
-      mode: yaml
-      filename: dashboards/home.yaml
-      title: Home
-      icon: mdi:home
-      show_in_sidebar: true
-```
+Two YAML dashboards registered in `configuration.yaml`. Both are fully git-tracked; no UI editing.
+
+### `dashboards/home.yaml` — Home + Kiosk
 
 ### Two Views
 
@@ -199,6 +200,20 @@ lovelace:
 - `/config/themes/kiosk_dark.yaml` — Original custom dark theme (deprecated, replaced by Noctis Kiosk)
 - Noctis base theme installed via HACS
 
+### `dashboards/homelab-status.yaml` — Homelab Status
+
+Seven-section infrastructure overview dashboard (sidebar: Homelab Status, icon: `mdi:server-network`):
+
+| Section | Entities surfaced |
+|---------|-------------------|
+| Neptune NAS (UGREEN DXP2800) | Pool health, disk temps, SMART hours, CPU/RAM/fan, LAN throughput |
+| Proxmox (pve) | Node CPU/memory/disk, HAOS + grafana-stack VM status, backup schedule |
+| Smart Home Coordinators | ZWA-2, ZBT-2, both Konnected panels — WiFi RSSI, firmware uptime |
+| Battery Health | 8-device grid with amber (<40%) / red (<20%) color thresholds |
+| Printer (HP M477fdw) | CMYK toner levels with color-coded warnings |
+| GitHub (cpitzi/prompts) | Commits, issues, PRs, stars, forks, watchers via REST sensor |
+| Meeting Indicator | ESP32 device state, WiFi signal quality, uptime |
+
 ### Kiosk Mode Config (top of dashboards/home.yaml)
 ```yaml
 kiosk_mode:
@@ -218,30 +233,69 @@ The "Kiosk" person/user (Settings → People) is a non-admin local account used 
 
 ```
 /config/
-├── configuration.yaml          # Core config: alarm panel, template sensors, frontend, prometheus
-├── automations.yaml            # 8 alarm/chime automations
+├── configuration.yaml          # Core config: alarm panel, template sensors, frontend, Prometheus
+├── automations.yaml            # UI-authored automations (alarm + door chime + GitOps poller)
+├── shell_commands.yaml         # shell_command.gitops_sync → scripts/gitops-sync.sh
 ├── groups.yaml                 # Door and motion sensor groups
-├── scripts.yaml                # Empty
-├── scenes.yaml                 # Empty
-├── secrets.yaml                # WiFi, alarm code, API keys (gitignored)
-├── secrets.yaml.example        # Documents required secrets
-├── .gitignore                  # Excludes .storage/, db, deps, tts, secrets, etc.
-├── .HA_VERSION                 # Tracks HA version (currently 2026.4.1)
+├── scripts.yaml                # Empty (placeholder)
+├── scenes.yaml                 # Empty (placeholder)
+├── secrets.yaml                # API keys, alarm code, WiFi (gitignored)
+├── secrets.yaml.example        # Documents required secret keys
+├── secrets.fake.yaml           # Safe dummy values for CI check_config validation
+├── .ha-version                 # Pinned HA version for CI (matches running instance)
+├── .yamllint.yml               # YAML lint rules (line length 250, indentation 2, etc.)
+├── automations/
+│   └── meeting.yaml            # Git-managed automations: meeting indicator (Rachel's office)
+├── packages/
+│   └── ha_version_sync.yaml    # HA version dispatch to GitHub on startup
+├── scripts/
+│   └── gitops-sync.sh          # GitOps deploy: fetch → validate → reload/restart or rollback
 ├── dashboards/
-│   └── home.yaml               # Two-view dashboard (Home + Kiosk)
+│   ├── home.yaml               # Two-view dashboard (Home mobile + Kiosk wall display)
+│   └── homelab-status.yaml     # Homelab Status (NAS, Proxmox, coordinators, battery, printer)
 ├── themes/
-│   ├── noctis_kiosk.yaml       # Active kiosk theme with card-mod overrides
-│   └── kiosk_dark.yaml         # Deprecated custom theme
+│   ├── noctis_kiosk.yaml       # Active theme: global card-mod state-based backgrounds
+│   └── kiosk_dark.yaml         # Deprecated custom theme (retained for reference)
 ├── esphome/
-│   ├── konnected-56ac70.yaml   # Main alarm panel firmware config
-│   ├── konnected-56a4fa.yaml   # Secondary panel (piezo buzzer) firmware config
+│   ├── konnected-56ac70.yaml   # Main panel firmware: 4 doors, 2 motion, siren
+│   ├── konnected-56a4fa.yaml   # Secondary panel firmware: piezo RTTTL annunciator
 │   ├── secrets.yaml            # ESPHome WiFi + API keys (gitignored)
-│   ├── secrets.yaml.example    # Documents required ESPHome secrets
-│   └── .esphome/               # Build artifacts (gitignored)
-└── blueprints/                 # Stock HA automation/script blueprints
+│   └── secrets.yaml.example    # Documents required ESPHome secrets
+├── .github/workflows/
+│   ├── ha-config-check.yml     # CI gate: HA check_config against pinned version
+│   ├── ha-version-sync.yml     # Auto-bump .ha-version on HAOS startup dispatch
+│   ├── lint.yml                # YAML lint gate
+│   ├── claude.yml              # Claude Code issue/PR automation
+│   └── claude-code-review.yml  # Automated PR review (bash safety, security, idempotency)
+├── CLAUDE.md                   # AI-assistant project context (this file)
+└── .gitignore                  # Excludes runtime state, secrets, build artifacts, blueprints
 ```
 
 ---
+
+## GitOps Auto-Deploy (`scripts/gitops-sync.sh`)
+
+`shell_command.gitops_sync` invokes `scripts/gitops-sync.sh` every 5 minutes via a `time_pattern` automation. The script:
+
+1. Acquires a lock file (prevents concurrent runs)
+2. Verifies branch is `main` before touching anything
+3. Fetches `origin/main`; exits 0 (silent) if already up to date
+4. On divergence: resets working tree to `origin/main`
+5. Calls `POST /core/check` via Supervisor API
+6. On success: smart-routes to the lightest reload (lovelace → automation → script → scene → full restart based on changed paths), sends success notification
+7. On failure: rolls back to pre-sync SHA, sends failure notification; HA Core is never restarted
+
+**Log:** `/config/gitops-sync.log` — timestamped, leveled; rotates at 1 MB.
+
+## Packages (`packages/ha_version_sync.yaml`)
+
+HA version tracking and auto-sync on startup. Components:
+
+- **`sensor.ha_core_version`** — `command_line` sensor reading `/config/.HA_VERSION` (HA's own runtime version file, uppercase), refreshed hourly
+- **`rest_command.github_dispatch_version`** — POSTs `ha-version-report` dispatch event with `client_payload.version` to GitHub API (uses `!secret github_pat`)
+- **`automation.ha_version_sync_on_start`** — fires on `homeassistant_started`, calls the rest command; `mode: single` prevents burst duplication on rapid reboots
+
+The GitHub workflow (`ha-version-sync.yml`) validates the incoming version, compares to `.ha-version` on main, and opens a PR to bump the pin if they differ. The PR triggers `ha-config-check` against the new version, then auto-merges on pass.
 
 ## Frontend Resource Loading
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ Proxmox VE (hypervisor)
 │   │   └── Secondary Panel — piezo annunciator (ESP8266)
 │   ├── YAML Configuration ← this repo
 │   │   ├── configuration.yaml — core config, alarm platform, template sensors
-│   │   ├── automations.yaml — alarm lifecycle + door chime
-│   │   ├── dashboards/home.yaml — Home (mobile) + Kiosk (wall display) views
+│   │   ├── automations.yaml — alarm lifecycle + door chime + GitOps poller
+│   │   ├── automations/ — git-managed automations (meeting indicator)
+│   │   ├── packages/ — HA version sync (startup dispatch to GitHub)
+│   │   ├── scripts/gitops-sync.sh — fetch → validate → smart reload or rollback
+│   │   ├── dashboards/ — Home (mobile) + Kiosk (wall display) + Homelab Status
 │   │   └── themes/noctis_kiosk.yaml — global card-mod state styling
 │   └── .storage/ — HA-managed runtime state (excluded from git)
 ├── Firewalla Gold SE (192.168.139.1) — network firewall
@@ -61,11 +64,11 @@ This project uses an AI-augmented development process that separates architectur
 │  4. MERGE — GitHub (automerge enabled)                  │
 │     PR merges to main after approval.                   │
 ├─────────────────────────────────────────────────────────┤
-│  5. DEPLOY — SSH to HA VM                               │
-│     git pull from /homeassistant                        │
-│     ha core check (validate config)                     │
-│     ha core restart                                     │
-│     Visual verification on target device                │
+│  5. DEPLOY — GitOps auto-deploy (no SSH required)       │
+│     scripts/gitops-sync.sh polls every 5 minutes.       │
+│     On drift: fetch → Supervisor check_config →         │
+│     smart reload (lovelace/automations/full restart).   │
+│     Failure: auto-rollback + mobile notification.       │
 ├─────────────────────────────────────────────────────────┤
 │  6. ITERATE — back to step 1                            │
 │     Observe behavior on real hardware.                  │
@@ -84,13 +87,13 @@ This project uses an AI-augmented development process that separates architectur
 
 **The deploy step includes validation.** `ha core check` catches YAML syntax errors and missing entity references before a restart. Visual verification on the target device (phone for mobile view, wall display for kiosk) confirms the actual rendered output matches intent.
 
-### What I'd Change at Scale
+### What's Already Here vs. What Would Scale Further
 
-This workflow is optimized for a single-maintainer project. For a team, I'd add:
+The CI pipeline and auto-deploy described in the sections below are implemented. What would additionally scale for a team:
 
-- **A CI pipeline** running `yamllint` and custom validators on PR (checking entity IDs against a known inventory, verifying theme references resolve, flagging secrets references that don't have `.example` counterparts).
-- **Automated deployment** via GitHub Actions — webhook on merge triggers `git pull` + `ha core check` + `ha core restart` on the HA VM, with rollback on check failure.
-- **Environment promotion** — a staging HA instance for testing dashboard changes before they hit the production wall display.
+- **Entity inventory validation** — a custom CI step checking entity IDs in dashboard YAML against a known-good registry snapshot, catching references to renamed or deleted entities before deployment.
+- **Environment promotion** — a staging HA instance for testing dashboard changes before they propagate to the production wall display.
+- **PR-scoped pre-deployment previews** — spinning up a temporary HA Docker container per PR to render config check output inline on the review.
 
 ## Validation Pipeline
 
@@ -212,32 +215,37 @@ Seven sections:
 
 ```
 ├── configuration.yaml        Core config: alarm, templates, frontend, Prometheus
-├── automations.yaml          UI-authored automations (HA editor target; drift expected)
-├── automations/
-│   └── meeting.yaml          Git-managed automations (pipeline-managed, PR-only)
-├── packages/
-│   └── ha_version_sync.yaml  HA Version Sync — startup dispatch to GitHub
+├── automations.yaml          UI-authored automations (alarm + door chime + GitOps poller)
+├── shell_commands.yaml       shell_command.gitops_sync → scripts/gitops-sync.sh
 ├── groups.yaml               Door and motion sensor groups
 ├── secrets.yaml.example      Documents required secrets (actual secrets gitignored)
 ├── secrets.fake.yaml         Safe dummy secrets for CI check_config validation
 ├── .ha-version               Pinned HA version for CI (matches running instance)
+├── .yamllint.yml             YAML lint rules for CI gate
+├── automations/
+│   └── meeting.yaml          Git-managed automations (PR-only; never HA UI)
+├── packages/
+│   └── ha_version_sync.yaml  HA version dispatch to GitHub on startup
+├── scripts/
+│   └── gitops-sync.sh        GitOps deploy: fetch → validate → smart reload or rollback
 ├── dashboards/
 │   ├── home.yaml             Two views: Home (mobile) + Kiosk (wall display)
-│   └── homelab-status.yaml   Homelab Status dashboard (7 sections)
+│   └── homelab-status.yaml   Homelab Status: NAS, Proxmox, coordinators, battery, printer
 ├── themes/
 │   ├── noctis_kiosk.yaml     Active theme with global card-mod state styling
 │   └── kiosk_dark.yaml       Deprecated — retained for reference
 ├── esphome/
-│   ├── konnected-56ac70.yaml Main alarm panel firmware
-│   ├── konnected-56a4fa.yaml Secondary panel (piezo) firmware
+│   ├── konnected-56ac70.yaml Main alarm panel firmware (4 doors, 2 motion, siren)
+│   ├── konnected-56a4fa.yaml Secondary panel firmware (piezo RTTTL annunciator)
 │   └── secrets.yaml.example  ESPHome secrets template
 ├── .github/workflows/
 │   ├── ha-config-check.yml   HA check_config CI gate (Card 1)
 │   ├── ha-version-sync.yml   Auto-bump .ha-version on HAOS startup (Card 2)
 │   ├── lint.yml              YAML lint gate
-│   └── claude.yml            Claude Code automation
+│   ├── claude.yml            Claude Code issue/PR automation
+│   └── claude-code-review.yml Automated PR review (bash safety, security, idempotency)
 ├── CLAUDE.md                 Project context for AI-assisted development
-└── .gitignore                Excludes runtime state, secrets, build artifacts
+└── .gitignore                Excludes runtime state, secrets, build artifacts, blueprints
 ```
 
 ## HACS Dependencies

--- a/automations/README.md
+++ b/automations/README.md
@@ -1,0 +1,35 @@
+# automations/
+
+Git-managed automations. This directory is the pipeline's exclusive domain — the HA UI editor never writes here. HA merges all `.yaml` files in this directory at startup via `!include_dir_merge_list automations/` in `configuration.yaml`.
+
+## Governance model
+
+Automations in this project are split by authority:
+
+| Location | Authority | Edit surface |
+|----------|-----------|-------------|
+| `automations.yaml` | HA UI editor | Settings → Automations (UI drift is expected and reconciled manually) |
+| `automations/` | Git / PR | This directory only — never touched via the HA UI |
+
+This partition prevents the GitOps pipeline from silently clobbering UI edits. The `git reset --hard origin/main` in the deploy script would overwrite any UI change to a git-tracked file. The separation makes the authority explicit.
+
+## Files
+
+### `meeting.yaml` — Meeting Indicator
+
+Four automations managing a physical meeting-in-progress indicator for Rachel's office. An ESP32 button device drives a hallway light as a visual signal.
+
+| Automation ID | Trigger | Action |
+|---------------|---------|--------|
+| `meeting_status_on` | Button entity turns `on` | Hallway light → red (RGB 255,0,0, brightness 150) |
+| `meeting_status_off` | Button entity turns `off` | Hallway light → off |
+| `meeting_button_offline` | Button unavailable for 10 s | Hallway light → off (fail-safe) |
+| `meeting_button_reconnect` | Button becomes available | Re-sync hallway light to current button state |
+
+The offline/reconnect pair handles an important edge case: if the ESP32 drops off WiFi while the button is on, the hallway light would remain red indefinitely. The 10-second unavailability trigger clears it; the reconnect trigger restores the correct state without manual intervention.
+
+## Adding automations
+
+Create a new `.yaml` file in this directory. HA will pick it up on the next restart or reload. No changes to `configuration.yaml` are needed.
+
+Name files by functional domain (e.g., `lighting.yaml`, `climate.yaml`) rather than creating one file per automation.

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -1,0 +1,70 @@
+# dashboards/
+
+YAML-managed Lovelace dashboards. Both are registered in `configuration.yaml` under `lovelace.dashboards` and are fully git-tracked — no UI editor involvement. Changes deploy automatically via the GitOps pipeline.
+
+## `home.yaml` — Home + Kiosk
+
+Two views in a single file, each solving a distinct display context.
+
+### Home view (`/dashboard-home/home`)
+
+Mobile-first control interface. Design principle: show only what's active.
+
+- **Masonry layout** — standard scrollable column layout
+- **Conditional lighting cards** — each light appears only when on; all-off rooms show an "All off" chip using template sensors from `configuration.yaml`
+- **Sonos group-awareness** — 6 media player cards, each gated on a `binary_sensor.sonos_*_leader` template sensor; only the group coordinator shows when speakers are grouped
+- **Alarm panel** — always visible at top, with a 3×2 sensor grid showing all door/motion contacts
+- **Weather forecast** — daily summary from Met.no
+
+### Kiosk view (`/dashboard-home/kiosk`)
+
+Fixed 1080p wall display on a 65-inch TCL TV running Chromium in kiosk mode.
+
+- **CSS Grid layout** via `layout-card` with `grid-template-areas`; `height: 100vh` — no scrolling at any content state
+- **Theme:** `Noctis Kiosk` (see `themes/`) applies state-based backgrounds to all cards globally — no per-card styling in this file
+- **`fill_container: true`** on all Mushroom cards so background color fills the grid cell
+- **Unavailable filtering** — every card is wrapped in `type: conditional` with `state_not: unavailable`; offline devices disappear silently
+- **Alarm chip animation** — card-mod CSS `@keyframes` with Jinja2 state checks: blue = armed_away, green = armed_home, amber = arming/pending, red = triggered
+
+**Grid structure:**
+```
+"alarm   alarm   alarm   alarm"
+"sensors sensors sensors sensors"
+"col1    col2    col3    col4"
+```
+
+| Column | Contents |
+|--------|----------|
+| Col 1 | Kitchen + Play Room lights |
+| Col 2 | Office lights |
+| Col 3 | Family Room + Entry/Upstairs + Switches |
+| Col 4 | clock-weather-card + Outdoor + conditional Sonos |
+
+### Kiosk Mode
+
+`kiosk_mode` block at the top of `home.yaml` hides header and sidebar for the `Kiosk` user (a non-admin local account used on the wall display).
+
+## `homelab-status.yaml` — Homelab Status
+
+Scrollable infrastructure overview dashboard (`/dashboard-homelab-status`). Seven sections covering the full homelab stack:
+
+| Section | What's surfaced |
+|---------|----------------|
+| Neptune NAS (UGREEN DXP2800) | RAID pool health, disk temps and SMART power-on hours, CPU/RAM/fan, LAN throughput |
+| Proxmox (pve) | Node CPU/memory/disk, HAOS and grafana-stack VM status, backup schedule |
+| Smart Home Coordinators | ZWA-2 (Z-Wave), ZBT-2 (Zigbee), both Konnected alarm panels — WiFi RSSI and uptime |
+| Battery Health | 8-device grid with amber (<40%) and red (<20%) color thresholds |
+| Printer (HP M477fdw) | CMYK toner levels with color-coded warnings |
+| GitHub | cpitzi/prompts repo stats via REST sensor (commits, issues, PRs, stars, forks) |
+| Meeting Indicator | ESP32 device state, WiFi signal quality, uptime |
+
+## HACS Dependencies
+
+| Card | Used by |
+|------|---------|
+| [Mushroom](https://github.com/piitaya/lovelace-mushroom) | Light, entity, alarm cards, chips, title cards |
+| [mini-media-player](https://github.com/kalkih/mini-media-player) | Sonos cards with album art |
+| [layout-card](https://github.com/thomasloven/lovelace-layout-card) | CSS Grid engine (kiosk view) |
+| [card-mod](https://github.com/thomasloven/lovelace-card-mod) | Theme-level CSS + Jinja2 templates |
+| [kiosk-mode](https://github.com/NemesisRE/kiosk-mode) | Sidebar/header hiding for wall display |
+| [clock-weather-card](https://github.com/pkissling/clock-weather-card) | Animated weather + clock widget |

--- a/esphome/README.md
+++ b/esphome/README.md
@@ -1,0 +1,48 @@
+# esphome/
+
+Custom ESPHome firmware for two Konnected ESP8266 alarm panels. Both configs are fully inlined — no remote `github://` package references, no cloud dependencies, every GPIO and component declared explicitly.
+
+## Boards
+
+### `konnected-56ac70.yaml` — Main Alarm Panel
+
+**Hardware:** Konnected ESP8266 (NodeMCU v2), MAC `2C:F4:32:56:AC:70`, IP `192.168.139.40`
+
+| Zone | GPIO | Assignment | Type |
+|------|------|------------|------|
+| 1 | GPIO5 | Front Door | Binary sensor (NC contact) |
+| 2 | GPIO4 | Garage Door | Binary sensor (NC contact) |
+| 3 | GPIO14 | Basement Door | Binary sensor (NC contact) |
+| 4 | GPIO12 | Sliding Door | Binary sensor (NC contact) |
+| 5 | GPIO13 | Office Motion | Binary sensor |
+| 6 | GPIO3 | Family Room Motion | Binary sensor |
+| ALRM | GPIO15 | Siren/Bell | Switch (RESTORE_DEFAULT_OFF) |
+
+**Diagnostics exposed to HA:** WiFi signal strength, IP address, uptime, restart button.
+
+### `konnected-56a4fa.yaml` — Secondary Panel (Piezo Annunciator)
+
+**Hardware:** Konnected ESP8266 (NodeMCU v2), MAC `2C:F4:32:56:A4:FA`, IP `192.168.139.175`
+
+Zone 1 (GPIO5) is repurposed as a PWM output driving a piezo buzzer. Zones 2–6 are unconnected. The panel exposes two custom ESPHome services:
+
+| Service | Call from HA |
+|---------|-------------|
+| `esphome.konnected_56a4fa_play_rtttl` | `data: { song_str: "t:d=32,o=4,b=100:e4" }` |
+| `esphome.konnected_56a4fa_stop_rtttl` | (no data) |
+
+These services are called directly from alarm automations in `automations.yaml` to produce audible countdown ticks and confirmation tones. Tone differentiation: 1 tick = delay countdown, 2 ticks = armed/chime, 3 ticks = disarmed.
+
+## Design Decisions
+
+**Why fully inlined configs?** Remote package references (`github://`) create a hidden runtime dependency — a network outage or upstream change can break firmware compilation at the worst possible time. Inlining every component makes the firmware reproducible from the local YAML alone.
+
+**Why repurpose a Konnected zone as a piezo output?** The secondary panel had five unused zones after its alarm sensor role was eliminated. Repurposing Zone 1 as a PWM annunciator gave a dedicated audible feedback channel without additional hardware — the panel's existing 12V power supply drives the piezo directly.
+
+**Why `RESTORE_DEFAULT_OFF` on the siren switch?** If HA restarts while the siren is triggered, the switch must not reactivate on reconnect. `RESTORE_DEFAULT_OFF` ensures the siren is always silent after a board reset regardless of the last known state.
+
+## Secrets
+
+`secrets.yaml` (gitignored) contains WiFi SSID/password and the ESPHome API encryption key. `secrets.yaml.example` documents the required keys.
+
+Firmware is compiled and flashed OTA via the ESPHome Device Builder add-on running on the same HA instance.

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,39 @@
+# packages/
+
+HA [packages](https://www.home-assistant.io/docs/configuration/packages/) — self-contained YAML units that bundle related entities, automations, and services. Loaded via `!include_dir_named packages` in `configuration.yaml`, which merges each file's keys into the top-level config namespace.
+
+## `ha_version_sync.yaml` — HA Version Sync
+
+Automatically tracks the running HA version and opens a PR to update `.ha-version` when it drifts from the pinned CI value.
+
+### Components
+
+**`sensor.ha_core_version`** — `command_line` sensor reading `/config/.HA_VERSION` (HA's own runtime version file, distinct from the git-tracked `.ha-version` pin). Updated hourly. Provides a queryable entity for the running version; the startup dispatch is event-driven, not polled from this sensor.
+
+**`rest_command.github_dispatch_version`** — POSTs a `ha-version-report` repository dispatch event to the GitHub API with `client_payload.version` set to the current HA version. Uses `!secret github_pat` (a PAT with `Contents: Write` on this repo).
+
+**`automation.ha_version_sync_on_start`** — Fires on `homeassistant_started`, calls `rest_command.github_dispatch_version`. `mode: single` prevents duplicate dispatches on rapid-reboot bursts.
+
+### How the full loop works
+
+```
+homeassistant_started
+  → rest_command POSTs dispatch to GitHub API
+  → ha-version-sync.yml workflow validates version format
+  → compares incoming version to .ha-version on main
+  → if equal: exits 0 (no-op)
+  → if drift: creates ha-version-bump/<version> branch
+               bumps .ha-version
+               opens PR via HA_SYNC_PAT
+  → PR triggers ha-config-check against the new version
+  → auto-merge fires on check pass
+```
+
+### Why `HA_SYNC_PAT` instead of `GITHUB_TOKEN`
+
+Two constraints force a PAT:
+
+1. `GITHUB_TOKEN`-created PRs do not trigger other GitHub Actions workflows (intentional anti-loop guard). The version-bump PR needs to fire `ha-config-check` and the Claude review — both run on `pull_request` events. A PAT-opened PR bypasses this.
+2. `actions/checkout` uses its `token:` input for all `git push` calls in the job. `github-actions[bot]` lacks write access to this repo under branch protection, so the push to the bump branch fails with 403 unless the PAT is substituted.
+
+The same PAT lives in two places: `secrets.yaml` on the HA instance as `github_pat` (for the dispatch POST) and in repo Actions secrets as `HA_SYNC_PAT` (for checkout and PR creation).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,35 @@
+# scripts/
+
+Shell scripts executed by Home Assistant's `shell_command` integration.
+
+## `gitops-sync.sh`
+
+GitOps auto-deploy script. Called every 5 minutes by the `gitops_sync_poll` automation via `shell_command.gitops_sync`. Requires the `SUPERVISOR_TOKEN` environment variable (injected automatically by the HA shell_command integration).
+
+### What it does
+
+1. **Lock acquisition** — creates `.gitops-sync.lock` to prevent concurrent runs from overlapping polls
+2. **Branch guard** — verifies the working tree is on `main` before touching anything; aborts if not
+3. **Fetch** — runs `git fetch origin main`
+4. **Drift check** — compares `HEAD` to `origin/main`; exits silently if already up to date (no-op polls produce no log entries)
+5. **Reset** — `git reset --hard origin/main` applies the new commits
+6. **Validate** — `POST /core/check` via Supervisor API; evaluates the HTTP response code
+7. **On success** — routes to the lightest applicable reload:
+   - Dashboard YAML changes only → `lovelace.reload_resources` + `frontend.reload_themes`
+   - Automation changes → `automation.reload`
+   - Script changes → `script.reload`
+   - Scene changes → `scene.reload`
+   - Any other config change → `core.restart`
+   - Sends a success notification via the HA notify service
+8. **On failure** — rolls back to the pre-sync SHA (`git reset --hard <pre-sync-sha>`), sends a failure notification; HA Core is never restarted on a failed check
+
+### Operational details
+
+- **Upper-bound deploy time:** 5 minutes from merge to running config
+- **Log:** `/config/gitops-sync.log` — timestamped, leveled entries; rotates at 1 MB to `gitops-sync.log.1`
+- **Disable:** toggle the `GitOps: Poll and deploy` automation off in Developer Tools
+- **Force sync:** call `shell_command.gitops_sync` from Developer Tools → Services
+
+### Why this approach
+
+Polling from inside HA (rather than pushing from a GitHub Actions webhook) avoids exposing the HA instance to inbound internet traffic and sidesteps NAT traversal entirely. The tradeoff is a maximum 5-minute latency on deploys — acceptable for a home automation context. The Supervisor API validation step (`/core/check`) runs the same config validator as a normal HA startup, so a bad merge is caught before the service is disrupted.

--- a/themes/README.md
+++ b/themes/README.md
@@ -1,0 +1,38 @@
+# themes/
+
+Custom Lovelace themes. Loaded via `!include_dir_merge_named themes` in `configuration.yaml`. The Noctis base theme (installed via HACS) is a prerequisite for `noctis_kiosk.yaml`.
+
+## `noctis_kiosk.yaml` — Active theme
+
+Extends the Noctis dark palette with a `card-mod-card` block that applies state-based backgrounds to all Mushroom cards globally, without any per-card `card_mod` configuration in the dashboard YAML.
+
+### State-based backgrounds
+
+| Card type | State | Background |
+|-----------|-------|------------|
+| `mushroom-light-card` | `on` | Warm amber `rgba(255, 180, 50, 0.20)` + `box-shadow: 0 0 12px rgba(255, 160, 40, 0.15)` |
+| `mushroom-light-card` | `off` | `var(--card-background-color)` |
+| `mushroom-entity-card` | `on` | Cool blue `rgba(72, 130, 194, 0.20)` + `box-shadow: 0 0 12px rgba(72, 130, 194, 0.15)` |
+| `mushroom-entity-card` | `off` | `var(--card-background-color)` |
+| `mushroom-alarm-control-panel-card` | any | Neutral border only |
+
+All transitions: `0.4s ease` on both `background` and `box-shadow`.
+
+### How it works
+
+The `card-mod-card` key injects a CSS + Jinja2 block evaluated in the browser for every card on load and on state change. The `config.type` check routes to the correct rule without any dashboard-side configuration. Adding a new light entity to the dashboard requires zero theme changes — it inherits automatically.
+
+This approach trades one design decision for a runtime dependency: every card evaluation hits the Jinja2 template engine. For a single-display kiosk with a bounded entity count, this is not a practical concern.
+
+### Color palette
+
+| Variable | Value | Usage |
+|----------|-------|-------|
+| `primary-color` | `#4882c2` | Accent (Noctis blue) |
+| `primary-background-color` | `#0b0c0f` | Page background |
+| `card-background-color` | `#171a21` | Card resting state |
+| `state-icon-active-color` | `#f0b429` | Active entity icons |
+
+## `kiosk_dark.yaml` — Deprecated
+
+The original custom dark theme, replaced by Noctis Kiosk. Retained for reference. Not applied to any dashboard or view.


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the Home Assistant configuration project, including new README files for each major subsystem and an expanded CLAUDE.md that details the GitOps deployment pipeline, automation governance model, and package architecture.

## Key changes

- **New README files** for subsystems:
  - `dashboards/README.md` — documents both YAML dashboards (Home/Kiosk and Homelab Status), HACS dependencies, and grid layout structure
  - `esphome/README.md` — details both Konnected ESP8266 boards, GPIO assignments, design decisions (inlined configs, piezo repurposing, siren safety)
  - `packages/README.md` — explains the HA version sync package, GitHub dispatch loop, and why `HA_SYNC_PAT` is required
  - `themes/README.md` — describes the Noctis Kiosk theme, state-based card backgrounds via card-mod, and color palette
  - `automations/README.md` — clarifies the split governance model (UI-authored vs. git-managed), lists meeting indicator automations, and explains the add-automation workflow
  - `scripts/README.md` — documents the GitOps sync script, its validation/rollback logic, and operational details

- **Expanded CLAUDE.md**:
  - Reorganized automations section to distinguish UI-authored (`automations.yaml`) from git-managed (`automations/`) with separate governance tables
  - Added `gitops_sync_poll` automation to the automation table
  - New "GitOps Auto-Deploy" section detailing the 7-step deploy flow (lock → branch guard → fetch → validate → smart reload or rollback)
  - New "Packages" section explaining HA version tracking and the startup dispatch to GitHub
  - Expanded file tree with new directories (`automations/`, `packages/`, `scripts/`, `.github/workflows/`) and detailed descriptions
  - Added `homelab-status.yaml` dashboard documentation with 7-section infrastructure overview table
  - Clarified dashboard registration and kiosk mode configuration

- **Updated README.md**:
  - Reflected new automation and package structure in the architecture diagram
  - Replaced manual SSH deploy step with GitOps auto-deploy description (5-minute polling, smart reload, auto-rollback)
  - Reframed "What I'd Change at Scale" to "What's Already Here vs. What Would Scale Further" — acknowledging implemented CI/CD while noting what a team would add (entity inventory validation, staging environment, PR-scoped previews)
  - Updated file tree to include new directories and clarified descriptions

## Notable implementation details

- **Governance clarity**: The split between `automations.yaml` (UI-authored, drift expected) and `automations/` (git-only, PR-managed) is now explicitly documented to prevent accidental overwrites during GitOps deploys.
- **GitOps validation**: The deploy script uses the Supervisor API's `/core/check` endpoint (same validator as HA startup) before committing to any reload, with automatic rollback on failure.
- **Smart reload routing**: The script intelligently selects the lightest reload path (lovelace → automation → script → scene → full restart) based on which config files changed, minimizing downtime.
- **HA version sync loop**: Fully documented the dispatch-based version tracking that opens PRs to bump `.ha-version` when the running instance drifts, with CI validation on the PR.

https://claude.ai/code/session_0194Csds2KH5CoTxcrD85v4P