### PR TITLE
security: scrub private IPs and internal network addresses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Git-controlled Home Assistant OS deployment on Proxmox VM at `192.168.139.172`. All configuration is YAML-driven — no UI-based config where avoidable. The HA UI is used only for integration setup (ESPHome device adoption, weather, Sonos, Hue, Kasa, etc.) which HA stores in `.storage/` (excluded from git).
+Git-controlled Home Assistant OS deployment running on Proxmox. All configuration is YAML-driven — no UI-based config where avoidable. The HA UI is used only for integration setup (ESPHome device adoption, weather, Sonos, Hue, Kasa, etc.) which HA stores in `.storage/` (excluded from git).
 
 **Config directory:** `/homeassistant/` on the VM, accessible as `/config/` from the SSH add-on.
 
@@ -16,7 +16,7 @@ Git-controlled Home Assistant OS deployment on Proxmox VM at `192.168.139.172`. 
 
 Two Konnected ESP8266 alarm panels running custom ESPHome firmware (fully inlined, no remote package dependencies):
 
-**Main Panel (56ac70)** — `192.168.139.40`
+**Main Panel (56ac70)**
 - MAC: `2C:F4:32:56:AC:70`
 - ESPHome config: `/config/esphome/konnected-56ac70.yaml`
 - Zones:
@@ -28,7 +28,7 @@ Two Konnected ESP8266 alarm panels running custom ESPHome firmware (fully inline
   - GPIO3 → Family Room Motion
   - GPIO15 → Siren/Bell (ALRM terminal)
 
-**Secondary Panel (56a4fa)** — `192.168.139.175`
+**Secondary Panel (56a4fa)**
 - MAC: `2C:F4:32:56:A4:FA`
 - ESPHome config: `/config/esphome/konnected-56a4fa.yaml`
 - Zone 1 (GPIO5) → Piezo buzzer (PWM output via RTTTL)
@@ -344,9 +344,9 @@ Auto-merge is a per-PR action, not a repo-wide default — without this command
 
 ## Infrastructure Context
 
-- **Proxmox VM:** HA OS at `192.168.139.172`
-- **Firewalla Gold SE:** `192.168.139.1` — network firewall, Zeek logs, device inventory
-- **Grafana/Loki stack:** LXC `192.168.139.20` — `firewalla-grafana-stack` repo
+- **Proxmox VM:** Home Assistant OS (local network)
+- **Firewalla Gold SE** — network firewall, Zeek logs, device inventory
+- **Grafana/Loki stack:** LXC container — `firewalla-grafana-stack` repo
 - **Kiosk display:** 65-inch TCL 1080p TV, Chromium kiosk mode, pointed at `/dashboard-home/kiosk`
 - **ESPHome Device Builder:** HA add-on, compiles and flashes firmware OTA to Konnected boards
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This isn't a collection of UI screenshots. It's an opinionated infrastructure pr
 
 ```
 Proxmox VE (hypervisor)
-├── Home Assistant OS VM (192.168.139.172)
+├── Home Assistant OS VM
 │   ├── ESPHome Device Builder (add-on)
 │   │   ├── Main Panel — 4 doors, 2 motion, siren (ESP8266)
 │   │   └── Secondary Panel — piezo annunciator (ESP8266)
@@ -33,8 +33,8 @@ Proxmox VE (hypervisor)
 │   │   ├── dashboards/ — Home (mobile) + Kiosk (wall display) + Homelab Status
 │   │   └── themes/noctis_kiosk.yaml — global card-mod state styling
 │   └── .storage/ — HA-managed runtime state (excluded from git)
-├── Firewalla Gold SE (192.168.139.1) — network firewall
-└── Grafana/Loki stack (LXC 192.168.139.20) — observability
+├── Firewalla Gold SE — network firewall
+└── Grafana/Loki stack (LXC) — observability
 ```
 
 ## Development Workflow

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -4,7 +4,7 @@ homeassistant:
     - type: homeassistant
     - type: trusted_networks
       trusted_networks:
-        - 192.168.139.0/24
+        - !secret trusted_network
       allow_bypass_login: true
   packages: !include_dir_named packages
 

--- a/esphome/README.md
+++ b/esphome/README.md
@@ -6,7 +6,7 @@ Custom ESPHome firmware for two Konnected ESP8266 alarm panels. Both configs are
 
 ### `konnected-56ac70.yaml` — Main Alarm Panel
 
-**Hardware:** Konnected ESP8266 (NodeMCU v2), MAC `2C:F4:32:56:AC:70`, IP `192.168.139.40`
+**Hardware:** Konnected ESP8266 (NodeMCU v2), MAC `2C:F4:32:56:AC:70`
 
 | Zone | GPIO | Assignment | Type |
 |------|------|------------|------|
@@ -22,7 +22,7 @@ Custom ESPHome firmware for two Konnected ESP8266 alarm panels. Both configs are
 
 ### `konnected-56a4fa.yaml` — Secondary Panel (Piezo Annunciator)
 
-**Hardware:** Konnected ESP8266 (NodeMCU v2), MAC `2C:F4:32:56:A4:FA`, IP `192.168.139.175`
+**Hardware:** Konnected ESP8266 (NodeMCU v2), MAC `2C:F4:32:56:A4:FA`
 
 Zone 1 (GPIO5) is repurposed as a PWM output driving a piezo buzzer. Zones 2–6 are unconnected. The panel exposes two custom ESPHome services:
 

--- a/esphome/konnected-56a4fa.yaml
+++ b/esphome/konnected-56a4fa.yaml
@@ -1,7 +1,7 @@
 # Konnected Alarm Panel — Secondary (Add-on) Board
 # Board: ESP8266 (NodeMCU v2 compatible)
 # MAC: 2C:F4:32:56:A4:FA
-# IP: 192.168.139.175
+# IP: (local network)
 #
 # Zone wiring:
 #   Zone 1 (GPIO5)  → Piezo buzzer (output)

--- a/esphome/konnected-56ac70.yaml
+++ b/esphome/konnected-56ac70.yaml
@@ -1,7 +1,7 @@
 # Konnected Alarm Panel — Main Panel
 # Board: ESP8266 (NodeMCU v2 compatible)
 # MAC: 2C:F4:32:56:AC:70
-# IP: 192.168.139.40
+# IP: (local network)
 #
 # Zone wiring:
 #   Zone 1 (GPIO5)  → Front door contact (NC)

--- a/secrets.fake.yaml
+++ b/secrets.fake.yaml
@@ -2,6 +2,7 @@
 alarm_code: "1234"
 api_key_main_panel: "fake_value"
 api_key_secondary_panel: "fake_value"
-wifi_password: "fake_value"
 wifi_ssid: "fake_value"
+wifi_password: "fake_value"
 github_pat: "fake_value"
+trusted_network: "10.0.0.0/24"

--- a/secrets.yaml.example
+++ b/secrets.yaml.example
@@ -1,5 +1,8 @@
-
-# Use this file to store secrets like usernames and passwords.
-# Learn more at https: "CHANGE_ME"
-some_password: "CHANGE_ME"
+# Required secrets. Copy to secrets.yaml and fill in real values (secrets.yaml is gitignored).
 alarm_code: "CHANGE_ME"
+api_key_main_panel: "CHANGE_ME"
+api_key_secondary_panel: "CHANGE_ME"
+wifi_ssid: "CHANGE_ME"
+wifi_password: "CHANGE_ME"
+github_pat: "CHANGE_ME"
+trusted_network: "CHANGE_ME"  # Local subnet in CIDR notation, e.g. 10.0.0.0/24


### PR DESCRIPTION
Remove all private IP addresses from documentation and config files:
- CLAUDE.md: remove IPs from project overview, panel entries, infrastructure context
- README.md: remove IPs from architecture diagram
- esphome/README.md: remove IPs from board hardware lines
- esphome/konnected-*.yaml: replace IP comments with (local network)
- configuration.yaml: move trusted_networks subnet to !secret trusted_network

Document the new secret in secrets.yaml.example (with CIDR guidance) and add a safe dummy value to secrets.fake.yaml for CI validation.

https://claude.ai/code/session_0194Csds2KH5CoTxcrD85v4P