### PR TITLE
Add visible room boundaries to Kiosk view

### DIFF
--- a/dashboards/home.yaml
+++ b/dashboards/home.yaml
@@ -655,136 +655,162 @@ views:
         view_layout:
           grid-area: col1
         cards:
-          - type: custom:mushroom-title-card
-            title: Kitchen
-          - type: grid
-            columns: 2
-            square: false
-            cards:
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.kitchen_main
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.kitchen_main
-                  name: Main
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.kitchen_island
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.kitchen_island
-                  name: Island
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.kitchen_table
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.kitchen_table
-                  name: Table
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.kitchen_sink
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.kitchen_sink
-                  name: Sink
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
+          - type: custom:mod-card
+            card_mod:
+              style: |
+                ha-card {
+                  border: 1px solid var(--divider-color);
+                  border-radius: 16px;
+                  padding: 8px;
+                  background: rgba(255, 255, 255, 0.015);
+                  box-shadow: none;
+                }
+            card:
+              type: vertical-stack
+              cards:
+                - type: custom:mushroom-title-card
+                  title: Kitchen
+                - type: grid
+                  columns: 2
+                  square: false
+                  cards:
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.kitchen_main
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.kitchen_main
+                        name: Main
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.kitchen_island
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.kitchen_island
+                        name: Island
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.kitchen_table
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.kitchen_table
+                        name: Table
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.kitchen_sink
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.kitchen_sink
+                        name: Sink
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
 
-          - type: custom:mushroom-title-card
-            title: Play Room
-          - type: grid
-            columns: 2
-            square: false
-            cards:
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.play_room
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.play_room
-                  name: Main
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.play_room_1
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.play_room_1
-                  name: Light 1
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.play_room_2
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.play_room_2
-                  name: Light 2
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.play_room_3
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.play_room_3
-                  name: Light 3
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.play_room_4
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.play_room_4
-                  name: Light 4
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
+          - type: custom:mod-card
+            card_mod:
+              style: |
+                ha-card {
+                  border: 1px solid var(--divider-color);
+                  border-radius: 16px;
+                  padding: 8px;
+                  background: rgba(255, 255, 255, 0.015);
+                  box-shadow: none;
+                }
+            card:
+              type: vertical-stack
+              cards:
+                - type: custom:mushroom-title-card
+                  title: Play Room
+                - type: grid
+                  columns: 2
+                  square: false
+                  cards:
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.play_room
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.play_room
+                        name: Main
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.play_room_1
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.play_room_1
+                        name: Light 1
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.play_room_2
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.play_room_2
+                        name: Light 2
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.play_room_3
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.play_room_3
+                        name: Light 3
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.play_room_4
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.play_room_4
+                        name: Light 4
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
 
       # ============================================================
       # COLUMN 2 — Office (grid area: col2)
@@ -793,103 +819,116 @@ views:
         view_layout:
           grid-area: col2
         cards:
-          - type: custom:mushroom-title-card
-            title: Office
-          - type: grid
-            columns: 2
-            square: false
-            cards:
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.office
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.office
-                  name: Main
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.office_lamp
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.office_lamp
-                  name: Lamp
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.office_bookcase
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.office_bookcase
-                  name: Bookcase
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.office_corner
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.office_corner
-                  name: Corner
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.office_door
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.office_door
-                  name: Door
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.desk_lamp
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.desk_lamp
-                  name: Desk Lamp
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.desk_lamp_2
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.desk_lamp_2
-                  name: Desk Lamp 2
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
+          - type: custom:mod-card
+            card_mod:
+              style: |
+                ha-card {
+                  border: 1px solid var(--divider-color);
+                  border-radius: 16px;
+                  padding: 8px;
+                  background: rgba(255, 255, 255, 0.015);
+                  box-shadow: none;
+                }
+            card:
+              type: vertical-stack
+              cards:
+                - type: custom:mushroom-title-card
+                  title: Office
+                - type: grid
+                  columns: 2
+                  square: false
+                  cards:
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.office
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.office
+                        name: Main
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.office_lamp
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.office_lamp
+                        name: Lamp
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.office_bookcase
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.office_bookcase
+                        name: Bookcase
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.office_corner
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.office_corner
+                        name: Corner
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.office_door
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.office_door
+                        name: Door
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.desk_lamp
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.desk_lamp
+                        name: Desk Lamp
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.desk_lamp_2
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.desk_lamp_2
+                        name: Desk Lamp 2
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
 
       # ============================================================
       # COLUMN 3 — Family Room + Entry + Switches (grid area: col3)
@@ -898,154 +937,193 @@ views:
         view_layout:
           grid-area: col3
         cards:
-          - type: custom:mushroom-title-card
-            title: Family Room
-          - type: grid
-            columns: 2
-            square: false
-            cards:
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.family_room
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.family_room
-                  name: Main
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.family_room_2
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.family_room_2
-                  name: Light 2
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: switch.family_room_outlets
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-entity-card
-                  entity: switch.family_room_outlets
-                  name: Outlets
-                  icon: mdi:power-plug
-                  layout: horizontal
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.floor_lamp
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.floor_lamp
-                  name: Floor Lamp
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
+          - type: custom:mod-card
+            card_mod:
+              style: |
+                ha-card {
+                  border: 1px solid var(--divider-color);
+                  border-radius: 16px;
+                  padding: 8px;
+                  background: rgba(255, 255, 255, 0.015);
+                  box-shadow: none;
+                }
+            card:
+              type: vertical-stack
+              cards:
+                - type: custom:mushroom-title-card
+                  title: Family Room
+                - type: grid
+                  columns: 2
+                  square: false
+                  cards:
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.family_room
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.family_room
+                        name: Main
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.family_room_2
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.family_room_2
+                        name: Light 2
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: switch.family_room_outlets
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-entity-card
+                        entity: switch.family_room_outlets
+                        name: Outlets
+                        icon: mdi:power-plug
+                        layout: horizontal
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.floor_lamp
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.floor_lamp
+                        name: Floor Lamp
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
 
-          - type: custom:mushroom-title-card
-            title: Entry & Upstairs
-          - type: grid
-            columns: 2
-            square: false
-            cards:
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.entry_1
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.entry_1
-                  name: Entry 1
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.entry_2
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.entry_2
-                  name: Entry 2
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.downstairs_hallway
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.downstairs_hallway
-                  name: Downstairs Hall
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.upstairs_hallway_light
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.upstairs_hallway_light
-                  name: Upstairs Hall
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.meeting_light
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.meeting_light
-                  name: Meeting Light
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
+          - type: custom:mod-card
+            card_mod:
+              style: |
+                ha-card {
+                  border: 1px solid var(--divider-color);
+                  border-radius: 16px;
+                  padding: 8px;
+                  background: rgba(255, 255, 255, 0.015);
+                  box-shadow: none;
+                }
+            card:
+              type: vertical-stack
+              cards:
+                - type: custom:mushroom-title-card
+                  title: Entry & Upstairs
+                - type: grid
+                  columns: 2
+                  square: false
+                  cards:
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.entry_1
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.entry_1
+                        name: Entry 1
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.entry_2
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.entry_2
+                        name: Entry 2
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.downstairs_hallway
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.downstairs_hallway
+                        name: Downstairs Hall
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.upstairs_hallway_light
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.upstairs_hallway_light
+                        name: Upstairs Hall
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.meeting_light
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.meeting_light
+                        name: Meeting Light
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
 
-          - type: custom:mushroom-title-card
-            title: Switches
-          - type: grid
-            columns: 2
-            square: false
-            cards:
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: switch.play_room_outlet
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-entity-card
-                  entity: switch.play_room_outlet
-                  name: Play Room Outlet
-                  icon: mdi:power-plug
-                  layout: horizontal
-                  fill_container: true
+          - type: custom:mod-card
+            card_mod:
+              style: |
+                ha-card {
+                  border: 1px solid var(--divider-color);
+                  border-radius: 16px;
+                  padding: 8px;
+                  background: rgba(255, 255, 255, 0.015);
+                  box-shadow: none;
+                }
+            card:
+              type: vertical-stack
+              cards:
+                - type: custom:mushroom-title-card
+                  title: Switches
+                - type: grid
+                  columns: 2
+                  square: false
+                  cards:
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: switch.play_room_outlet
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-entity-card
+                        entity: switch.play_room_outlet
+                        name: Play Room Outlet
+                        icon: mdi:power-plug
+                        layout: horizontal
+                        fill_container: true
 
       # ============================================================
       # COLUMN 4 — Weather + Outdoor + Sonos (grid area: col4)
@@ -1066,106 +1144,119 @@ views:
             animated_icon: true
             time_format: 12
 
-          - type: custom:mushroom-title-card
-            title: Outdoor
-          - type: grid
-            columns: 2
-            square: false
-            cards:
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.front_door
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.front_door
-                  name: Front Door
-                  icon: mdi:coach-lamp
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.front_lantern
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.front_lantern
-                  name: Lantern
-                  icon: mdi:lamp-outline
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.garage_front
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.garage_front
-                  name: Garage Fr
-                  icon: mdi:garage
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.garage_side
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.garage_side
-                  name: Garage Sd
-                  icon: mdi:garage
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: light.shed
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-light-card
-                  entity: light.shed
-                  name: Shed
-                  icon: mdi:shed
-                  layout: horizontal
-                  use_light_color: true
-                  show_brightness_control: false
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: switch.back_porch
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-entity-card
-                  entity: switch.back_porch
-                  name: Porch
-                  icon: mdi:outdoor-lamp
-                  layout: horizontal
-                  fill_container: true
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: switch.garden
-                    state_not: unavailable
-                card:
-                  type: custom:mushroom-entity-card
-                  entity: switch.garden
-                  name: Garden
-                  icon: mdi:flower
-                  layout: horizontal
-                  fill_container: true
+          - type: custom:mod-card
+            card_mod:
+              style: |
+                ha-card {
+                  border: 1px solid var(--divider-color);
+                  border-radius: 16px;
+                  padding: 8px;
+                  background: rgba(255, 255, 255, 0.015);
+                  box-shadow: none;
+                }
+            card:
+              type: vertical-stack
+              cards:
+                - type: custom:mushroom-title-card
+                  title: Outdoor
+                - type: grid
+                  columns: 2
+                  square: false
+                  cards:
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.front_door
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.front_door
+                        name: Front Door
+                        icon: mdi:coach-lamp
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.front_lantern
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.front_lantern
+                        name: Lantern
+                        icon: mdi:lamp-outline
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.garage_front
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.garage_front
+                        name: Garage Fr
+                        icon: mdi:garage
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.garage_side
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.garage_side
+                        name: Garage Sd
+                        icon: mdi:garage
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: light.shed
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-light-card
+                        entity: light.shed
+                        name: Shed
+                        icon: mdi:shed
+                        layout: horizontal
+                        use_light_color: true
+                        show_brightness_control: false
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: switch.back_porch
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-entity-card
+                        entity: switch.back_porch
+                        name: Porch
+                        icon: mdi:outdoor-lamp
+                        layout: horizontal
+                        fill_container: true
+                    - type: conditional
+                      conditions:
+                        - condition: state
+                          entity: switch.garden
+                          state_not: unavailable
+                      card:
+                        type: custom:mushroom-entity-card
+                        entity: switch.garden
+                        name: Garden
+                        icon: mdi:flower
+                        layout: horizontal
+                        fill_container: true
 
           # Sonos — conditional, bottom of Column 4
           - type: conditional


### PR DESCRIPTION
## Summary
- Wrap each of the 7 Kiosk-view room groups (Kitchen, Play Room, Office, Family Room, Entry & Upstairs, Switches, Outdoor) in a `custom:mod-card` so rooms visually own their cards on the wall display
- Panel uses `var(--divider-color)` border, 16px radius, 8px padding, 1.5% white lift, no box-shadow — adapts to the Noctis Kiosk theme automatically
- Home (mobile) view, alarm card, sensor chips, clock-weather-card, and conditional Sonos cards are byte-unchanged

Closes #89

## Test plan
- [ ] `YAML Lint` passes
- [ ] `ha-config-check` passes
- [ ] `claude-review` passes
- [ ] Visually verify on wall display: each room group reads as its own panel with subtle border
- [ ] Verify per-card state colors (amber lights-on, blue switches-on) still fire inside panels
- [ ] Verify Home mobile view is unchanged