### PR TITLE
Migrate workflows to PitziLabs/shared-workflows reusable templates

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,15 +1,8 @@
 # ============================================================================
 # Claude Code — Automated PR Review
 # ============================================================================
-# Runs automatically on every PR. No plugins, no marketplace — just a focused
-# review prompt with the PR context the action provides natively.
-#
-# The action already knows the PR context (repo, number, diff, branch) when
-# triggered by pull_request events. We just need to tell it what to focus on.
-#
-# The reviewer is read-only by design: it reads the diff and source files,
-# then returns a single consolidated review. The action posts the result.
-# No incremental commenting — one pass, one artifact.
+# Thin wrapper around PitziLabs/shared-workflows/claude-review.yml.
+# Pinned to Haiku. Accepts bot-authored PRs (allowed_bots: "*").
 # ============================================================================
 
 name: Claude Code Review
@@ -20,56 +13,18 @@ on:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
+    uses: PitziLabs/shared-workflows/.github/workflows/claude-review.yml@main
+    secrets: inherit
+    with:
+      allowed_bots: "*"
+      review_prompt: |
+        This repository contains bash bootstrap scripts for Linux workstations
+        and Terraform infrastructure code. Focus your review on:
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "*"
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            Review this pull request. The PR branch is already checked out.
-
-            This repository contains bash bootstrap scripts for Linux workstations
-            and Terraform infrastructure code. Focus your review on:
-
-            1. **Bash correctness** — quoting bugs, unset variable references,
-               broken conditionals, incorrect exit codes, non-portable syntax
-            2. **Idempotency** — will re-running the script break anything?
-            3. **Security** — hardcoded credentials, secrets in output, unsafe
-               permissions, curl|bash pitfalls
-            4. **Terraform** — if HCL files changed: dependency graph issues,
-               resources requiring multiple applies, missing variable validation
-
-            Rules:
-            - Only comment on actual problems or meaningful improvements
-            - Do NOT comment on style, formatting, or naming preferences
-            - Do NOT give positive feedback or praise — just flag issues
-            - Do NOT propose inline fix code — describe the problem and why it
-              matters, not the solution. Fixes go through a separate commit.
-            - If nothing significant is wrong, say so in one sentence and move on
-
-            Output format:
-            - Read the full diff and any source files needed for context
-            - Collect ALL findings before producing any output
-            - Return a single consolidated review — do not post comments
-              incrementally as you discover issues
-          claude_args: |
-            --max-turns 15
-            --model haiku
-            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Read"
+        1. **Bash correctness** — quoting bugs, unset variable references,
+           broken conditionals, incorrect exit codes, non-portable syntax
+        2. **Idempotency** — will re-running the script break anything?
+        3. **Security** — hardcoded credentials, secrets in output, unsafe
+           permissions, curl|bash pitfalls
+        4. **Terraform** — if HCL files changed: dependency graph issues,
+           resources requiring multiple applies, missing variable validation

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,9 @@
+# ============================================================================
+# Claude Code — Interactive @claude Responder
+# ============================================================================
+# Thin wrapper around PitziLabs/shared-workflows/claude-responder.yml.
+# ============================================================================
+
 name: Claude Code
 
 on:
@@ -14,43 +20,10 @@ on:
 
 jobs:
   claude:
-    if: |
-      github.actor != 'github-actions[bot]' &&
-      (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-      )
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        env:
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: "64000"
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "github-actions"
-          claude_args: |
-            --verbose
-            --output-format stream-json
-            --model ${{
-              (contains(github.event.issue.labels.*.name, 'model:opus') ||
-               contains(github.event.pull_request.labels.*.name, 'model:opus')) && 'opus' ||
-              (contains(github.event.issue.labels.*.name, 'model:haiku') ||
-               contains(github.event.pull_request.labels.*.name, 'model:haiku')) && 'haiku' ||
-              'sonnet'
-            }}
-            --allowedTools "Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch"
+    uses: PitziLabs/shared-workflows/.github/workflows/claude-responder.yml@main
+    secrets: inherit
+    with:
+      allowed_tools: '"Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch"'
+      extra_args: |
+        --verbose
+        --output-format stream-json


### PR DESCRIPTION
Replace the in-line claude.yml, claude-code-review.yml, and (where present) shellcheck.yml with thin wrappers that delegate to the reusable workflows in PitziLabs/shared-workflows. Repo-specific configuration (allowed_tools, default_model, review focus block, script list) becomes input parameters; everything else moves into the shared templates.

Net effect: the workflows directory shrinks by ~70%, and future changes to the responder predicate, model routing, output cap, or review scaffolding land in one place across all consumer repos.