### PR TITLE
fix(kiosk): swap markdown cards for custom:html-template-card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,8 +161,8 @@ Two YAML dashboards registered in `configuration.yaml`. Both are fully git-track
 
 **Kiosk view** (`/dashboard-home/kiosk`) — 65-inch 1080p wall display
 - Panel mode (`panel: true`, `type: panel`) with one root `custom:layout-card` (`height: 100vh`, no scroll)
-- Markdown-only cards with inline `card_mod`; no Mushroom, no Noctis Kiosk theme dependency
-- Non-interactive — markdown cards have no tap action
+- `custom:html-template-card` cells with inline `card_mod`; no Mushroom, no Noctis Kiosk theme dependency. (Built-in `markdown` cards strip arbitrary inline `style` attributes via DOMPurify, which collapsed our spans/divs — `html-template-card` renders the Jinja-templated HTML verbatim.)
+- Non-interactive — HTML template cards have no tap action
 - Unavailable handling lives inside Jinja macros (e.g. door dot grays out for `unavailable`); no wrapper conditionals
 - Kiosk-mode hides sidebar/header for "Kiosk" user
 - Alarm state shown in top-strip card via 3px `border-left` recolored by Jinja (green=disarmed, amber=arming/armed, red=triggered)
@@ -182,6 +182,7 @@ Each main column carries a 3px accent `border-top`:
 ### HACS Cards Used by Kiosk View
 - `layout-card` (lovelace-layout-card) — CSS Grid layout engine for panel-mode root
 - `card-mod` (lovelace-card-mod) — inline CSS for every cell
+- `html-template-card` (lovelace-html-jinja2-template-card) — renders Jinja-templated HTML verbatim, bypassing the markdown card's style sanitizer
 - `kiosk-mode` — hides sidebar/header for kiosk user
 
 The Home view additionally uses standard HA `tile`, `weather-forecast`, and `media-control` cards plus `mini-media-player` for Sonos.
@@ -311,7 +312,7 @@ Other HACS cards (mushroom, clock-weather-card, mini-media-player, layout-card) 
 - **Entity IDs retain original adoption names.** The siren is `switch.alarm_panel_56ac70_siren` (not `switch.main_panel_siren`) because ESPHome entity IDs are set at first adoption and don't change when the device is renamed.
 - **Sonos group awareness.** Template sensors (`binary_sensor.sonos_*_leader`) detect group coordinators on the Home view; only the coordinator's media card renders, preventing duplicate cards when speakers are grouped.
 - **Home view uses conditionals.** Light/switch tiles in the Home view are wrapped in `type: conditional` so each tile appears only when the entity is on; per-room "All off" tiles use `binary_sensor.*_lights_on` template sensors.
-- **Kiosk view styles inline.** The kiosk uses markdown cards with inline `card_mod` and Jinja state-driven colors — no theme-level state styling, no Mushroom, no `fill_container`. Unavailable handling is inside Jinja macros, not in conditional wrappers.
+- **Kiosk view styles inline.** The kiosk uses `custom:html-template-card` cells with inline `card_mod` and Jinja state-driven colors — no theme-level state styling, no Mushroom, no `fill_container`. The built-in `markdown` card sanitizes inline `style` attributes (DOMPurify) and was collapsing styled spans, so `html-template-card` is required for raw HTML+Jinja output. Unavailable handling is inside Jinja macros, not in conditional wrappers.
 - **Alarm color semantics (kiosk top strip):** green = disarmed, amber = arming/armed_home/armed_away, red = pending/triggered. Recolors the card's 3px `border-left`, the state label, and the subtitle; no animation.
 - **PR creation includes arming auto-merge.** When implementation is complete,
   open a pull request as the final step — do not stop at "pushed the branch."

--- a/dashboards/home.yaml
+++ b/dashboards/home.yaml
@@ -574,7 +574,8 @@ views:
             cards:
 
               # --- Clock ---
-              - type: markdown
+              - type: custom:html-template-card
+                ignore_line_breaks: true
                 content: |
                   <div style="font-size:30px;font-weight:500;line-height:1;">{{ now().strftime('%-I:%M %p') }}</div>
                   <div style="font-size:11px;color:#8b949e;margin-top:4px;">{{ now().strftime('%A, %B %-d') }}</div>
@@ -594,7 +595,8 @@ views:
                     ha-markdown { padding: 0 !important; }
 
               # --- Weather + 3-day forecast ---
-              - type: markdown
+              - type: custom:html-template-card
+                ignore_line_breaks: true
                 content: |
                   <div style="display:flex;align-items:center;gap:14px;height:100%;">
                     <div>
@@ -622,7 +624,8 @@ views:
                     ha-markdown > * { height: 100%; }
 
               # --- Alarm ---
-              - type: markdown
+              - type: custom:html-template-card
+                ignore_line_breaks: true
                 content: |
                   {%- set s = states('alarm_control_panel.home_alarm') -%}
                   {%- set color = '#56d364' if s == 'disarmed' else ('#e3b341' if 'armed' in s else '#f85149') -%}
@@ -659,7 +662,8 @@ views:
               # --------------------------------------------------------
               # COLUMN 1: CLIMATE (orange accent)
               # --------------------------------------------------------
-              - type: markdown
+              - type: custom:html-template-card
+                ignore_line_breaks: true
                 content: |
                   <div style="font-size:11px;color:#8b949e;margin-bottom:10px;">Climate</div>
 
@@ -707,7 +711,8 @@ views:
               # --------------------------------------------------------
               # COLUMN 2: DOORS & MOTION (green accent)
               # --------------------------------------------------------
-              - type: markdown
+              - type: custom:html-template-card
+                ignore_line_breaks: true
                 content: |
                   {%- macro dot(entity, label) -%}
                     {%- set s = states(entity) -%}
@@ -777,7 +782,8 @@ views:
                 cards:
 
                   # --- Lights summary + per-area counts ---
-                  - type: markdown
+                  - type: custom:html-template-card
+                    ignore_line_breaks: true
                     content: |
                       {%- set total = (states.light | rejectattr('state','eq','unavailable') | list | length) -%}
                       {%- set on_count = (states.light | selectattr('state','eq','on') | list | length) -%}
@@ -829,7 +835,8 @@ views:
                         .box { display: none !important; }
 
                   # --- Doorbell event timestamps ---
-                  - type: markdown
+                  - type: custom:html-template-card
+                    ignore_line_breaks: true
                     content: |
                       {%- macro rel(ent) -%}
                         {%- set s = states(ent) -%}
@@ -860,7 +867,8 @@ views:
               # COLUMN 4: MEDIA (blue accent)
               # 3x2 uniform Sonos grid + TVs row
               # --------------------------------------------------------
-              - type: markdown
+              - type: custom:html-template-card
+                ignore_line_breaks: true
                 content: |
                   {%- macro sonos_cell(entity, label) -%}
                     {%- set s = states(entity) -%}


### PR DESCRIPTION
## Summary
- Replace the 8 markdown cards in the kiosk view (`dashboards/home.yaml`) with `custom:html-template-card`. The built-in markdown card sanitizes HTML via DOMPurify and was stripping our inline `style` attributes — styled spans/divs collapsed (text bunched together, colors lost) on the wall display.
- `html-template-card` renders Jinja-templated HTML verbatim. Content, template logic, and outer `ha-card` card_mod blocks are unchanged; `ignore_line_breaks: true` set on each cell.
- Home view masonry cards (Kitchen/Office/Play Room/etc.) keep plain markdown — they have no inline styles and don't need the swap.
- CLAUDE.md updated: HACS Cards Used by Kiosk View now lists `html-template-card` (lovelace-html-jinja2-template-card), and the "styles inline" / "kiosk view" notes call out the DOMPurify reason.

## Prerequisites
- Install `html-template-card` via HACS (search `lovelace-html-jinja2-template-card`, by PiotrMachowski). Per repo convention, HACS-installed cards auto-load — no `extra_module_url` change needed.

## Test plan
- [ ] HACS: install `html-template-card` if not already present, restart HA.
- [ ] Reload Lovelace; load `/dashboard-home/kiosk` on the wall TV.
- [ ] Top strip: clock, weather + 3-day forecast, and alarm cells render with correct fonts, colors, and the alarm `border-left` state color.
- [ ] Climate column: Outdoor temp uses the orange accent, Upstairs/Downstairs sub-cells render as styled rounded blocks.
- [ ] Doors & motion column: dot characters render in the 2-col grid with green/red/grey colors per state.
- [ ] Lights & doorbell column: per-room counts in the styled inline grid; camera tile and chime/motion timestamps render.
- [ ] Media column: 3×2 Sonos grid renders with playing cells highlighted blue; TVs row at bottom shows correct states.
- [ ] Mobile Home view (`/dashboard-home/home`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)