### PR TITLE
docs: catch up CLAUDE.md and READMEs to kiosk V2 architecture

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -4,6 +4,8 @@ extends: default
 rules:
   brackets:
     max-spaces-inside: 1 # allow the `[ x, y ]` style GitHub uses everywhere
+  braces:
+    max-spaces-inside: 1 # allow the `{ key: value }` flow-mapping style used in dashboard view_layout/tap_action shorthands
   # HA Jinja2 templates and base64 keys create long lines
   line-length:
     max: 250

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,11 +145,9 @@ Automations are split across two locations with different governance models:
 
 ## Dashboard Architecture
 
-Two YAML dashboards registered in `configuration.yaml`. Both are fully git-tracked; no UI editing.
+Three YAML dashboards registered in `configuration.yaml`. All are fully git-tracked; no UI editing.
 
-### `dashboards/home.yaml` — Home + Kiosk
-
-### Two Views
+### `dashboards/home.yaml` — Home view
 
 **Home view** (`/dashboard-home/home`) — Mobile/tablet control dashboard
 - Masonry layout (standard, not panel mode)
@@ -159,36 +157,51 @@ Two YAML dashboards registered in `configuration.yaml`. Both are fully git-track
 - Alarm panel with permanent sensor grid (always visible)
 - Activity-driven: lights/switches appear when on, vanish when off
 
-**Kiosk view** (`/dashboard-home/kiosk`) — 65-inch 1080p wall display
-- Panel mode (`panel: true`, `type: panel`) with one root `custom:layout-card` (`height: 100vh`, no scroll)
-- `custom:html-template-card` cells with inline `card_mod`; no Mushroom, no Noctis Kiosk theme dependency. (Built-in `markdown` cards strip arbitrary inline `style` attributes via DOMPurify, which collapsed our spans/divs — `html-template-card` renders the Jinja-templated HTML verbatim.)
-- Non-interactive — HTML template cards have no tap action
-- Unavailable handling lives inside Jinja macros (e.g. door dot grays out for `unavailable`); no wrapper conditionals
+The Home view uses standard HA `tile`, `weather-forecast`, and `media-control` cards plus `mini-media-player` for Sonos.
+
+### `dashboards/kiosk.yaml` — Kiosk view
+
+**Kiosk view** (`/dashboard-kiosk/home`) — 65-inch 1080p wall display
+- View type: `custom:grid-layout` (layout-card AS the view, not nested inside a panel)
+- Cell wrappers: `custom:mod-card` provides the ha-card host so `height: 100%` cascades through the nested shadow DOM
+- Typed cards per panel (no html-template-card):
+  - Climate: `custom:better-thermostat-ui-card` with humidity sensor binding
+  - Sensors: `custom:button-card` with state-driven backgrounds and pulse animations
+  - Lights: `custom:mushroom-light-card` per individual light (21 lights in a 3×7 grid)
+  - Media: `custom:mini-media-player` with `artwork: full-cover-fit` for album art
+  - Weather: `custom:clock-weather-card` (combined clock + 4-day forecast)
+  - Alarm: `custom:button-card` hero with state-driven colors and pulse on triggered
+- Non-interactive — every card has `tap_action: { action: none }`
 - Kiosk-mode hides sidebar/header for "Kiosk" user
-- Alarm state shown in top-strip card via 3px `border-left` recolored by Jinja (green=disarmed, amber=arming/armed, red=triggered)
+- No camera (handled in a separate cameras dashboard)
 
 ### Grid Layout (Kiosk)
-Top strip (76px): `clock | weather + 3-day forecast | alarm`
-Main grid (fills viewport):
 ```
-"climate doors lights media"
+grid-template-columns: 1fr 1fr 1.4fr 1fr
+grid-template-rows: 130px 1fr
+grid-template-areas:
+  "weather weather alarm   alarm"
+  "climate sensors lights  media"
 ```
-Each main column carries a 3px accent `border-top`:
-- **Climate** (orange) — outdoor temp/condition, upstairs + downstairs temp/humidity, Heatstorm office heater state
-- **Doors & motion** (green) — 6 door contacts as colored dots (front, basement-kitchen, sliding, garage, Hannah, Jacob), 2 garage cover states, 2 motion sensors
-- **Lights & doorbell** (amber) — total on/off counts, per-room counts (`sensor.lights_on_*_count`), front-door camera snapshot, last chime/motion timestamps
-- **Media** (blue) — 3×2 Sonos cell grid (master bedroom, basement, office, kitchen, dining room, roam 2; active cells highlighted with title/artist), TV status row (office, basement, play room)
+- **weather** — clock-weather-card with 4-day forecast (top-left, spans 2 cols)
+- **alarm** — button-card hero (top-right, spans 2 cols)
+- **climate** — 2 better-thermostat-ui-cards stacked + heater button-card
+- **sensors** — 10 button-cards in a 2×5 internal grid (6 doors + 2 garage covers + 2 motion)
+- **lights** — 21 mushroom-light-cards in a 3×7 internal grid
+- **media** — 6 mini-media-players in a 2×3 internal grid + TVs row spanning both cols
 
 ### HACS Cards Used by Kiosk View
-- `layout-card` (lovelace-layout-card) — CSS Grid layout engine for panel-mode root
-- `card-mod` (lovelace-card-mod) — inline CSS for every cell
-- `html-template-card` (lovelace-html-jinja2-template-card) — renders Jinja-templated HTML verbatim, bypassing the markdown card's style sanitizer
+- `layout-card` — provides `custom:grid-layout` (used as the VIEW type, not nested)
+- `card-mod` — provides `custom:mod-card` cell wrapper + theme-level CSS
+- `button-card` — sensors, alarm hero, heater state, TVs row
+- `mushroom` — `mushroom-light-card` for individual lights
+- `mini-media-player` — Sonos with album art via `artwork: full-cover-fit`
+- `clock-weather-card` — combined clock + forecast in top strip
+- `better-thermostat-ui-card` — circular thermostat dial with humidity
 - `kiosk-mode` — hides sidebar/header for kiosk user
 
-The Home view additionally uses standard HA `tile`, `weather-forecast`, and `media-control` cards plus `mini-media-player` for Sonos.
-
 ### Theme Files
-- `/config/themes/noctis_kiosk.yaml` — Active theme. Originally provided global state-based backgrounds for Mushroom cards on the kiosk; the kiosk view no longer relies on it (state styling moved inline). Still loaded as the project's default dark theme.
+- `/config/themes/noctis_kiosk.yaml` — Active theme. Originally provided global state-based backgrounds for Mushroom cards on the kiosk; the kiosk view no longer relies on it (state styling moved into per-card `card_mod` and `button-card` state blocks). Still loaded as the project's default dark theme.
 - `/config/themes/kiosk_dark.yaml` — Deprecated custom theme (retained for reference).
 - Noctis base theme installed via HACS.
 
@@ -206,7 +219,7 @@ Seven-section infrastructure overview dashboard (sidebar: Homelab Status, icon: 
 | GitHub (cpitzi/prompts) | Commits, issues, PRs, stars, forks, watchers via REST sensor |
 | Meeting Indicator | ESP32 device state, WiFi signal quality, uptime |
 
-### Kiosk Mode Config (top of dashboards/home.yaml)
+### Kiosk Mode Config (top of dashboards/kiosk.yaml)
 ```yaml
 kiosk_mode:
   non_admin_settings:
@@ -243,7 +256,8 @@ The "Kiosk" person/user (Settings → People) is a non-admin local account used 
 ├── scripts/
 │   └── gitops-sync.sh          # GitOps deploy: fetch → validate → reload/restart or rollback
 ├── dashboards/
-│   ├── home.yaml               # Two-view dashboard (Home mobile + Kiosk wall display)
+│   ├── home.yaml               # Mobile/tablet Home dashboard
+│   ├── kiosk.yaml              # 1080p wall-display Kiosk dashboard (custom:grid-layout)
 │   └── homelab-status.yaml     # Homelab Status (NAS, Proxmox, coordinators, battery, printer)
 ├── themes/
 │   ├── noctis_kiosk.yaml       # Active theme: global card-mod state-based backgrounds
@@ -300,7 +314,7 @@ frontend:
     - /hacsfiles/card-mod/card-mod.js
 ```
 
-Other HACS cards (mushroom, clock-weather-card, mini-media-player, layout-card) are loaded automatically by HACS — do NOT add them to `extra_module_url` or they'll double-register and throw "already been used with this registry" errors.
+Other HACS cards (mushroom, clock-weather-card, mini-media-player, layout-card, button-card, better-thermostat-ui-card) are loaded automatically by HACS — do NOT add them to `extra_module_url` or they'll double-register and throw "already been used with this registry" errors.
 
 ---
 
@@ -312,8 +326,8 @@ Other HACS cards (mushroom, clock-weather-card, mini-media-player, layout-card) 
 - **Entity IDs retain original adoption names.** The siren is `switch.alarm_panel_56ac70_siren` (not `switch.main_panel_siren`) because ESPHome entity IDs are set at first adoption and don't change when the device is renamed.
 - **Sonos group awareness.** Template sensors (`binary_sensor.sonos_*_leader`) detect group coordinators on the Home view; only the coordinator's media card renders, preventing duplicate cards when speakers are grouped.
 - **Home view uses conditionals.** Light/switch tiles in the Home view are wrapped in `type: conditional` so each tile appears only when the entity is on; per-room "All off" tiles use `binary_sensor.*_lights_on` template sensors.
-- **Kiosk view styles inline.** The kiosk uses `custom:html-template-card` cells with inline `card_mod` and Jinja state-driven colors — no theme-level state styling, no Mushroom, no `fill_container`. The built-in `markdown` card sanitizes inline `style` attributes (DOMPurify) and was collapsing styled spans, so `html-template-card` is required for raw HTML+Jinja output. Unavailable handling is inside Jinja macros, not in conditional wrappers.
-- **Alarm color semantics (kiosk top strip):** green = disarmed, amber = arming/armed_home/armed_away, red = pending/triggered. Recolors the card's 3px `border-left`, the state label, and the subtitle; no animation.
+- **Kiosk uses typed cards, not html-template-card.** The kiosk view is itself a `custom:grid-layout`; each cell is a typed card (`mushroom-light-card`, `button-card`, `mini-media-player`, `clock-weather-card`, `better-thermostat-ui-card`) wrapped in `custom:mod-card`. State-driven colors live in per-card `state` blocks and `card_mod` styles — no Jinja-templated HTML, no DOMPurify fight. Unavailable handling lives inside each card's state list (e.g. a `value: unavailable` block on a button-card).
+- **Alarm color semantics (kiosk hero):** green = disarmed, amber = arming/armed_home/armed_away, red = pending/triggered, with a pulse animation on triggered. State-driven via `button-card` `state` blocks.
 - **PR creation includes arming auto-merge.** When implementation is complete,
   open a pull request as the final step — do not stop at "pushed the branch."
   PR title should match or clearly refine the issue title. PR body must include

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This isn't a collection of UI screenshots. It's an opinionated infrastructure pr
 
 **A custom alarm system** built from bare hardware up. Two Konnected ESP8266 panels running fully inlined ESPHome firmware: one driving 4 door contacts, 2 motion sensors, and a siren output; the other repurposed as an interior annunciator with a piezo buzzer playing RTTTL tones. Eight YAML automations handle the full alarm lifecycle — arming sequences, entry/exit delays with audible countdowns, triggered siren activation, disarm confirmation, and a door chime for everyday use.
 
-**Two dashboard experiences** from a single YAML file. A mobile-first Home view uses conditional cards that surface only what's active — lights appear when on, Sonos players show only when playing (with group-awareness so grouped speakers don't duplicate). A Kiosk view drives a 65-inch wall display using CSS Grid layout, Mushroom cards with theme-driven state coloring, animated alarm status chips, and a clock-weather widget — all locked to 1080p with zero scrolling.
+**Two dashboard experiences** built from typed Lovelace cards. A mobile-first Home view uses conditional cards that surface only what's active — lights appear when on, Sonos players show only when playing (with group-awareness so grouped speakers don't duplicate). A Kiosk view drives a 65-inch wall display using `custom:grid-layout` as the view itself, populated with `mushroom-light-card`, `button-card`, `mini-media-player` (with album art), `clock-weather-card`, and circular `better-thermostat-ui-card` dials — all locked to 1080p with zero scrolling.
 
 **A Homelab Status dashboard** providing an at-a-glance infrastructure overview: NAS health (Neptune UGREEN DXP2800 — pool status, disk temps, SMART hours, LAN throughput), Proxmox node and VM metrics, smart home coordinator firmware/signal status, battery health grid with amber/red color coding, CMYK toner levels, GitHub repo activity, and the custom-built ESP32 meeting indicator device.
 
@@ -30,7 +30,7 @@ Proxmox VE (hypervisor)
 │   │   ├── automations/ — git-managed automations (meeting indicator)
 │   │   ├── packages/ — HA version sync (startup dispatch to GitHub)
 │   │   ├── scripts/gitops-sync.sh — fetch → validate → smart reload or rollback
-│   │   ├── dashboards/ — Home (mobile) + Kiosk (wall display) + Homelab Status
+│   │   ├── dashboards/ — Home (mobile) + Kiosk (wall display) + Homelab Status (3 files)
 │   │   └── themes/noctis_kiosk.yaml — global card-mod state styling
 │   └── .storage/ — HA-managed runtime state (excluded from git)
 ├── Firewalla Gold SE — network firewall
@@ -190,7 +190,7 @@ A `time_pattern` automation (`GitOps: Poll and deploy`) triggers `shell_command.
 
 **Why a manual alarm platform instead of an integration?** The manual platform gives explicit control over every timing parameter and state transition. The alarm behavior is defined entirely in YAML — arming delays, entry delays, trigger duration, which sensors are active in which arm mode — making it auditable, version-controlled, and reproducible.
 
-**Why global theme-based card styling instead of per-card card-mod?** The Noctis Kiosk theme applies state-based backgrounds (warm amber for lights on, cool blue for switches on) to all Mushroom cards through a single `card-mod-card` block. This means adding a new light to the dashboard requires zero styling work — it inherits the theme automatically. Per-card styling creates maintenance debt that scales linearly with entity count.
+**Why typed Lovelace cards on the kiosk instead of html-template-card?** An earlier kiosk iteration used `custom:html-template-card` so each cell was Jinja-templated HTML. That gave maximum layout control but offered no schema validation, fought shadow-DOM CSS for sizing, and made every minor change a string-concatenation problem. The current kiosk uses typed cards (`mushroom-light-card`, `button-card`, `mini-media-player`, `clock-weather-card`, `better-thermostat-ui-card`) wrapped in `custom:mod-card` so per-card styling lives next to the entity binding. Adding a new light is one extra `mushroom-light-card` block; state-driven colors are declarative `state` lists, not Jinja conditionals.
 
 **Why conditional cards on the mobile view?** A house with 40+ controllable entities produces a dashboard that's mostly noise. The Home view shows only what's active — if all kitchen lights are off, you see "All off" instead of four disabled tiles. This is an opinionated UX choice: the dashboard reflects the current state of the house, not its full capability.
 
@@ -229,7 +229,8 @@ Seven sections:
 ├── scripts/
 │   └── gitops-sync.sh        GitOps deploy: fetch → validate → smart reload or rollback
 ├── dashboards/
-│   ├── home.yaml             Two views: Home (mobile) + Kiosk (wall display)
+│   ├── home.yaml             Mobile/tablet Home dashboard
+│   ├── kiosk.yaml            Kiosk wall-display dashboard (custom:grid-layout)
 │   └── homelab-status.yaml   Homelab Status: NAS, Proxmox, coordinators, battery, printer
 ├── themes/
 │   ├── noctis_kiosk.yaml     Active theme with global card-mod state styling
@@ -255,8 +256,10 @@ Seven sections:
 | [Mushroom](https://github.com/piitaya/lovelace-mushroom) | Light/entity/alarm cards and sensor chips |
 | [clock-weather-card](https://github.com/pkissling/clock-weather-card) | Animated weather with clock and forecast |
 | [mini-media-player](https://github.com/kalkih/mini-media-player) | Compact Sonos display with album art |
-| [layout-card](https://github.com/thomasloven/lovelace-layout-card) | CSS Grid layout engine for kiosk view |
-| [card-mod](https://github.com/thomasloven/lovelace-card-mod) | Theme-level CSS styling with Jinja2 |
+| [layout-card](https://github.com/thomasloven/lovelace-layout-card) | CSS Grid layout engine — used as the kiosk view type itself |
+| [card-mod](https://github.com/thomasloven/lovelace-card-mod) | Theme-level CSS styling + `custom:mod-card` cell wrapper |
+| [button-card](https://github.com/custom-cards/button-card) | Sensor tiles, alarm hero, TV row in kiosk view |
+| [better-thermostat-ui-card](https://github.com/KartoffelToby/better-thermostat-ui-card) | Circular thermostat dial in kiosk view |
 | [kiosk-mode](https://github.com/NemesisRE/kiosk-mode) | Hides sidebar/header for wall display |
 | [Noctis](https://github.com/aFFekopp/nern) | Base dark theme (extended by Noctis Kiosk) |
 

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -1,12 +1,8 @@
 # dashboards/
 
-YAML-managed Lovelace dashboards. Both are registered in `configuration.yaml` under `lovelace.dashboards` and are fully git-tracked — no UI editor involvement. Changes deploy automatically via the GitOps pipeline.
+YAML-managed Lovelace dashboards. All three are registered in `configuration.yaml` under `lovelace.dashboards` and are fully git-tracked — no UI editor involvement. Changes deploy automatically via the GitOps pipeline.
 
-## `home.yaml` — Home + Kiosk
-
-Two views in a single file, each solving a distinct display context.
-
-### Home view (`/dashboard-home/home`)
+## `home.yaml` — Home view (`/dashboard-home/home`)
 
 Mobile-first control interface. Design principle: show only what's active.
 
@@ -16,34 +12,37 @@ Mobile-first control interface. Design principle: show only what's active.
 - **Alarm panel** — always visible at top, with a 3×2 sensor grid showing all door/motion contacts
 - **Weather forecast** — daily summary from Met.no
 
-### Kiosk view (`/dashboard-home/kiosk`)
+## `kiosk.yaml` — Kiosk view (`/dashboard-kiosk/home`)
 
 Fixed 1080p wall display on a 65-inch TCL TV running Chromium in kiosk mode.
 
-- **Panel mode** (`panel: true`, `type: panel`) hosts a single root `custom:layout-card` with `height: 100vh` — no scrolling at any content state
-- **Markdown-only cards** — every cell is a `type: markdown` card with inline `card_mod` styles. No Mushroom, no theme dependency, no per-state class toggling. State drives color via Jinja2 inside the markdown.
-- **Non-interactive** — markdown cards have no tap action by default; the wall display ignores touch.
-- **Unavailable handling** — handled inside each Jinja macro (e.g. door dot turns gray for `unavailable`/`unknown`, green for closed, red for open), not via wrapper conditionals.
-- **Accent borders** — each column carries a 3px `border-top` in its column color: orange (Climate), green (Doors & motion), amber (Lights & doorbell), blue (Media). Alarm uses a 3px `border-left` that recolors with state.
+- **View IS the grid** — the view itself is `type: custom:grid-layout` with `height: 100vh`; no nested panel-mode wrapper
+- **Typed cards per cell** — every panel is a typed Lovelace card (`mushroom-light-card`, `button-card`, `mini-media-player`, `clock-weather-card`, `better-thermostat-ui-card`) wrapped in `custom:mod-card` so the ha-card host provides the height cascade
+- **State-driven styling** — colors live in per-card `state` blocks (`button-card`) and `card_mod` styles, not Jinja-templated HTML. The alarm hero pulses on triggered.
+- **Non-interactive** — every card sets `tap_action: { action: none }`; the wall display ignores touch
+- **Unavailable handling** — declared inside each card's `state` list (e.g. a `value: unavailable` block on a button-card), not via wrapper conditionals
 
 **Grid structure:**
 ```
-top strip (76px):  "clock  weather+forecast  alarm"
-main grid:         "climate  doors  lights  media"
+grid-template-columns: 1fr 1fr 1.4fr 1fr
+grid-template-rows:    130px 1fr
+grid-template-areas:
+  "weather weather alarm   alarm"
+  "climate sensors lights  media"
 ```
 
-| Column | Contents |
-|--------|----------|
-| Col 1 | Climate — outdoor temp/condition, upstairs/downstairs temp+humidity, office heater state |
-| Col 2 | Doors & motion — 6 door contacts as colored dots, 2 garage cover states, 2 motion sensors |
-| Col 3 | Lights & doorbell — on/total counts and per-room counts, front-door camera snapshot, last chime/motion timestamps |
-| Col 4 | Media — 3×2 Sonos cell grid (active cells highlighted blue with title/artist), TV status row |
-
-The `lights_on_*_count` template sensors backing Col 3 are defined in `configuration.yaml`.
+| Cell | Contents |
+|------|----------|
+| weather | `clock-weather-card` with 4-day forecast (top-left, spans 2 cols) |
+| alarm | `button-card` hero (top-right, spans 2 cols) |
+| climate | 2 `better-thermostat-ui-card` dials stacked + heater `button-card` |
+| sensors | 10 `button-card` tiles in a 2×5 internal grid (6 doors + 2 garage covers + 2 motion) |
+| lights | 21 `mushroom-light-card` tiles in a 3×7 internal grid |
+| media | 6 `mini-media-player` cards (album art via `artwork: full-cover-fit`) in a 2×3 internal grid + TVs row |
 
 ### Kiosk Mode
 
-`kiosk_mode` block at the top of `home.yaml` hides header and sidebar for the `Kiosk` user (a non-admin local account used on the wall display).
+`kiosk_mode` block at the top of `kiosk.yaml` hides header and sidebar for the `Kiosk` user (a non-admin local account used on the wall display).
 
 ## `homelab-status.yaml` — Homelab Status
 
@@ -63,9 +62,11 @@ Scrollable infrastructure overview dashboard (`/dashboard-homelab-status`). Seve
 
 | Card | Used by |
 |------|---------|
-| [Mushroom](https://github.com/piitaya/lovelace-mushroom) | Light, entity, alarm cards, chips, title cards |
-| [mini-media-player](https://github.com/kalkih/mini-media-player) | Sonos cards with album art |
-| [layout-card](https://github.com/thomasloven/lovelace-layout-card) | CSS Grid engine (kiosk view) |
-| [card-mod](https://github.com/thomasloven/lovelace-card-mod) | Theme-level CSS + Jinja2 templates |
+| [Mushroom](https://github.com/piitaya/lovelace-mushroom) | Home view light/entity/alarm cards; `mushroom-light-card` per light on kiosk |
+| [mini-media-player](https://github.com/kalkih/mini-media-player) | Sonos cards on Home view; kiosk media cells with `artwork: full-cover-fit` |
+| [layout-card](https://github.com/thomasloven/lovelace-layout-card) | `custom:grid-layout` — used as the kiosk VIEW type (not nested) |
+| [card-mod](https://github.com/thomasloven/lovelace-card-mod) | Theme-level CSS + `custom:mod-card` cell wrapper |
+| [button-card](https://github.com/custom-cards/button-card) | Sensor tiles, alarm hero, heater, TVs row in kiosk view |
+| [better-thermostat-ui-card](https://github.com/KartoffelToby/better-thermostat-ui-card) | Circular thermostat dial in kiosk view |
 | [kiosk-mode](https://github.com/NemesisRE/kiosk-mode) | Sidebar/header hiding for wall display |
-| [clock-weather-card](https://github.com/pkissling/clock-weather-card) | Animated weather + clock widget |
+| [clock-weather-card](https://github.com/pkissling/clock-weather-card) | Combined clock + 4-day forecast on kiosk top strip |


### PR DESCRIPTION
## Summary

Closes #128.

The kiosk dashboard rebuild from `custom:html-template-card` cells to typed Lovelace cards (`custom:grid-layout` view + `custom:mod-card` wrappers around `mushroom-light-card`, `button-card`, `mini-media-player`, `clock-weather-card`, and `better-thermostat-ui-card`) shipped with `dashboards/kiosk.yaml` in the prior commit, but the docs still described the panel-mode html-template-card foundation. This PR is the docs catch-up — no YAML or runtime config changed.

- **CLAUDE.md** — rewrite the Kiosk view subsection, grid layout block, HACS card list, theme files note, kiosk_mode location, file-structure tree, and the Key Patterns line about kiosk styling. Add `button-card` and `better-thermostat-ui-card` to the auto-loaded HACS cards note.
- **README.md** — rewrite the dashboards paragraph and the design-decision blurb; add `button-card` and `better-thermostat-ui-card` rows to the HACS table; add `kiosk.yaml` to the file-structure tree.
- **dashboards/README.md** — split the combined home+kiosk section, rewrite the Kiosk subsection for the new architecture (`/dashboard-kiosk/home` URL, `custom:grid-layout` view, typed cells), add the two new HACS rows.

### Note on the URL in the issue body

Issue #128 referenced `/kiosk/home` as the kiosk path. The actual registered slug in `configuration.yaml` is `dashboard-kiosk`, so the correct URL is `/dashboard-kiosk/home`. Docs use the registered slug.

## Test plan

- [ ] `YAML Lint` workflow passes (no YAML edited, but lint runs anyway)
- [ ] `claude-review` passes
- [ ] Spot-check the rendered Markdown on github.com after merge — file-structure ASCII trees and tables should align