### PR TITLE
feat(kiosk): kiosk_polish design tokens + Sonos group-follower dimming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,7 @@ grid-template-areas:
 
 ### Theme Files
 - `/config/themes/noctis_kiosk.yaml` — Active theme. Originally provided global state-based backgrounds for Mushroom cards on the kiosk; the kiosk view no longer relies on it (state styling moved into per-card `card_mod` and `button-card` state blocks). Still loaded as the project's default dark theme.
+- `/config/themes/kiosk_polish.yaml` — Design-token layer applied on top of Noctis Kiosk via `theme: Kiosk Polish` on the kiosk view. Defines `--kiosk-*` CSS variables for column accents, tile/card backgrounds, text tints, alarm-state colors, and Mushroom sizing — `dashboards/kiosk.yaml` references these tokens instead of inlining hex literals.
 - `/config/themes/kiosk_dark.yaml` — Deprecated custom theme (retained for reference).
 - Noctis base theme installed via HACS.
 
@@ -261,6 +262,7 @@ The "Kiosk" person/user (Settings → People) is a non-admin local account used 
 │   └── homelab-status.yaml     # Homelab Status (NAS, Proxmox, coordinators, battery, printer)
 ├── themes/
 │   ├── noctis_kiosk.yaml       # Active theme: global card-mod state-based backgrounds
+│   ├── kiosk_polish.yaml       # Kiosk design tokens (--kiosk-*) layered via view-level theme
 │   └── kiosk_dark.yaml         # Deprecated custom theme (retained for reference)
 ├── esphome/
 │   ├── konnected-56ac70.yaml   # Main panel firmware: 4 doors, 2 motion, siren

--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -29,6 +29,7 @@ views:
   - title: Home
     path: home
     icon: mdi:monitor-dashboard
+    theme: Kiosk Polish
     type: custom:grid-layout
     layout:
       height: 100vh
@@ -77,50 +78,50 @@ views:
         state:
           - value: disarmed
             icon: mdi:shield-check
-            color: '#56d364'
+            color: 'var(--kiosk-accent-disarmed)'
             styles:
               card:
                 - background-color: 'rgba(86, 211, 100, 0.15)'
-                - border-left: '4px solid #56d364'
-              state: [{ color: '#56d364' }]
+                - border-left: '4px solid var(--kiosk-accent-disarmed)'
+              state: [{ color: 'var(--kiosk-accent-disarmed)' }]
           - value: arming
             icon: mdi:shield-half-full
-            color: '#e3b341'
+            color: 'var(--kiosk-accent-armed)'
             styles:
               card:
                 - background-color: 'rgba(227, 179, 65, 0.15)'
-                - border-left: '4px solid #e3b341'
-              state: [{ color: '#e3b341' }]
+                - border-left: '4px solid var(--kiosk-accent-armed)'
+              state: [{ color: 'var(--kiosk-accent-armed)' }]
           - operator: regex
             value: '^armed.*'
             icon: mdi:shield-lock
-            color: '#e3b341'
+            color: 'var(--kiosk-accent-armed)'
             styles:
               card:
                 - background-color: 'rgba(227, 179, 65, 0.15)'
-                - border-left: '4px solid #e3b341'
-              state: [{ color: '#e3b341' }]
+                - border-left: '4px solid var(--kiosk-accent-armed)'
+              state: [{ color: 'var(--kiosk-accent-armed)' }]
           - operator: regex
             value: '^(pending|triggered)$'
             icon: mdi:alarm-light
-            color: '#f85149'
+            color: 'var(--kiosk-accent-triggered)'
             styles:
               card:
                 - background-color: 'rgba(248, 81, 73, 0.20)'
-                - border-left: '4px solid #f85149'
+                - border-left: '4px solid var(--kiosk-accent-triggered)'
                 - animation: 'pulse 1.2s infinite'
-              state: [{ color: '#f85149' }]
+              state: [{ color: 'var(--kiosk-accent-triggered)' }]
         styles:
           card:
             - height: '100%'
             - border-radius: '10px'
             - border: 'none'
             - padding: '20px 28px'
-            - background: '#161b22'
+            - background: 'var(--kiosk-bg-card)'
           name:
             - font-size: '20px'
             - font-weight: '500'
-            - color: '#8b949e'
+            - color: 'var(--kiosk-text-secondary)'
             - justify-self: start
           state:
             - font-size: '38px'
@@ -152,9 +153,9 @@ views:
               height: 100%;
               border-radius: 10px;
               border: none;
-              border-top: 3px solid #f0883e;
+              border-top: 3px solid var(--kiosk-accent-climate);
               padding: 8px;
-              background: #161b22;
+              background: var(--kiosk-bg-card);
               display: flex;
               flex-direction: column;
               gap: 8px;
@@ -172,7 +173,7 @@ views:
               disable_menu: true
               card_mod:
                 style: |
-                  ha-card { height: 100%; background: #1a1f27; border-radius: 8px; border: none; }
+                  ha-card { height: 100%; background: var(--kiosk-bg-tile); border-radius: 8px; border: none; }
 
             - type: custom:better-thermostat-ui-card
               entity: climate.downstairs
@@ -182,7 +183,7 @@ views:
               disable_menu: true
               card_mod:
                 style: |
-                  ha-card { height: 100%; background: #1a1f27; border-radius: 8px; border: none; }
+                  ha-card { height: 100%; background: var(--kiosk-bg-tile); border-radius: 8px; border: none; }
 
             - type: custom:button-card
               entity: climate.heatstorm_infrared_heater
@@ -196,20 +197,20 @@ views:
               state:
                 - value: 'off'
                   icon: mdi:radiator-off
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
                 - value: 'heat'
                   icon: mdi:radiator
-                  color: '#f0883e'
+                  color: 'var(--kiosk-accent-climate)'
                   styles:
                     card: [{ background-color: 'rgba(240, 136, 62, 0.12)' }]
               styles:
                 card:
                   - height: '70px'
-                  - background: '#1a1f27'
+                  - background: 'var(--kiosk-bg-tile)'
                   - border-radius: '8px'
                   - border: 'none'
                   - padding: '8px 14px'
-                name: [{ font-size: '11px' }, { color: '#8b949e' }, { justify-self: 'start' }]
+                name: [{ font-size: '11px' }, { color: 'var(--kiosk-text-secondary)' }, { justify-self: 'start' }]
                 state: [{ font-size: '14px' }, { font-weight: '500' }, { text-transform: 'capitalize' }, { justify-self: 'start' }]
                 grid:
                   - grid-template-areas: '"i n" "i s"'
@@ -227,9 +228,9 @@ views:
               height: 100%;
               border-radius: 10px;
               border: none;
-              border-top: 3px solid #56d364;
+              border-top: 3px solid var(--kiosk-accent-sensors);
               padding: 8px;
-              background: #161b22;
+              background: var(--kiosk-bg-card);
             }
         card:
           type: custom:grid-layout
@@ -251,23 +252,23 @@ views:
               state:
                 - value: 'on'
                   icon: mdi:door-open
-                  color: '#f85149'
+                  color: 'var(--kiosk-accent-triggered)'
                   styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid #f85149' }]
+                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
                 - value: 'off'
                   icon: mdi:door-closed
-                  color: '#56d364'
+                  color: 'var(--kiosk-accent-sensors)'
                   styles:
                     card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
                 - value: 'unavailable'
                   icon: mdi:door
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
                 - value: 'unknown'
                   icon: mdi:door
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
               styles:
-                card: [{ height: '100%' }, { background: '#1a1f27' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: '#8b949e' }, { padding-top: '4px' }]
+                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
+                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
                 state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
 
             - type: custom:button-card
@@ -281,23 +282,23 @@ views:
               state:
                 - value: 'on'
                   icon: mdi:door-sliding-open
-                  color: '#f85149'
+                  color: 'var(--kiosk-accent-triggered)'
                   styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid #f85149' }]
+                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
                 - value: 'off'
                   icon: mdi:door-sliding
-                  color: '#56d364'
+                  color: 'var(--kiosk-accent-sensors)'
                   styles:
                     card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
                 - value: 'unavailable'
                   icon: mdi:door-sliding
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
                 - value: 'unknown'
                   icon: mdi:door-sliding
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
               styles:
-                card: [{ height: '100%' }, { background: '#1a1f27' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: '#8b949e' }, { padding-top: '4px' }]
+                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
+                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
                 state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
 
             - type: custom:button-card
@@ -311,23 +312,23 @@ views:
               state:
                 - value: 'on'
                   icon: mdi:door-open
-                  color: '#f85149'
+                  color: 'var(--kiosk-accent-triggered)'
                   styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid #f85149' }]
+                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
                 - value: 'off'
                   icon: mdi:door-closed
-                  color: '#56d364'
+                  color: 'var(--kiosk-accent-sensors)'
                   styles:
                     card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
                 - value: 'unavailable'
                   icon: mdi:door
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
                 - value: 'unknown'
                   icon: mdi:door
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
               styles:
-                card: [{ height: '100%' }, { background: '#1a1f27' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: '#8b949e' }, { padding-top: '4px' }]
+                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
+                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
                 state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
 
             - type: custom:button-card
@@ -341,23 +342,23 @@ views:
               state:
                 - value: 'on'
                   icon: mdi:door-open
-                  color: '#f85149'
+                  color: 'var(--kiosk-accent-triggered)'
                   styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid #f85149' }]
+                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
                 - value: 'off'
                   icon: mdi:door-closed
-                  color: '#56d364'
+                  color: 'var(--kiosk-accent-sensors)'
                   styles:
                     card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
                 - value: 'unavailable'
                   icon: mdi:door
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
                 - value: 'unknown'
                   icon: mdi:door
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
               styles:
-                card: [{ height: '100%' }, { background: '#1a1f27' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: '#8b949e' }, { padding-top: '4px' }]
+                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
+                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
                 state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
 
             - type: custom:button-card
@@ -371,23 +372,23 @@ views:
               state:
                 - value: 'on'
                   icon: mdi:door-open
-                  color: '#f85149'
+                  color: 'var(--kiosk-accent-triggered)'
                   styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid #f85149' }]
+                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
                 - value: 'off'
                   icon: mdi:door-closed
-                  color: '#56d364'
+                  color: 'var(--kiosk-accent-sensors)'
                   styles:
                     card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
                 - value: 'unavailable'
                   icon: mdi:door
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
                 - value: 'unknown'
                   icon: mdi:door
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
               styles:
-                card: [{ height: '100%' }, { background: '#1a1f27' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: '#8b949e' }, { padding-top: '4px' }]
+                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
+                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
                 state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
 
             - type: custom:button-card
@@ -401,23 +402,23 @@ views:
               state:
                 - value: 'on'
                   icon: mdi:door-open
-                  color: '#f85149'
+                  color: 'var(--kiosk-accent-triggered)'
                   styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid #f85149' }]
+                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
                 - value: 'off'
                   icon: mdi:door-closed
-                  color: '#56d364'
+                  color: 'var(--kiosk-accent-sensors)'
                   styles:
                     card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
                 - value: 'unavailable'
                   icon: mdi:door
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
                 - value: 'unknown'
                   icon: mdi:door
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
               styles:
-                card: [{ height: '100%' }, { background: '#1a1f27' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: '#8b949e' }, { padding-top: '4px' }]
+                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
+                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
                 state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
 
             # === Garage door covers (state: closed/open) ===
@@ -432,27 +433,27 @@ views:
               state:
                 - value: 'closed'
                   icon: mdi:garage
-                  color: '#56d364'
+                  color: 'var(--kiosk-accent-sensors)'
                   styles:
                     card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
                 - value: 'open'
                   icon: mdi:garage-open-variant
-                  color: '#f85149'
+                  color: 'var(--kiosk-accent-triggered)'
                   styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid #f85149' }]
+                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
                 - value: 'opening'
                   icon: mdi:garage-alert-variant
-                  color: '#e3b341'
+                  color: 'var(--kiosk-accent-lights)'
                   styles:
                     card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
                 - value: 'closing'
                   icon: mdi:garage-alert-variant
-                  color: '#e3b341'
+                  color: 'var(--kiosk-accent-lights)'
                   styles:
                     card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
               styles:
-                card: [{ height: '100%' }, { background: '#1a1f27' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: '#8b949e' }, { padding-top: '4px' }]
+                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
+                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
                 state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
 
             - type: custom:button-card
@@ -466,27 +467,27 @@ views:
               state:
                 - value: 'closed'
                   icon: mdi:garage
-                  color: '#56d364'
+                  color: 'var(--kiosk-accent-sensors)'
                   styles:
                     card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
                 - value: 'open'
                   icon: mdi:garage-open-variant
-                  color: '#f85149'
+                  color: 'var(--kiosk-accent-triggered)'
                   styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid #f85149' }]
+                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
                 - value: 'opening'
                   icon: mdi:garage-alert-variant
-                  color: '#e3b341'
+                  color: 'var(--kiosk-accent-lights)'
                   styles:
                     card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
                 - value: 'closing'
                   icon: mdi:garage-alert-variant
-                  color: '#e3b341'
+                  color: 'var(--kiosk-accent-lights)'
                   styles:
                     card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
               styles:
-                card: [{ height: '100%' }, { background: '#1a1f27' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: '#8b949e' }, { padding-top: '4px' }]
+                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
+                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
                 state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
 
             # === Motion sensors (binary_sensor; on=detected=red pulse, off=clear=gray) ===
@@ -501,18 +502,18 @@ views:
               state:
                 - value: 'on'
                   icon: mdi:motion-sensor
-                  color: '#f85149'
+                  color: 'var(--kiosk-accent-triggered)'
                   styles:
                     card: [{ background-color: 'rgba(248, 81, 73, 0.20)' }, { animation: 'pulse 1s infinite' }]
                 - value: 'off'
                   icon: mdi:motion-sensor-off
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
                 - value: 'unavailable'
                   icon: mdi:motion-sensor-off
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
               styles:
-                card: [{ height: '100%' }, { background: '#1a1f27' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: '#8b949e' }, { padding-top: '4px' }]
+                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
+                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
                 state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
 
             - type: custom:button-card
@@ -526,18 +527,18 @@ views:
               state:
                 - value: 'on'
                   icon: mdi:motion-sensor
-                  color: '#f85149'
+                  color: 'var(--kiosk-accent-triggered)'
                   styles:
                     card: [{ background-color: 'rgba(248, 81, 73, 0.20)' }, { animation: 'pulse 1s infinite' }]
                 - value: 'off'
                   icon: mdi:motion-sensor-off
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
                 - value: 'unavailable'
                   icon: mdi:motion-sensor-off
-                  color: '#6e7681'
+                  color: 'var(--kiosk-text-tertiary)'
               styles:
-                card: [{ height: '100%' }, { background: '#1a1f27' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: '#8b949e' }, { padding-top: '4px' }]
+                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
+                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
                 state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
 
       # ============================================================
@@ -551,9 +552,9 @@ views:
               height: 100%;
               border-radius: 10px;
               border: none;
-              border-top: 3px solid #e3b341;
+              border-top: 3px solid var(--kiosk-accent-lights);
               padding: 8px;
-              background: #161b22;
+              background: var(--kiosk-bg-card);
             }
         card:
           type: custom:grid-layout
@@ -596,9 +597,9 @@ views:
               height: 100%;
               border-radius: 10px;
               border: none;
-              border-top: 3px solid #58a6ff;
+              border-top: 3px solid var(--kiosk-accent-media);
               padding: 8px;
-              background: #161b22;
+              background: var(--kiosk-bg-card);
             }
         card:
           type: custom:grid-layout
@@ -617,7 +618,30 @@ views:
               tap_action: { action: none }
               card_mod:
                 style: |
-                  ha-card { height: 100%; border-radius: 6px; border: none; overflow: hidden; }
+                  ha-card {
+                    height: 100%;
+                    border-radius: 6px;
+                    border: none;
+                    overflow: hidden;
+                    {% set members = state_attr(config.entity, 'group_members') or [] %}
+                    {% if members | length > 1 and members[0] != config.entity %}
+                      opacity: 0.5;
+                      filter: grayscale(0.4);
+                    {% endif %}
+                  }
+                  {% set members = state_attr(config.entity, 'group_members') or [] %}
+                  {% if members | length > 1 and members[0] != config.entity %}
+                  ha-card::after {
+                    content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                    position: absolute;
+                    bottom: 6px;
+                    left: 8px;
+                    font-size: 10px;
+                    color: white;
+                    text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                    z-index: 10;
+                  }
+                  {% endif %}
 
             - type: custom:mini-media-player
               entity: media_player.basement
@@ -628,7 +652,30 @@ views:
               tap_action: { action: none }
               card_mod:
                 style: |
-                  ha-card { height: 100%; border-radius: 6px; border: none; overflow: hidden; }
+                  ha-card {
+                    height: 100%;
+                    border-radius: 6px;
+                    border: none;
+                    overflow: hidden;
+                    {% set members = state_attr(config.entity, 'group_members') or [] %}
+                    {% if members | length > 1 and members[0] != config.entity %}
+                      opacity: 0.5;
+                      filter: grayscale(0.4);
+                    {% endif %}
+                  }
+                  {% set members = state_attr(config.entity, 'group_members') or [] %}
+                  {% if members | length > 1 and members[0] != config.entity %}
+                  ha-card::after {
+                    content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                    position: absolute;
+                    bottom: 6px;
+                    left: 8px;
+                    font-size: 10px;
+                    color: white;
+                    text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                    z-index: 10;
+                  }
+                  {% endif %}
 
             - type: custom:mini-media-player
               entity: media_player.office
@@ -639,7 +686,30 @@ views:
               tap_action: { action: none }
               card_mod:
                 style: |
-                  ha-card { height: 100%; border-radius: 6px; border: none; overflow: hidden; }
+                  ha-card {
+                    height: 100%;
+                    border-radius: 6px;
+                    border: none;
+                    overflow: hidden;
+                    {% set members = state_attr(config.entity, 'group_members') or [] %}
+                    {% if members | length > 1 and members[0] != config.entity %}
+                      opacity: 0.5;
+                      filter: grayscale(0.4);
+                    {% endif %}
+                  }
+                  {% set members = state_attr(config.entity, 'group_members') or [] %}
+                  {% if members | length > 1 and members[0] != config.entity %}
+                  ha-card::after {
+                    content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                    position: absolute;
+                    bottom: 6px;
+                    left: 8px;
+                    font-size: 10px;
+                    color: white;
+                    text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                    z-index: 10;
+                  }
+                  {% endif %}
 
             - type: custom:mini-media-player
               entity: media_player.kitchen
@@ -650,7 +720,30 @@ views:
               tap_action: { action: none }
               card_mod:
                 style: |
-                  ha-card { height: 100%; border-radius: 6px; border: none; overflow: hidden; }
+                  ha-card {
+                    height: 100%;
+                    border-radius: 6px;
+                    border: none;
+                    overflow: hidden;
+                    {% set members = state_attr(config.entity, 'group_members') or [] %}
+                    {% if members | length > 1 and members[0] != config.entity %}
+                      opacity: 0.5;
+                      filter: grayscale(0.4);
+                    {% endif %}
+                  }
+                  {% set members = state_attr(config.entity, 'group_members') or [] %}
+                  {% if members | length > 1 and members[0] != config.entity %}
+                  ha-card::after {
+                    content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                    position: absolute;
+                    bottom: 6px;
+                    left: 8px;
+                    font-size: 10px;
+                    color: white;
+                    text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                    z-index: 10;
+                  }
+                  {% endif %}
 
             - type: custom:mini-media-player
               entity: media_player.dining_room
@@ -661,7 +754,30 @@ views:
               tap_action: { action: none }
               card_mod:
                 style: |
-                  ha-card { height: 100%; border-radius: 6px; border: none; overflow: hidden; }
+                  ha-card {
+                    height: 100%;
+                    border-radius: 6px;
+                    border: none;
+                    overflow: hidden;
+                    {% set members = state_attr(config.entity, 'group_members') or [] %}
+                    {% if members | length > 1 and members[0] != config.entity %}
+                      opacity: 0.5;
+                      filter: grayscale(0.4);
+                    {% endif %}
+                  }
+                  {% set members = state_attr(config.entity, 'group_members') or [] %}
+                  {% if members | length > 1 and members[0] != config.entity %}
+                  ha-card::after {
+                    content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                    position: absolute;
+                    bottom: 6px;
+                    left: 8px;
+                    font-size: 10px;
+                    color: white;
+                    text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                    z-index: 10;
+                  }
+                  {% endif %}
 
             - type: custom:mini-media-player
               entity: media_player.roam_2
@@ -672,7 +788,30 @@ views:
               tap_action: { action: none }
               card_mod:
                 style: |
-                  ha-card { height: 100%; border-radius: 6px; border: none; overflow: hidden; }
+                  ha-card {
+                    height: 100%;
+                    border-radius: 6px;
+                    border: none;
+                    overflow: hidden;
+                    {% set members = state_attr(config.entity, 'group_members') or [] %}
+                    {% if members | length > 1 and members[0] != config.entity %}
+                      opacity: 0.5;
+                      filter: grayscale(0.4);
+                    {% endif %}
+                  }
+                  {% set members = state_attr(config.entity, 'group_members') or [] %}
+                  {% if members | length > 1 and members[0] != config.entity %}
+                  ha-card::after {
+                    content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                    position: absolute;
+                    bottom: 6px;
+                    left: 8px;
+                    font-size: 10px;
+                    color: white;
+                    text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                    z-index: 10;
+                  }
+                  {% endif %}
 
             # --- TVs row (spans both cols) ---
             - type: horizontal-stack
@@ -690,18 +829,18 @@ views:
                   state:
                     - value: 'off'
                       icon: mdi:television-off
-                      color: '#6e7681'
+                      color: 'var(--kiosk-text-tertiary)'
                     - value: 'unavailable'
                       icon: mdi:television-off
-                      color: '#6e7681'
+                      color: 'var(--kiosk-text-tertiary)'
                     - operator: default
                       icon: mdi:television
-                      color: '#58a6ff'
+                      color: 'var(--kiosk-accent-media)'
                       styles:
                         card: [{ background-color: 'rgba(88, 166, 255, 0.12)' }]
                   styles:
-                    card: [{ height: '70px' }, { background: '#1a1f27' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px 10px' }]
-                    name: [{ font-size: '11px' }, { color: '#8b949e' }, { justify-self: 'start' }]
+                    card: [{ height: '70px' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px 10px' }]
+                    name: [{ font-size: '11px' }, { color: 'var(--kiosk-text-secondary)' }, { justify-self: 'start' }]
                     state: [{ font-size: '12px' }, { text-transform: 'capitalize' }, { justify-self: 'start' }]
                     grid: [{ grid-template-areas: '"i n" "i s"' }, { grid-template-columns: 'min-content 1fr' }, { column-gap: '8px' }]
 
@@ -717,18 +856,18 @@ views:
                   state:
                     - value: 'off'
                       icon: mdi:television-off
-                      color: '#6e7681'
+                      color: 'var(--kiosk-text-tertiary)'
                     - value: 'unavailable'
                       icon: mdi:television-off
-                      color: '#6e7681'
+                      color: 'var(--kiosk-text-tertiary)'
                     - operator: default
                       icon: mdi:television
-                      color: '#58a6ff'
+                      color: 'var(--kiosk-accent-media)'
                       styles:
                         card: [{ background-color: 'rgba(88, 166, 255, 0.12)' }]
                   styles:
-                    card: [{ height: '70px' }, { background: '#1a1f27' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px 10px' }]
-                    name: [{ font-size: '11px' }, { color: '#8b949e' }, { justify-self: 'start' }]
+                    card: [{ height: '70px' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px 10px' }]
+                    name: [{ font-size: '11px' }, { color: 'var(--kiosk-text-secondary)' }, { justify-self: 'start' }]
                     state: [{ font-size: '12px' }, { text-transform: 'capitalize' }, { justify-self: 'start' }]
                     grid: [{ grid-template-areas: '"i n" "i s"' }, { grid-template-columns: 'min-content 1fr' }, { column-gap: '8px' }]
 
@@ -744,17 +883,17 @@ views:
                   state:
                     - value: 'off'
                       icon: mdi:television-off
-                      color: '#6e7681'
+                      color: 'var(--kiosk-text-tertiary)'
                     - value: 'unavailable'
                       icon: mdi:television-off
-                      color: '#6e7681'
+                      color: 'var(--kiosk-text-tertiary)'
                     - operator: default
                       icon: mdi:television
-                      color: '#58a6ff'
+                      color: 'var(--kiosk-accent-media)'
                       styles:
                         card: [{ background-color: 'rgba(88, 166, 255, 0.12)' }]
                   styles:
-                    card: [{ height: '70px' }, { background: '#1a1f27' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px 10px' }]
-                    name: [{ font-size: '11px' }, { color: '#8b949e' }, { justify-self: 'start' }]
+                    card: [{ height: '70px' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px 10px' }]
+                    name: [{ font-size: '11px' }, { color: 'var(--kiosk-text-secondary)' }, { justify-self: 'start' }]
                     state: [{ font-size: '12px' }, { text-transform: 'capitalize' }, { justify-self: 'start' }]
                     grid: [{ grid-template-areas: '"i n" "i s"' }, { grid-template-columns: 'min-content 1fr' }, { column-gap: '8px' }]

--- a/themes/README.md
+++ b/themes/README.md
@@ -33,6 +33,31 @@ This approach trades one design decision for a runtime dependency: every card ev
 | `card-background-color` | `#171a21` | Card resting state |
 | `state-icon-active-color` | `#f0b429` | Active entity icons |
 
+## `kiosk_polish.yaml` — Kiosk design tokens
+
+Layered on top of `Noctis Kiosk` via the `theme: Kiosk Polish` key on the kiosk view in `dashboards/kiosk.yaml`. Defines `--kiosk-*` CSS custom properties for the 1920x1080 wall-display dashboard so colors, accents, and Mushroom sizing tokens are edited in one place instead of search-and-replace across `kiosk.yaml`.
+
+### Tokens
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--kiosk-bg-page` | `#0e1117` | Page background (forced via `card-mod-root`) |
+| `--kiosk-bg-card` | `#161b22` | Outer column wrappers (climate/sensors/lights/media/alarm hero) |
+| `--kiosk-bg-tile` | `#1a1f27` | Inner tile backgrounds (per-sensor, per-thermostat, TV row) |
+| `--kiosk-bg-tile-active-media` | `#14283f` | Reserved for active-media tinting |
+| `--kiosk-text-primary` | `#e6edf3` | Reserved for headline text |
+| `--kiosk-text-secondary` | `#8b949e` | Card name labels |
+| `--kiosk-text-tertiary` | `#6e7681` | Off / unavailable icons |
+| `--kiosk-accent-climate` | `#f0883e` | Climate column border-top + heater on |
+| `--kiosk-accent-sensors` | `#56d364` | Sensors column border-top + door/cover closed |
+| `--kiosk-accent-lights` | `#e3b341` | Lights column border-top + cover transition |
+| `--kiosk-accent-media` | `#58a6ff` | Media column border-top + TV on |
+| `--kiosk-accent-disarmed` | `#56d364` | Alarm hero, disarmed state |
+| `--kiosk-accent-armed` | `#e3b341` | Alarm hero, arming/armed states |
+| `--kiosk-accent-triggered` | `#f85149` | Alarm hero pending/triggered + door open + motion |
+
+Mushroom token overrides (`--mush-icon-size`, `--mush-icon-symbol-size`, `--mush-card-primary-font-size`, `--mush-card-secondary-font-size`) propagate to every `mushroom-light-card` in the lights grid.
+
 ## `kiosk_dark.yaml` — Deprecated
 
 The original custom dark theme, replaced by Noctis Kiosk. Retained for reference. Not applied to any dashboard or view.

--- a/themes/kiosk_polish.yaml
+++ b/themes/kiosk_polish.yaml
@@ -1,0 +1,40 @@
+Kiosk Polish:
+  # Tokens used by dashboards/kiosk.yaml — change here, propagate everywhere.
+  # Loaded via the standard themes !include_dir_merge_named pattern in
+  # configuration.yaml. Applied per-view via `theme: Kiosk Polish` on the
+  # kiosk view, on top of the project's default Noctis Kiosk theme.
+
+  # Color palette
+  kiosk-bg-page: "#0e1117"
+  kiosk-bg-card: "#161b22"
+  kiosk-bg-tile: "#1a1f27"
+  kiosk-bg-tile-active-media: "#14283f"
+  kiosk-text-primary: "#e6edf3"
+  kiosk-text-secondary: "#8b949e"
+  kiosk-text-tertiary: "#6e7681"
+
+  # Accent colors per panel
+  kiosk-accent-climate: "#f0883e"
+  kiosk-accent-sensors: "#56d364"
+  kiosk-accent-lights: "#e3b341"
+  kiosk-accent-media: "#58a6ff"
+  kiosk-accent-disarmed: "#56d364"
+  kiosk-accent-armed: "#e3b341"
+  kiosk-accent-triggered: "#f85149"
+
+  # Mushroom token overrides (applied via card-mod theme block)
+  mush-icon-size: 36px
+  mush-icon-symbol-size: 0.6em
+  mush-card-primary-font-size: 13px
+  mush-card-secondary-font-size: 11px
+
+  # State-color sugar
+  state-on-color: "#56d364"
+  state-off-color: "#6e7681"
+
+  card-mod-theme: Kiosk Polish
+  card-mod-root: |
+    /* Force kiosk grid background through layout-card */
+    home-assistant-main {
+      --primary-background-color: var(--kiosk-bg-page);
+    }


### PR DESCRIPTION
## Summary

Iteration 2 polish on the kiosk dashboard. Theming-only — no new cards, no layout changes.

- **`themes/kiosk_polish.yaml`** (new) — defines `--kiosk-*` CSS custom properties: page/card/tile backgrounds, text tints, panel accents (climate/sensors/lights/media), alarm-state colors (disarmed/armed/triggered), and Mushroom sizing tokens. Applied per-view via `theme: Kiosk Polish` on the kiosk view, layered on top of Noctis Kiosk.
- **`dashboards/kiosk.yaml`** — every inline hex literal that has a token has been replaced with the corresponding `var(--kiosk-*)` reference. The alarm hero block uses the semantic `disarmed`/`armed`/`triggered` tokens; column wrappers and per-tile styling use the panel-accent tokens. Future palette tweaks are now one-line edits in the theme file.
- **`dashboards/kiosk.yaml`** — each of the 6 `mini-media-player` cards now drops to `opacity: 0.5` with a grayscale tint and a "↳ LeaderName" overlay when its speaker is a group follower (`group_members[0] != config.entity`). Coordinators render at full opacity and show the playing track normally.
- **`themes/README.md`** — documents `kiosk_polish.yaml` with a token reference table.
- **`CLAUDE.md`** — Theme Files section + file-tree updated to mention the new theme.

The "empty-space audit" knobs called out in the issue (thermostat padding, mushroom icon size, sensor icon size, alarm font-size) were left at iteration-1 values; the issue says "Apply only the changes that screenshot review actually demands. Don't guess." The Mushroom token slots are wired into the theme so they can be adjusted in one place if a screenshot review later identifies a need.

Closes #129

## Test plan

- [ ] CI: `YAML Lint` workflow green
- [ ] CI: `HA Config Check` (against pinned `2026.4.4`) green
- [ ] CI: `claude-review` green
- [ ] Visual: kiosk view at 1920x1080 — no vertical scrollbar, all four columns reach the bottom edge, alarm hero color cycles correctly across disarmed/arming/armed/triggered
- [ ] Visual: group two Sonos speakers (e.g. Office + Kitchen) — the follower cell renders at 0.5 opacity with a "↳ Office" overlay; the coordinator stays at full opacity

https://claude.ai/code/session_01Nsk83hAkTkRyAwcypDXbTK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nsk83hAkTkRyAwcypDXbTK)_