### PR TITLE
fix(kiosk): empty Sensors/Lights/Media columns + top-strip layout

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -46,12 +46,8 @@ views:
       # ============================================================
       # WEATHER + CLOCK (top-left, spans 2 cols)
       # ============================================================
-      - type: custom:clock-weather-card
+      - type: custom:mod-card
         view_layout: { grid-area: weather }
-        entity: weather.forecast_home
-        forecast_rows: 4
-        time_format: 12
-        date_pattern: "EEEE, MMM d"
         card_mod:
           style: |
             ha-card {
@@ -60,87 +56,103 @@ views:
               border: none;
               background: linear-gradient(135deg, #1e3a5f 0%, #0f1f3a 100%);
             }
+        card:
+          type: custom:clock-weather-card
+          entity: weather.forecast_home
+          forecast_rows: 2
+          time_format: 12
+          date_pattern: "EEEE, MMM d"
 
       # ============================================================
       # ALARM HERO (top-right, spans 2 cols)
       # ============================================================
-      - type: custom:button-card
+      - type: custom:mod-card
         view_layout: { grid-area: alarm }
-        entity: alarm_control_panel.home_alarm
-        name: Home Alarm
-        show_name: true
-        show_state: true
-        show_icon: true
-        size: 35%
-        layout: icon_name_state
-        tap_action: { action: none }
-        hold_action: { action: none }
-        state:
-          - value: disarmed
-            icon: mdi:shield-check
-            color: 'var(--kiosk-accent-disarmed)'
-            styles:
-              card:
-                - background-color: 'rgba(86, 211, 100, 0.15)'
-                - border-left: '4px solid var(--kiosk-accent-disarmed)'
-              state: [{ color: 'var(--kiosk-accent-disarmed)' }]
-          - value: arming
-            icon: mdi:shield-half-full
-            color: 'var(--kiosk-accent-armed)'
-            styles:
-              card:
-                - background-color: 'rgba(227, 179, 65, 0.15)'
-                - border-left: '4px solid var(--kiosk-accent-armed)'
-              state: [{ color: 'var(--kiosk-accent-armed)' }]
-          - operator: regex
-            value: '^armed.*'
-            icon: mdi:shield-lock
-            color: 'var(--kiosk-accent-armed)'
-            styles:
-              card:
-                - background-color: 'rgba(227, 179, 65, 0.15)'
-                - border-left: '4px solid var(--kiosk-accent-armed)'
-              state: [{ color: 'var(--kiosk-accent-armed)' }]
-          - operator: regex
-            value: '^(pending|triggered)$'
-            icon: mdi:alarm-light
-            color: 'var(--kiosk-accent-triggered)'
-            styles:
-              card:
-                - background-color: 'rgba(248, 81, 73, 0.20)'
-                - border-left: '4px solid var(--kiosk-accent-triggered)'
-                - animation: 'pulse 1.2s infinite'
-              state: [{ color: 'var(--kiosk-accent-triggered)' }]
-        styles:
-          card:
-            - height: '100%'
-            - border-radius: '10px'
-            - border: 'none'
-            - padding: '20px 28px'
-            - background: 'var(--kiosk-bg-card)'
-          name:
-            - font-size: '20px'
-            - font-weight: '500'
-            - color: 'var(--kiosk-text-secondary)'
-            - justify-self: start
+        card_mod:
+          style: |
+            ha-card {
+              height: 100%;
+              border-radius: 10px;
+              border: none;
+              background: transparent;
+            }
+        card:
+          type: custom:button-card
+          entity: alarm_control_panel.home_alarm
+          name: Home Alarm
+          show_name: true
+          show_state: true
+          show_icon: true
+          size: 35%
+          layout: icon_name_state
+          tap_action: { action: none }
+          hold_action: { action: none }
           state:
-            - font-size: '38px'
-            - font-weight: '600'
-            - text-transform: 'uppercase'
-            - letter-spacing: '2px'
-            - justify-self: start
-          grid:
-            - grid-template-areas: '"i n" "i s"'
-            - grid-template-columns: 'min-content 1fr'
-            - grid-template-rows: 'min-content min-content'
-            - column-gap: '24px'
-            - row-gap: '4px'
-            - align-items: 'center'
-        extra_styles: |
-          @keyframes pulse {
-            0%, 100% { opacity: 1; transform: scale(1); }
-            50% { opacity: 0.7; transform: scale(0.99); }
-          }
+            - value: disarmed
+              icon: mdi:shield-check
+              color: 'var(--kiosk-accent-disarmed)'
+              styles:
+                card:
+                  - background-color: 'rgba(86, 211, 100, 0.15)'
+                  - border-left: '4px solid var(--kiosk-accent-disarmed)'
+                state: [{ color: 'var(--kiosk-accent-disarmed)' }]
+            - value: arming
+              icon: mdi:shield-half-full
+              color: 'var(--kiosk-accent-armed)'
+              styles:
+                card:
+                  - background-color: 'rgba(227, 179, 65, 0.15)'
+                  - border-left: '4px solid var(--kiosk-accent-armed)'
+                state: [{ color: 'var(--kiosk-accent-armed)' }]
+            - operator: regex
+              value: '^armed.*'
+              icon: mdi:shield-lock
+              color: 'var(--kiosk-accent-armed)'
+              styles:
+                card:
+                  - background-color: 'rgba(227, 179, 65, 0.15)'
+                  - border-left: '4px solid var(--kiosk-accent-armed)'
+                state: [{ color: 'var(--kiosk-accent-armed)' }]
+            - operator: regex
+              value: '^(pending|triggered)$'
+              icon: mdi:alarm-light
+              color: 'var(--kiosk-accent-triggered)'
+              styles:
+                card:
+                  - background-color: 'rgba(248, 81, 73, 0.20)'
+                  - border-left: '4px solid var(--kiosk-accent-triggered)'
+                  - animation: 'pulse 1.2s infinite'
+                state: [{ color: 'var(--kiosk-accent-triggered)' }]
+          styles:
+            card:
+              - height: '100%'
+              - border-radius: '10px'
+              - border: 'none'
+              - padding: '20px 28px'
+              - background: 'var(--kiosk-bg-card)'
+            name:
+              - font-size: '20px'
+              - font-weight: '500'
+              - color: 'var(--kiosk-text-secondary)'
+              - justify-self: start
+            state:
+              - font-size: '38px'
+              - font-weight: '600'
+              - text-transform: 'uppercase'
+              - letter-spacing: '2px'
+              - justify-self: start
+            grid:
+              - grid-template-areas: '"i n" "i s"'
+              - grid-template-columns: 'min-content 1fr'
+              - grid-template-rows: 'min-content min-content'
+              - column-gap: '24px'
+              - row-gap: '4px'
+              - align-items: 'center'
+          extra_styles: |
+            @keyframes pulse {
+              0%, 100% { opacity: 1; transform: scale(1); }
+              50% { opacity: 0.7; transform: scale(0.99); }
+            }
 
       # ============================================================
       # CLIMATE COLUMN
@@ -233,12 +245,9 @@ views:
               background: var(--kiosk-bg-card);
             }
         card:
-          type: custom:grid-layout
-          layout:
-            grid-template-columns: 1fr 1fr
-            grid-template-rows: repeat(5, 1fr)
-            grid-gap: 6px
-            height: 100%
+          type: grid
+          columns: 2
+          square: false
           cards:
             # === Door sensors (binary_sensor; on=open=red, off=closed=green) ===
             - type: custom:button-card
@@ -557,12 +566,9 @@ views:
               background: var(--kiosk-bg-card);
             }
         card:
-          type: custom:grid-layout
-          layout:
-            grid-template-columns: 1fr 1fr 1fr
-            grid-template-rows: repeat(7, 1fr)
-            grid-gap: 4px
-            height: 100%
+          type: grid
+          columns: 3
+          square: false
           cards:
             - { type: 'custom:mushroom-light-card', entity: light.family_room, name: Family, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
             - { type: 'custom:mushroom-light-card', entity: light.family_room_2, name: Family 2, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
@@ -602,220 +608,218 @@ views:
               background: var(--kiosk-bg-card);
             }
         card:
-          type: custom:grid-layout
-          layout:
-            grid-template-columns: 1fr 1fr
-            grid-template-rows: 1fr 1fr 1fr 70px
-            grid-gap: 6px
-            height: 100%
+          type: vertical-stack
           cards:
-            - type: custom:mini-media-player
-              entity: media_player.master_bedroom
-              name: Master Bedroom
-              artwork: full-cover-fit
-              info: scroll
-              hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-              tap_action: { action: none }
-              card_mod:
-                style: |
-                  ha-card {
-                    height: 100%;
-                    border-radius: 6px;
-                    border: none;
-                    overflow: hidden;
-                    {% set members = state_attr(config.entity, 'group_members') or [] %}
-                    {% if members | length > 1 and members[0] != config.entity %}
-                      opacity: 0.5;
-                      filter: grayscale(0.4);
-                    {% endif %}
-                  }
-                  {% set members = state_attr(config.entity, 'group_members') or [] %}
-                  {% if members | length > 1 and members[0] != config.entity %}
-                  ha-card::after {
-                    content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
-                    position: absolute;
-                    bottom: 6px;
-                    left: 8px;
-                    font-size: 10px;
-                    color: white;
-                    text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-                    z-index: 10;
-                  }
-                  {% endif %}
+            - type: grid
+              columns: 2
+              square: false
+              cards:
+                - type: custom:mini-media-player
+                  entity: media_player.master_bedroom
+                  name: Master Bedroom
+                  artwork: full-cover-fit
+                  info: scroll
+                  hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
+                  tap_action: { action: none }
+                  card_mod:
+                    style: |
+                      ha-card {
+                        height: 100%;
+                        border-radius: 6px;
+                        border: none;
+                        overflow: hidden;
+                        {% set members = state_attr(config.entity, 'group_members') or [] %}
+                        {% if members | length > 1 and members[0] != config.entity %}
+                          opacity: 0.5;
+                          filter: grayscale(0.4);
+                        {% endif %}
+                      }
+                      {% set members = state_attr(config.entity, 'group_members') or [] %}
+                      {% if members | length > 1 and members[0] != config.entity %}
+                      ha-card::after {
+                        content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                        position: absolute;
+                        bottom: 6px;
+                        left: 8px;
+                        font-size: 10px;
+                        color: white;
+                        text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                        z-index: 10;
+                      }
+                      {% endif %}
 
-            - type: custom:mini-media-player
-              entity: media_player.basement
-              name: Basement
-              artwork: full-cover-fit
-              info: scroll
-              hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-              tap_action: { action: none }
-              card_mod:
-                style: |
-                  ha-card {
-                    height: 100%;
-                    border-radius: 6px;
-                    border: none;
-                    overflow: hidden;
-                    {% set members = state_attr(config.entity, 'group_members') or [] %}
-                    {% if members | length > 1 and members[0] != config.entity %}
-                      opacity: 0.5;
-                      filter: grayscale(0.4);
-                    {% endif %}
-                  }
-                  {% set members = state_attr(config.entity, 'group_members') or [] %}
-                  {% if members | length > 1 and members[0] != config.entity %}
-                  ha-card::after {
-                    content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
-                    position: absolute;
-                    bottom: 6px;
-                    left: 8px;
-                    font-size: 10px;
-                    color: white;
-                    text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-                    z-index: 10;
-                  }
-                  {% endif %}
+                - type: custom:mini-media-player
+                  entity: media_player.basement
+                  name: Basement
+                  artwork: full-cover-fit
+                  info: scroll
+                  hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
+                  tap_action: { action: none }
+                  card_mod:
+                    style: |
+                      ha-card {
+                        height: 100%;
+                        border-radius: 6px;
+                        border: none;
+                        overflow: hidden;
+                        {% set members = state_attr(config.entity, 'group_members') or [] %}
+                        {% if members | length > 1 and members[0] != config.entity %}
+                          opacity: 0.5;
+                          filter: grayscale(0.4);
+                        {% endif %}
+                      }
+                      {% set members = state_attr(config.entity, 'group_members') or [] %}
+                      {% if members | length > 1 and members[0] != config.entity %}
+                      ha-card::after {
+                        content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                        position: absolute;
+                        bottom: 6px;
+                        left: 8px;
+                        font-size: 10px;
+                        color: white;
+                        text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                        z-index: 10;
+                      }
+                      {% endif %}
 
-            - type: custom:mini-media-player
-              entity: media_player.office
-              name: Office
-              artwork: full-cover-fit
-              info: scroll
-              hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-              tap_action: { action: none }
-              card_mod:
-                style: |
-                  ha-card {
-                    height: 100%;
-                    border-radius: 6px;
-                    border: none;
-                    overflow: hidden;
-                    {% set members = state_attr(config.entity, 'group_members') or [] %}
-                    {% if members | length > 1 and members[0] != config.entity %}
-                      opacity: 0.5;
-                      filter: grayscale(0.4);
-                    {% endif %}
-                  }
-                  {% set members = state_attr(config.entity, 'group_members') or [] %}
-                  {% if members | length > 1 and members[0] != config.entity %}
-                  ha-card::after {
-                    content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
-                    position: absolute;
-                    bottom: 6px;
-                    left: 8px;
-                    font-size: 10px;
-                    color: white;
-                    text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-                    z-index: 10;
-                  }
-                  {% endif %}
+                - type: custom:mini-media-player
+                  entity: media_player.office
+                  name: Office
+                  artwork: full-cover-fit
+                  info: scroll
+                  hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
+                  tap_action: { action: none }
+                  card_mod:
+                    style: |
+                      ha-card {
+                        height: 100%;
+                        border-radius: 6px;
+                        border: none;
+                        overflow: hidden;
+                        {% set members = state_attr(config.entity, 'group_members') or [] %}
+                        {% if members | length > 1 and members[0] != config.entity %}
+                          opacity: 0.5;
+                          filter: grayscale(0.4);
+                        {% endif %}
+                      }
+                      {% set members = state_attr(config.entity, 'group_members') or [] %}
+                      {% if members | length > 1 and members[0] != config.entity %}
+                      ha-card::after {
+                        content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                        position: absolute;
+                        bottom: 6px;
+                        left: 8px;
+                        font-size: 10px;
+                        color: white;
+                        text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                        z-index: 10;
+                      }
+                      {% endif %}
 
-            - type: custom:mini-media-player
-              entity: media_player.kitchen
-              name: Kitchen
-              artwork: full-cover-fit
-              info: scroll
-              hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-              tap_action: { action: none }
-              card_mod:
-                style: |
-                  ha-card {
-                    height: 100%;
-                    border-radius: 6px;
-                    border: none;
-                    overflow: hidden;
-                    {% set members = state_attr(config.entity, 'group_members') or [] %}
-                    {% if members | length > 1 and members[0] != config.entity %}
-                      opacity: 0.5;
-                      filter: grayscale(0.4);
-                    {% endif %}
-                  }
-                  {% set members = state_attr(config.entity, 'group_members') or [] %}
-                  {% if members | length > 1 and members[0] != config.entity %}
-                  ha-card::after {
-                    content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
-                    position: absolute;
-                    bottom: 6px;
-                    left: 8px;
-                    font-size: 10px;
-                    color: white;
-                    text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-                    z-index: 10;
-                  }
-                  {% endif %}
+                - type: custom:mini-media-player
+                  entity: media_player.kitchen
+                  name: Kitchen
+                  artwork: full-cover-fit
+                  info: scroll
+                  hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
+                  tap_action: { action: none }
+                  card_mod:
+                    style: |
+                      ha-card {
+                        height: 100%;
+                        border-radius: 6px;
+                        border: none;
+                        overflow: hidden;
+                        {% set members = state_attr(config.entity, 'group_members') or [] %}
+                        {% if members | length > 1 and members[0] != config.entity %}
+                          opacity: 0.5;
+                          filter: grayscale(0.4);
+                        {% endif %}
+                      }
+                      {% set members = state_attr(config.entity, 'group_members') or [] %}
+                      {% if members | length > 1 and members[0] != config.entity %}
+                      ha-card::after {
+                        content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                        position: absolute;
+                        bottom: 6px;
+                        left: 8px;
+                        font-size: 10px;
+                        color: white;
+                        text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                        z-index: 10;
+                      }
+                      {% endif %}
 
-            - type: custom:mini-media-player
-              entity: media_player.dining_room
-              name: Dining Room
-              artwork: full-cover-fit
-              info: scroll
-              hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-              tap_action: { action: none }
-              card_mod:
-                style: |
-                  ha-card {
-                    height: 100%;
-                    border-radius: 6px;
-                    border: none;
-                    overflow: hidden;
-                    {% set members = state_attr(config.entity, 'group_members') or [] %}
-                    {% if members | length > 1 and members[0] != config.entity %}
-                      opacity: 0.5;
-                      filter: grayscale(0.4);
-                    {% endif %}
-                  }
-                  {% set members = state_attr(config.entity, 'group_members') or [] %}
-                  {% if members | length > 1 and members[0] != config.entity %}
-                  ha-card::after {
-                    content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
-                    position: absolute;
-                    bottom: 6px;
-                    left: 8px;
-                    font-size: 10px;
-                    color: white;
-                    text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-                    z-index: 10;
-                  }
-                  {% endif %}
+                - type: custom:mini-media-player
+                  entity: media_player.dining_room
+                  name: Dining Room
+                  artwork: full-cover-fit
+                  info: scroll
+                  hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
+                  tap_action: { action: none }
+                  card_mod:
+                    style: |
+                      ha-card {
+                        height: 100%;
+                        border-radius: 6px;
+                        border: none;
+                        overflow: hidden;
+                        {% set members = state_attr(config.entity, 'group_members') or [] %}
+                        {% if members | length > 1 and members[0] != config.entity %}
+                          opacity: 0.5;
+                          filter: grayscale(0.4);
+                        {% endif %}
+                      }
+                      {% set members = state_attr(config.entity, 'group_members') or [] %}
+                      {% if members | length > 1 and members[0] != config.entity %}
+                      ha-card::after {
+                        content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                        position: absolute;
+                        bottom: 6px;
+                        left: 8px;
+                        font-size: 10px;
+                        color: white;
+                        text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                        z-index: 10;
+                      }
+                      {% endif %}
 
-            - type: custom:mini-media-player
-              entity: media_player.roam_2
-              name: Roam 2
-              artwork: full-cover-fit
-              info: scroll
-              hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-              tap_action: { action: none }
-              card_mod:
-                style: |
-                  ha-card {
-                    height: 100%;
-                    border-radius: 6px;
-                    border: none;
-                    overflow: hidden;
-                    {% set members = state_attr(config.entity, 'group_members') or [] %}
-                    {% if members | length > 1 and members[0] != config.entity %}
-                      opacity: 0.5;
-                      filter: grayscale(0.4);
-                    {% endif %}
-                  }
-                  {% set members = state_attr(config.entity, 'group_members') or [] %}
-                  {% if members | length > 1 and members[0] != config.entity %}
-                  ha-card::after {
-                    content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
-                    position: absolute;
-                    bottom: 6px;
-                    left: 8px;
-                    font-size: 10px;
-                    color: white;
-                    text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-                    z-index: 10;
-                  }
-                  {% endif %}
+                - type: custom:mini-media-player
+                  entity: media_player.roam_2
+                  name: Roam 2
+                  artwork: full-cover-fit
+                  info: scroll
+                  hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
+                  tap_action: { action: none }
+                  card_mod:
+                    style: |
+                      ha-card {
+                        height: 100%;
+                        border-radius: 6px;
+                        border: none;
+                        overflow: hidden;
+                        {% set members = state_attr(config.entity, 'group_members') or [] %}
+                        {% if members | length > 1 and members[0] != config.entity %}
+                          opacity: 0.5;
+                          filter: grayscale(0.4);
+                        {% endif %}
+                      }
+                      {% set members = state_attr(config.entity, 'group_members') or [] %}
+                      {% if members | length > 1 and members[0] != config.entity %}
+                      ha-card::after {
+                        content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                        position: absolute;
+                        bottom: 6px;
+                        left: 8px;
+                        font-size: 10px;
+                        color: white;
+                        text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                        z-index: 10;
+                      }
+                      {% endif %}
 
             # --- TVs row (spans both cols) ---
             - type: horizontal-stack
-              view_layout: { grid-column-start: 1, grid-column-end: 3 }
               cards:
                 - type: custom:button-card
                   entity: media_player.office_tv


### PR DESCRIPTION
## Summary

- Sensors / Lights / Media columns rendered the `mod-card` cell but no children. Root cause: `custom:grid-layout` is reliable as the **view** type but does not render children when nested inside `custom:mod-card`. Swap nested grids for the built-in `type: grid` (`columns:` + `square: false`). Media wraps a 2-col grid for the 6 Sonos players + the existing TVs `horizontal-stack` in a `vertical-stack`.
- Weather and alarm in the top strip were direct children of the view-grid with no `mod-card` wrapper, so `height: 100%` had no `ha-card` host to cascade from. Wrap both in `custom:mod-card`. Drop weather `forecast_rows` from 4 → 2 so the forecast fits the 130px row without overlapping the clock.
- Climate column unchanged (it already uses `mod-card → vertical-stack → typed cards`, which renders correctly).

## Test plan

- [ ] GitOps poller picks up the change → `lovelace.reload_resources` (no restart)
- [ ] `/kiosk/home`: Climate column unchanged
- [ ] Sensors: 10 button-cards visible in 2×5 with state-driven colors
- [ ] Lights: 21 mushroom-light-cards visible in 3×7
- [ ] Media: 6 mini-media-players in 2×3 above the TVs row, album art on `full-cover-fit`
- [ ] Top strip: clock and forecast no longer overlap; alarm hero shows full-width with 35% icon and state-driven background

🤖 Generated with [Claude Code](https://claude.com/claude-code)