### PR TITLE
polish(kiosk): equal-height sensor rows; bump top strip to 200px

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -37,7 +37,7 @@ views:
       padding: 8px
       grid-gap: 8px
       grid-template-columns: 1fr 1fr 1.4fr 1fr
-      grid-template-rows: 130px 1fr
+      grid-template-rows: 200px 1fr
       grid-template-areas: |
         "weather weather alarm   alarm"
         "climate sensors lights  media"
@@ -59,7 +59,7 @@ views:
         card:
           type: custom:clock-weather-card
           entity: weather.forecast_home
-          forecast_rows: 2
+          forecast_rows: 0
           time_format: 12
           date_pattern: "EEEE, MMM d"
 
@@ -248,6 +248,17 @@ views:
           type: grid
           columns: 2
           square: false
+          card_mod:
+            style: |
+              :host {
+                height: 100%;
+                display: block;
+              }
+              #root {
+                height: 100%;
+                grid-template-rows: repeat(5, 1fr) !important;
+                gap: 6px !important;
+              }
           cards:
             # === Door sensors (binary_sensor; on=open=red, off=closed=green) ===
             - type: custom:button-card


### PR DESCRIPTION
## Summary

- **Sensors column** had uneven vertical spacing — the inner `type: grid` was sizing rows to button-card content. Add a `card_mod` block targeting `:host` (height: 100%) and `#root` (`grid-template-rows: repeat(5, 1fr) !important`) so the five rows distribute evenly across the full column height.
- **Top strip** bumped from 130px → 200px so `clock-weather-card` has room for icon + conditions + clock without clipping. Bottom row still fills `1fr`.
- **Weather forecast_rows** dropped 2 → 0. With the taller strip the card renders cleanly on current conditions + clock alone; can bump back to 1 later if it feels too sparse.

## Test plan

- [ ] GitOps poller picks up → `lovelace.reload_resources` (no restart)
- [ ] `/kiosk/home`: sensors column shows 5 equal-height rows of 2 button-cards each, no vertical gaps
- [ ] Top strip is taller; weather card no longer clipped or overlapping
- [ ] Alarm hero scales with the extra height (its `height: 100%` already cascades)
- [ ] Lights grid still beautiful in the bottom row

## Fallbacks (if `#root` selector doesn't take)

Try `.root`, `:host > *`, or `:host > .grid` as the inner selector. Last resort: swap inner card to `vertical-stack` of `horizontal-stack` (heavier syntax, bulletproof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)