### PR TITLE
feat(kiosk): meeting tile, room-grouped lights, retire dead entities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,9 +187,9 @@ grid-template-areas:
 - **weather** — clock-weather-card with 4-day forecast (top-left, spans 2 cols)
 - **alarm** — button-card hero (top-row, col 3 — 1.4fr)
 - **meeting** — button-card driven by `light.meeting_light` (top-row, col 4 — 1fr)
-- **climate** — 2 better-thermostat-ui-cards stacked + heater button-card
-- **sensors** — 10 button-cards in a 2×5 internal grid (6 doors + 2 garage covers + 2 motion)
-- **lights** — 20 mushroom-light-cards grouped into 5 room sections (Family Room, Kitchen, Office, Hallways, Outdoor) inside a vertical-stack; each section is a markdown header + 3-col grid. The meeting light is hoisted to the top-right `meeting` cell.
+- **climate** — 2 better-thermostat-ui-cards stacked (upstairs + downstairs)
+- **sensors** — 8 button-cards in a 2×4 internal grid (4 doors + 2 garage covers + 2 motion)
+- **lights** — 20 mushroom-light-cards grouped into 5 room sections (Family Room, Kitchen, Office, Hallways, Outdoor) inside a vertical-stack; each section is a markdown header + 4-col grid. The meeting light is hoisted to the top-right `meeting` cell.
 - **media** — 6 mini-media-players in a 2×3 internal grid + TVs row spanning both cols
 
 ### HACS Cards Used by Kiosk View

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,10 +167,11 @@ The Home view uses standard HA `tile`, `weather-forecast`, and `media-control` c
 - Typed cards per panel (no html-template-card):
   - Climate: `custom:better-thermostat-ui-card` with humidity sensor binding
   - Sensors: `custom:button-card` with state-driven backgrounds and pulse animations
-  - Lights: `custom:mushroom-light-card` per individual light (21 lights in a 3×7 grid)
+  - Lights: `custom:mushroom-light-card` per individual light (20 lights, grouped into 5 room sections inside a vertical-stack)
   - Media: `custom:mini-media-player` with `artwork: full-cover-fit` for album art
   - Weather: `custom:clock-weather-card` (combined clock + 4-day forecast)
   - Alarm: `custom:button-card` hero with state-driven colors and pulse on triggered
+  - Meeting: `custom:button-card` driven by `light.meeting_light` — "In Meeting" red+pulse / "Available" green / "Offline" muted
 - Non-interactive — every card has `tap_action: { action: none }`
 - Kiosk-mode hides sidebar/header for "Kiosk" user
 - No camera (handled in a separate cameras dashboard)
@@ -178,16 +179,17 @@ The Home view uses standard HA `tile`, `weather-forecast`, and `media-control` c
 ### Grid Layout (Kiosk)
 ```
 grid-template-columns: 1fr 1fr 1.4fr 1fr
-grid-template-rows: 130px 1fr
+grid-template-rows: 200px 1fr
 grid-template-areas:
-  "weather weather alarm   alarm"
+  "weather weather alarm   meeting"
   "climate sensors lights  media"
 ```
 - **weather** — clock-weather-card with 4-day forecast (top-left, spans 2 cols)
-- **alarm** — button-card hero (top-right, spans 2 cols)
+- **alarm** — button-card hero (top-row, col 3 — 1.4fr)
+- **meeting** — button-card driven by `light.meeting_light` (top-row, col 4 — 1fr)
 - **climate** — 2 better-thermostat-ui-cards stacked + heater button-card
 - **sensors** — 10 button-cards in a 2×5 internal grid (6 doors + 2 garage covers + 2 motion)
-- **lights** — 21 mushroom-light-cards in a 3×7 internal grid
+- **lights** — 20 mushroom-light-cards grouped into 5 room sections (Family Room, Kitchen, Office, Hallways, Outdoor) inside a vertical-stack; each section is a markdown header + 3-col grid. The meeting light is hoisted to the top-right `meeting` cell.
 - **media** — 6 mini-media-players in a 2×3 internal grid + TVs row spanning both cols
 
 ### HACS Cards Used by Kiosk View

--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -177,7 +177,7 @@ views:
           show_state: false
           show_label: true
           show_icon: true
-          size: 35%
+          size: 60%
           tap_action: { action: none }
           hold_action: { action: none }
           state:
@@ -214,23 +214,26 @@ views:
               - padding: '20px 24px'
               - background: 'var(--kiosk-bg-card)'
             name:
-              - font-size: '18px'
+              - font-size: '20px'
               - font-weight: '500'
               - color: 'var(--kiosk-text-secondary)'
               - justify-self: start
+              - align-self: end
             label:
-              - font-size: '24px'
+              - font-size: '28px'
               - font-weight: '600'
               - text-transform: 'uppercase'
               - letter-spacing: '1.5px'
               - justify-self: start
+              - align-self: start
             grid:
               - grid-template-areas: '"i n" "i l"'
               - grid-template-columns: 'min-content 1fr'
-              - grid-template-rows: 'min-content min-content'
-              - column-gap: '18px'
+              - grid-template-rows: '1fr 1fr'
+              - column-gap: '20px'
               - row-gap: '4px'
-              - align-items: 'center'
+              - align-items: 'stretch'
+              - height: '100%'
 
       # ============================================================
       # CLIMATE COLUMN
@@ -251,7 +254,6 @@ views:
               gap: 8px;
             }
             ha-card > * { flex: 1 1 auto; min-height: 0; }
-            ha-card > *:last-child { flex: 0 0 70px; }
         card:
           type: vertical-stack
           cards:
@@ -275,40 +277,9 @@ views:
                 style: |
                   ha-card { height: 100%; background: var(--kiosk-bg-tile); border-radius: 8px; border: none; }
 
-            - type: custom:button-card
-              entity: climate.heatstorm_infrared_heater
-              name: Office Heater
-              show_name: true
-              show_state: true
-              show_icon: true
-              size: 30%
-              layout: icon_name_state
-              tap_action: { action: none }
-              state:
-                - value: 'off'
-                  icon: mdi:radiator-off
-                  color: 'var(--kiosk-text-tertiary)'
-                - value: 'heat'
-                  icon: mdi:radiator
-                  color: 'var(--kiosk-accent-climate)'
-                  styles:
-                    card: [{ background-color: 'rgba(240, 136, 62, 0.12)' }]
-              styles:
-                card:
-                  - height: '70px'
-                  - background: 'var(--kiosk-bg-tile)'
-                  - border-radius: '8px'
-                  - border: 'none'
-                  - padding: '8px 14px'
-                name: [{ font-size: '11px' }, { color: 'var(--kiosk-text-secondary)' }, { justify-self: 'start' }]
-                state: [{ font-size: '14px' }, { font-weight: '500' }, { text-transform: 'capitalize' }, { justify-self: 'start' }]
-                grid:
-                  - grid-template-areas: '"i n" "i s"'
-                  - grid-template-columns: 'min-content 1fr'
-                  - column-gap: '12px'
-
       # ============================================================
-      # SENSORS COLUMN — 10 sensors in 2x5 grid
+      # SENSORS COLUMN — 8 sensors in 2x4 grid
+      # (4 doors + 2 garage covers + 2 motion)
       # ============================================================
       - type: custom:mod-card
         view_layout: { grid-area: sensors }
@@ -334,7 +305,7 @@ views:
               }
               #root {
                 height: 100%;
-                grid-template-rows: repeat(5, 1fr) !important;
+                grid-template-rows: repeat(4, 1fr) !important;
                 gap: 6px !important;
               }
           cards:
@@ -432,66 +403,6 @@ views:
             - type: custom:button-card
               entity: binary_sensor.basement_kitchen_door
               name: Basement
-              show_name: true
-              show_state: true
-              show_icon: true
-              size: 50%
-              tap_action: { action: none }
-              state:
-                - value: 'on'
-                  icon: mdi:door-open
-                  color: 'var(--kiosk-accent-triggered)'
-                  styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
-                - value: 'off'
-                  icon: mdi:door-closed
-                  color: 'var(--kiosk-accent-sensors)'
-                  styles:
-                    card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                - value: 'unavailable'
-                  icon: mdi:door
-                  color: 'var(--kiosk-text-tertiary)'
-                - value: 'unknown'
-                  icon: mdi:door
-                  color: 'var(--kiosk-text-tertiary)'
-              styles:
-                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
-                state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
-
-            - type: custom:button-card
-              entity: binary_sensor.z_wave_door_window_sensor
-              name: Hannah
-              show_name: true
-              show_state: true
-              show_icon: true
-              size: 50%
-              tap_action: { action: none }
-              state:
-                - value: 'on'
-                  icon: mdi:door-open
-                  color: 'var(--kiosk-accent-triggered)'
-                  styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
-                - value: 'off'
-                  icon: mdi:door-closed
-                  color: 'var(--kiosk-accent-sensors)'
-                  styles:
-                    card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                - value: 'unavailable'
-                  icon: mdi:door
-                  color: 'var(--kiosk-text-tertiary)'
-                - value: 'unknown'
-                  icon: mdi:door
-                  color: 'var(--kiosk-text-tertiary)'
-              styles:
-                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
-                state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
-
-            - type: custom:button-card
-              entity: binary_sensor.z_wave_door_window_sensor_2
-              name: Jacob
               show_name: true
               show_state: true
               show_icon: true
@@ -642,7 +553,9 @@ views:
       # ============================================================
       # LIGHTS COLUMN — 20 lights, grouped into 5 room sections.
       # (light.meeting_light is hoisted to the top-right meeting cell.)
-      # Sections render as a vertical-stack of (section header + 3-col grid).
+      # Sections render as a vertical-stack of (section header + 4-col grid).
+      # 4 cols keeps the column from outgrowing its cell and triggering
+      # a page-level scrollbar.
       # ============================================================
       - type: custom:mod-card
         view_layout: { grid-area: lights }
@@ -681,7 +594,7 @@ views:
                   }
                   ha-card .card-content p { margin: 0 !important; }
             - type: grid
-              columns: 3
+              columns: 4
               square: false
               cards:
                 - { type: 'custom:mushroom-light-card', entity: light.family_room, name: Family, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
@@ -692,7 +605,7 @@ views:
             - <<: *light_section_header
               content: "KITCHEN"
             - type: grid
-              columns: 3
+              columns: 4
               square: false
               cards:
                 - { type: 'custom:mushroom-light-card', entity: light.kitchen_island, name: Island, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
@@ -703,7 +616,7 @@ views:
             - <<: *light_section_header
               content: "OFFICE"
             - type: grid
-              columns: 3
+              columns: 4
               square: false
               cards:
                 - { type: 'custom:mushroom-light-card', entity: light.office, name: Office, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
@@ -718,7 +631,7 @@ views:
             - <<: *light_section_header
               content: "HALLWAYS"
             - type: grid
-              columns: 3
+              columns: 4
               square: false
               cards:
                 - { type: 'custom:mushroom-light-card', entity: light.downstairs_hallway, name: Down Hall, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
@@ -728,7 +641,7 @@ views:
             - <<: *light_section_header
               content: "OUTDOOR"
             - type: grid
-              columns: 3
+              columns: 4
               square: false
               cards:
                 - { type: 'custom:mushroom-light-card', entity: light.front_door, name: Front, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }

--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -39,7 +39,7 @@ views:
       grid-template-columns: 1fr 1fr 1.4fr 1fr
       grid-template-rows: 200px 1fr
       grid-template-areas: |
-        "weather weather alarm   alarm"
+        "weather weather alarm   meeting"
         "climate sensors lights  media"
     cards:
 
@@ -153,6 +153,84 @@ views:
               0%, 100% { opacity: 1; transform: scale(1); }
               50% { opacity: 0.7; transform: scale(0.99); }
             }
+
+      # ============================================================
+      # MEETING INDICATOR (top-right corner — Rachel's office light)
+      # State-driven by light.meeting_light, which the meeting.yaml
+      # automations drive red when switch.meeting_button_in_meeting is on.
+      # ============================================================
+      - type: custom:mod-card
+        view_layout: { grid-area: meeting }
+        card_mod:
+          style: |
+            ha-card {
+              height: 100%;
+              border-radius: 10px;
+              border: none;
+              background: transparent;
+            }
+        card:
+          type: custom:button-card
+          entity: light.meeting_light
+          name: Rachel
+          show_name: true
+          show_state: false
+          show_label: true
+          show_icon: true
+          size: 35%
+          tap_action: { action: none }
+          hold_action: { action: none }
+          state:
+            - value: 'on'
+              icon: mdi:account-voice
+              color: 'var(--kiosk-accent-triggered)'
+              label: In Meeting
+              styles:
+                card:
+                  - background-color: 'rgba(248, 81, 73, 0.20)'
+                  - border-left: '4px solid var(--kiosk-accent-triggered)'
+                  - animation: 'pulse 1.8s infinite'
+                label: [{ color: 'var(--kiosk-accent-triggered)' }]
+            - value: 'off'
+              icon: mdi:account-check
+              color: 'var(--kiosk-accent-disarmed)'
+              label: Available
+              styles:
+                card:
+                  - background-color: 'rgba(86, 211, 100, 0.12)'
+                  - border-left: '4px solid var(--kiosk-accent-disarmed)'
+                label: [{ color: 'var(--kiosk-accent-disarmed)' }]
+            - value: 'unavailable'
+              icon: mdi:account-off
+              color: 'var(--kiosk-text-tertiary)'
+              label: Offline
+              styles:
+                label: [{ color: 'var(--kiosk-text-tertiary)' }]
+          styles:
+            card:
+              - height: '100%'
+              - border-radius: '10px'
+              - border: 'none'
+              - padding: '20px 24px'
+              - background: 'var(--kiosk-bg-card)'
+            name:
+              - font-size: '18px'
+              - font-weight: '500'
+              - color: 'var(--kiosk-text-secondary)'
+              - justify-self: start
+            label:
+              - font-size: '24px'
+              - font-weight: '600'
+              - text-transform: 'uppercase'
+              - letter-spacing: '1.5px'
+              - justify-self: start
+            grid:
+              - grid-template-areas: '"i n" "i l"'
+              - grid-template-columns: 'min-content 1fr'
+              - grid-template-rows: 'min-content min-content'
+              - column-gap: '18px'
+              - row-gap: '4px'
+              - align-items: 'center'
 
       # ============================================================
       # CLIMATE COLUMN
@@ -562,7 +640,9 @@ views:
                 state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
 
       # ============================================================
-      # LIGHTS COLUMN — 21 lights in 3x7 grid
+      # LIGHTS COLUMN — 20 lights, grouped into 5 room sections.
+      # (light.meeting_light is hoisted to the top-right meeting cell.)
+      # Sections render as a vertical-stack of (section header + 3-col grid).
       # ============================================================
       - type: custom:mod-card
         view_layout: { grid-area: lights }
@@ -577,31 +657,85 @@ views:
               background: var(--kiosk-bg-card);
             }
         card:
-          type: grid
-          columns: 3
-          square: false
+          type: vertical-stack
           cards:
-            - { type: 'custom:mushroom-light-card', entity: light.family_room, name: Family, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.family_room_2, name: Family 2, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.floor_lamp_composite, name: Floor Lamp, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.kitchen_island, name: Island, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.kitchen_main, name: Kitchen, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.kitchen_table, name: Table, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.office, name: Office, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.office_bookcase, name: Bookcase, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.office_corner, name: Corner, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.office_door, name: Door, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.office_lamp, name: Lamp, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.meeting_light, name: Meeting, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.desk_lamp, name: Desk, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.desk_lamp_2, name: Desk 2, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.front_door, name: Front, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.front_lantern, name: Lantern, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.garage_front, name: Garage Fr, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.garage_side, name: Garage Sd, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.shed, name: Shed, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.downstairs_hallway, name: Down Hall, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-            - { type: 'custom:mushroom-light-card', entity: light.upstairs_hallway_light, name: Up Hall, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+            # --- Family Room ---
+            - &light_section_header
+              type: markdown
+              content: "FAMILY ROOM"
+              card_mod:
+                style: |
+                  ha-card {
+                    background: transparent !important;
+                    border: none !important;
+                    box-shadow: none !important;
+                    border-radius: 0 !important;
+                  }
+                  ha-card .card-content {
+                    padding: 4px 4px 2px 4px !important;
+                    font-size: 10px !important;
+                    font-weight: 700 !important;
+                    letter-spacing: 1.5px !important;
+                    color: var(--kiosk-accent-lights) !important;
+                    border-bottom: 1px solid rgba(227, 179, 65, 0.25) !important;
+                  }
+                  ha-card .card-content p { margin: 0 !important; }
+            - type: grid
+              columns: 3
+              square: false
+              cards:
+                - { type: 'custom:mushroom-light-card', entity: light.family_room, name: Family, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.family_room_2, name: Family 2, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.floor_lamp_composite, name: Floor Lamp, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+
+            # --- Kitchen ---
+            - <<: *light_section_header
+              content: "KITCHEN"
+            - type: grid
+              columns: 3
+              square: false
+              cards:
+                - { type: 'custom:mushroom-light-card', entity: light.kitchen_island, name: Island, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.kitchen_main, name: Kitchen, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.kitchen_table, name: Table, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+
+            # --- Office ---
+            - <<: *light_section_header
+              content: "OFFICE"
+            - type: grid
+              columns: 3
+              square: false
+              cards:
+                - { type: 'custom:mushroom-light-card', entity: light.office, name: Office, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.office_bookcase, name: Bookcase, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.office_corner, name: Corner, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.office_door, name: Door, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.office_lamp, name: Lamp, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.desk_lamp, name: Desk, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.desk_lamp_2, name: Desk 2, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+
+            # --- Hallways ---
+            - <<: *light_section_header
+              content: "HALLWAYS"
+            - type: grid
+              columns: 3
+              square: false
+              cards:
+                - { type: 'custom:mushroom-light-card', entity: light.downstairs_hallway, name: Down Hall, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.upstairs_hallway_light, name: Up Hall, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+
+            # --- Outdoor ---
+            - <<: *light_section_header
+              content: "OUTDOOR"
+            - type: grid
+              columns: 3
+              square: false
+              cards:
+                - { type: 'custom:mushroom-light-card', entity: light.front_door, name: Front, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.front_lantern, name: Lantern, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.garage_front, name: Garage Fr, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.garage_side, name: Garage Sd, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.shed, name: Shed, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
 
       # ============================================================
       # MEDIA COLUMN — 6 Sonos cells (2x3) + TV row (60px)


### PR DESCRIPTION
## Summary

Reorganizes the kiosk dashboard top strip and lights column without changing the overall 4-col / 200px-top-row footprint, plus a follow-up cleanup pass for retired entities and layout bugs surfaced on the wall display.

### Layout reorg
- **Meeting tile (new)**: `custom:button-card` bound to `light.meeting_light` lives in a new `meeting` grid-area (top row, col 4). Pulsing red "In Meeting", green "Available", muted "Offline" — fills the previously empty space under the alarm hero.
- **Top-row areas**: `"weather weather alarm alarm"` → `"weather weather alarm meeting"`. Alarm = col 3 (1.4fr), meeting = col 4 (1fr). Same total footprint.
- **Lights grouped by room**: flat 3×7 mushroom grid replaced with a `vertical-stack` of five room sections (Family Room, Kitchen, Office, Hallways, Outdoor = 20 lights, meeting hoisted out). Each section is a minimal markdown header (uppercase amber label + thin underline, no card chrome) followed by a 4-col mushroom grid. YAML anchors centralize the header styling.

### Cleanup
- **Sensors**: drop Hannah and Jacob z-wave door sensors (retired); 2×5 grid → 2×4 (4 doors + 2 garage covers + 2 motion = 8 cards).
- **Climate**: remove the Office Heater button-card and the `last-child` flex rule that sized it; `climate.heatstorm_infrared_heater` no longer exists. The two thermostats now share the column evenly.
- **Lights cols 3 → 4**: 3-col layout was outgrowing its cell on the 1080p kiosk and triggering a page-level scrollbar (against spec).
- **Meeting card dead space**: bump icon to 60% and font sizes (Rachel 20px, label 28px); set the internal grid to `grid-template-rows: 1fr 1fr` with `height: 100%` so content fills the 200px cell instead of hugging the top edge.

### Spec
- CLAUDE.md kiosk grid block + lights description updated to match.

Replaces #134.

## Test plan

- [ ] `YAML Lint` CI check passes
- [ ] `claude-review` CI check passes
- [ ] HA `check_config` passes via `ha-config-check` workflow
- [ ] On the wall display, top row renders weather (left, 2 cols) | alarm hero (col 3) | meeting indicator (col 4); meeting card content fills the cell with no dead space
- [ ] Meeting cell shows "Available" (green) when `light.meeting_light` is off, "In Meeting" (red, pulsing) when on, "Offline" (muted) when unavailable
- [ ] Sensors column shows 8 cards (Front, Sliding, Garage Entry, Basement, Garage 1, Garage 2, Family motion, Office motion) — no Hannah or Jacob
- [ ] Climate column shows only the two thermostats (no Office Heater tile)
- [ ] Lights column shows five labeled room sections in a 4-col grid; no page-level scrollbar
- [ ] No "already been used with this registry" console errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01YR1gvdmYkma43mRqbPt6ua)_