### PR TITLE
fix(kiosk): fill weather, stretch sensor rows, shrink lights to fit

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -59,7 +59,7 @@ views:
         card:
           type: custom:clock-weather-card
           entity: weather.forecast_home
-          forecast_rows: 0
+          forecast_rows: 4
           time_format: 12
           date_pattern: "EEEE, MMM d"
 
@@ -307,6 +307,14 @@ views:
                 height: 100%;
                 grid-template-rows: repeat(4, 1fr) !important;
                 gap: 6px !important;
+              }
+              /* Stretch each grid child so the inner button-card's
+                 height: 100% has a parent to fill against. Without
+                 this, hui-card collapses to its content height and
+                 leaves dead space below each row. */
+              #root > * {
+                height: 100% !important;
+                min-height: 0 !important;
               }
           cards:
             # === Door sensors (binary_sensor; on=open=red, off=closed=green) ===
@@ -566,9 +574,12 @@ views:
               border-radius: 10px;
               border: none;
               border-top: 3px solid var(--kiosk-accent-lights);
-              padding: 8px;
+              padding: 6px;
               background: var(--kiosk-bg-card);
             }
+            /* Tighten vertical-stack so the 5 section headers + 7 tile
+               rows fit inside the cell without a page-level scrollbar. */
+            ha-card #root > * + * { margin-top: 4px !important; }
         card:
           type: vertical-stack
           cards:
@@ -585,8 +596,8 @@ views:
                     border-radius: 0 !important;
                   }
                   ha-card .card-content {
-                    padding: 4px 4px 2px 4px !important;
-                    font-size: 10px !important;
+                    padding: 2px 4px 1px 4px !important;
+                    font-size: 9px !important;
                     font-weight: 700 !important;
                     letter-spacing: 1.5px !important;
                     color: var(--kiosk-accent-lights) !important;

--- a/themes/kiosk_polish.yaml
+++ b/themes/kiosk_polish.yaml
@@ -22,11 +22,14 @@ Kiosk Polish:
   kiosk-accent-armed: "#e3b341"
   kiosk-accent-triggered: "#f85149"
 
-  # Mushroom token overrides (applied via card-mod theme block)
-  mush-icon-size: 36px
-  mush-icon-symbol-size: 0.6em
-  mush-card-primary-font-size: 13px
-  mush-card-secondary-font-size: 11px
+  # Mushroom token overrides — sized to fit the lights column
+  # (5 sections + 7 tile rows + headers) inside the kiosk cell
+  # without triggering a page-level scrollbar at 1920x1080.
+  mush-icon-size: 26px
+  mush-icon-symbol-size: 0.55em
+  mush-card-primary-font-size: 10px
+  mush-card-secondary-font-size: 9px
+  mush-spacing: 6px
 
   # State-color sugar
   state-on-color: "#56d364"


### PR DESCRIPTION
## Summary

Three polish fixes against issues surfaced on the wall display after #135 merged.

- **Weather dead space.** `forecast_rows: 0` was leaving the right half of the 2-col weather cell empty (only the clock + sun icon rendered). Per the kiosk spec the card is "clock + 4-day forecast"; setting `forecast_rows: 4` fills the cell horizontally.
- **Sensors not filling the cell.** The 2×4 inner grid had `grid-template-rows: repeat(4, 1fr)`, but the `hui-card` wrappers GitHub injects between the grid root and each child weren't picking up `height: 100%`. So each button-card collapsed to its content height, leaving a fat empty band below it. Add `#root > * { height: 100% !important; min-height: 0 !important; }` to the sensors `card_mod` so each child stretches with the row.
- **Lights overflowing the cell.** 5 section headers + 7 tile rows at the prior mushroom sizes pushed past the ~856px cell on a 1080p kiosk and triggered a page-level scrollbar (against spec). Shrink Kiosk Polish mushroom tokens (`--mush-icon-size` 36→26, primary 13→10, secondary 11→9, add `--mush-spacing: 6px`); tighten the lights `mod-card` padding 8→6px, collapse vertical-stack gaps to 4px, trim section-header font/padding.

No structural / grid-layout changes — same cells, same columns, same overall footprint.

## Test plan

- [ ] `YAML Lint` CI check passes
- [ ] `claude-review` CI check passes
- [ ] HA `check_config` passes via `ha-config-check` workflow
- [ ] Weather cell renders clock + 4-row forecast; no empty right half
- [ ] Sensors column: each of the 8 button-cards stretches to fill its row (no dead bands between Front/Sliding, Garage Entry/Basement, Garage 1/2, Family/Office)
- [ ] Lights column fits inside its cell — no page-level scrollbar; all 5 room sections + 20 tiles visible without scrolling
- [ ] Mushroom tiles still legible at the smaller token sizes
- [ ] Other panels (alarm, meeting, climate, media, TVs row) unchanged in size/layout

---
_Generated by [Claude Code](https://claude.ai/code/session_01YR1gvdmYkma43mRqbPt6ua)_