### PR TITLE
phase1(kiosk): scale sensor tile content to fill square cells

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -325,7 +325,7 @@ views:
               show_name: true
               show_state: true
               show_icon: true
-              size: 50%
+              size: 70%
               tap_action: { action: none }
               state:
                 - value: 'on'
@@ -345,9 +345,23 @@ views:
                   icon: mdi:door
                   color: 'var(--kiosk-text-tertiary)'
               styles:
-                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
-                state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
+                card:
+                  - height: '100%'
+                  - background: 'var(--kiosk-bg-tile)'
+                  - border-radius: '8px'
+                  - border: 'none'
+                  - padding: '12px'
+                name:
+                  - font-size: '18px'
+                  - font-weight: '500'
+                  - color: 'var(--kiosk-text-secondary)'
+                  - padding-top: '8px'
+                state:
+                  - font-size: '24px'
+                  - text-transform: 'uppercase'
+                  - font-weight: '600'
+                  - letter-spacing: '1px'
+                  - padding-top: '4px'
 
             - type: custom:button-card
               entity: binary_sensor.main_panel_sliding_door
@@ -355,7 +369,7 @@ views:
               show_name: true
               show_state: true
               show_icon: true
-              size: 50%
+              size: 70%
               tap_action: { action: none }
               state:
                 - value: 'on'
@@ -375,9 +389,23 @@ views:
                   icon: mdi:door-sliding
                   color: 'var(--kiosk-text-tertiary)'
               styles:
-                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
-                state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
+                card:
+                  - height: '100%'
+                  - background: 'var(--kiosk-bg-tile)'
+                  - border-radius: '8px'
+                  - border: 'none'
+                  - padding: '12px'
+                name:
+                  - font-size: '18px'
+                  - font-weight: '500'
+                  - color: 'var(--kiosk-text-secondary)'
+                  - padding-top: '8px'
+                state:
+                  - font-size: '24px'
+                  - text-transform: 'uppercase'
+                  - font-weight: '600'
+                  - letter-spacing: '1px'
+                  - padding-top: '4px'
 
             - type: custom:button-card
               entity: binary_sensor.main_panel_garage_door
@@ -385,7 +413,7 @@ views:
               show_name: true
               show_state: true
               show_icon: true
-              size: 50%
+              size: 70%
               tap_action: { action: none }
               state:
                 - value: 'on'
@@ -405,9 +433,23 @@ views:
                   icon: mdi:door
                   color: 'var(--kiosk-text-tertiary)'
               styles:
-                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
-                state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
+                card:
+                  - height: '100%'
+                  - background: 'var(--kiosk-bg-tile)'
+                  - border-radius: '8px'
+                  - border: 'none'
+                  - padding: '12px'
+                name:
+                  - font-size: '18px'
+                  - font-weight: '500'
+                  - color: 'var(--kiosk-text-secondary)'
+                  - padding-top: '8px'
+                state:
+                  - font-size: '24px'
+                  - text-transform: 'uppercase'
+                  - font-weight: '600'
+                  - letter-spacing: '1px'
+                  - padding-top: '4px'
 
             - type: custom:button-card
               entity: binary_sensor.basement_kitchen_door
@@ -415,7 +457,7 @@ views:
               show_name: true
               show_state: true
               show_icon: true
-              size: 50%
+              size: 70%
               tap_action: { action: none }
               state:
                 - value: 'on'
@@ -435,9 +477,23 @@ views:
                   icon: mdi:door
                   color: 'var(--kiosk-text-tertiary)'
               styles:
-                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
-                state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
+                card:
+                  - height: '100%'
+                  - background: 'var(--kiosk-bg-tile)'
+                  - border-radius: '8px'
+                  - border: 'none'
+                  - padding: '12px'
+                name:
+                  - font-size: '18px'
+                  - font-weight: '500'
+                  - color: 'var(--kiosk-text-secondary)'
+                  - padding-top: '8px'
+                state:
+                  - font-size: '24px'
+                  - text-transform: 'uppercase'
+                  - font-weight: '600'
+                  - letter-spacing: '1px'
+                  - padding-top: '4px'
 
             # === Garage door covers (state: closed/open) ===
             - type: custom:button-card
@@ -446,7 +502,7 @@ views:
               show_name: true
               show_state: true
               show_icon: true
-              size: 50%
+              size: 70%
               tap_action: { action: none }
               state:
                 - value: 'closed'
@@ -470,9 +526,23 @@ views:
                   styles:
                     card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
               styles:
-                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
-                state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
+                card:
+                  - height: '100%'
+                  - background: 'var(--kiosk-bg-tile)'
+                  - border-radius: '8px'
+                  - border: 'none'
+                  - padding: '12px'
+                name:
+                  - font-size: '18px'
+                  - font-weight: '500'
+                  - color: 'var(--kiosk-text-secondary)'
+                  - padding-top: '8px'
+                state:
+                  - font-size: '24px'
+                  - text-transform: 'uppercase'
+                  - font-weight: '600'
+                  - letter-spacing: '1px'
+                  - padding-top: '4px'
 
             - type: custom:button-card
               entity: cover.garage_door_2_door
@@ -480,7 +550,7 @@ views:
               show_name: true
               show_state: true
               show_icon: true
-              size: 50%
+              size: 70%
               tap_action: { action: none }
               state:
                 - value: 'closed'
@@ -504,9 +574,23 @@ views:
                   styles:
                     card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
               styles:
-                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
-                state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
+                card:
+                  - height: '100%'
+                  - background: 'var(--kiosk-bg-tile)'
+                  - border-radius: '8px'
+                  - border: 'none'
+                  - padding: '12px'
+                name:
+                  - font-size: '18px'
+                  - font-weight: '500'
+                  - color: 'var(--kiosk-text-secondary)'
+                  - padding-top: '8px'
+                state:
+                  - font-size: '24px'
+                  - text-transform: 'uppercase'
+                  - font-weight: '600'
+                  - letter-spacing: '1px'
+                  - padding-top: '4px'
 
             # === Motion sensors (binary_sensor; on=detected=red pulse, off=clear=gray) ===
             - type: custom:button-card
@@ -515,7 +599,7 @@ views:
               show_name: true
               show_state: true
               show_icon: true
-              size: 50%
+              size: 70%
               tap_action: { action: none }
               state:
                 - value: 'on'
@@ -530,9 +614,23 @@ views:
                   icon: mdi:motion-sensor-off
                   color: 'var(--kiosk-text-tertiary)'
               styles:
-                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
-                state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
+                card:
+                  - height: '100%'
+                  - background: 'var(--kiosk-bg-tile)'
+                  - border-radius: '8px'
+                  - border: 'none'
+                  - padding: '12px'
+                name:
+                  - font-size: '18px'
+                  - font-weight: '500'
+                  - color: 'var(--kiosk-text-secondary)'
+                  - padding-top: '8px'
+                state:
+                  - font-size: '24px'
+                  - text-transform: 'uppercase'
+                  - font-weight: '600'
+                  - letter-spacing: '1px'
+                  - padding-top: '4px'
 
             - type: custom:button-card
               entity: binary_sensor.main_panel_office_motion
@@ -540,7 +638,7 @@ views:
               show_name: true
               show_state: true
               show_icon: true
-              size: 50%
+              size: 70%
               tap_action: { action: none }
               state:
                 - value: 'on'
@@ -555,9 +653,23 @@ views:
                   icon: mdi:motion-sensor-off
                   color: 'var(--kiosk-text-tertiary)'
               styles:
-                card: [{ height: '100%' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px' }]
-                name: [{ font-size: '12px' }, { color: 'var(--kiosk-text-secondary)' }, { padding-top: '4px' }]
-                state: [{ font-size: '11px' }, { text-transform: 'uppercase' }, { font-weight: '500' }]
+                card:
+                  - height: '100%'
+                  - background: 'var(--kiosk-bg-tile)'
+                  - border-radius: '8px'
+                  - border: 'none'
+                  - padding: '12px'
+                name:
+                  - font-size: '18px'
+                  - font-weight: '500'
+                  - color: 'var(--kiosk-text-secondary)'
+                  - padding-top: '8px'
+                state:
+                  - font-size: '24px'
+                  - text-transform: 'uppercase'
+                  - font-weight: '600'
+                  - letter-spacing: '1px'
+                  - padding-top: '4px'
 
       # ============================================================
       # LIGHTS COLUMN — 20 lights, grouped into 5 room sections.


### PR DESCRIPTION
## Summary
Phase 1 of the kiosk visual pass — scales sensor tile content to fit the now-square (~217x221) cells from Phase 0. Each of the 8 sensor button-cards (4 doors + 2 garage covers + 2 motion) gets:

- `size: 50%` → `70%`
- name font: `12px` → `18px`
- state font: `11px` → `24px`
- padding: `6px` → `12px`

Button-cards keep their default vertical-centered layout (no `grid-template-areas` override). Visual target: match the mushroom-light-card density next door.

## Test plan
- [ ] gitops-sync pulls and `lovelace.reload_resources` fires
- [ ] Reload kiosk page at 1920x1080
- [ ] Each tile's icon visually dominates (~60% of tile height)
- [ ] Name + state legible from across the room
- [ ] No empty space at top or bottom of any tile
- [ ] Colored state backgrounds (red OPEN, green CLOSED, amber motion pulse) still render
- [ ] No regressions on lights/media/climate/alarm cells