### PR TITLE
hotfix(kiosk): Outdoor lights to columns 5 to eliminate overflow

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -765,7 +765,7 @@ views:
             - <<: *light_section_header
               content: "OUTDOOR"
             - type: grid
-              columns: 4
+              columns: 5
               square: false
               cards:
                 - { type: 'custom:mushroom-light-card', entity: light.front_door, name: Front, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }


### PR DESCRIPTION
## Summary

Outdoor has 5 entities (Front, Lantern, Garage Fr, Garage Sd, Shed). At `columns: 4` the 5th wrapped to row 2, pushing the total lights-column height ~115px past the bottom-row budget and producing a scroll bar with `light.shed` clipped at the bottom.

Switching the Outdoor section's grid to `columns: 5` fits all entities in a single row, recovering the ~115px and eliminating the overflow. Tiles get slightly narrower (~115px vs ~140px) but they're already the smallest content in the column.

This pre-stages Phase 2's per-section column-count strategy by introducing the first non-uniform section.

## Changes

- `dashboards/kiosk.yaml`: Outdoor lights grid `columns: 4` → `columns: 5` (one-line change)

## Test plan

- [ ] GitOps applies; lovelace reloads
- [ ] Reload kiosk page — scroll bar is gone
- [ ] All 5 outdoor lights visible on a single row
- [ ] Outdoor tiles do not clip horizontally
- [ ] Lights column fits the column height with margin to spare


---
_Generated by [Claude Code](https://claude.ai/code/session_01QAt2xLHpRwTMMpi2JDx4aT)_