### PR TITLE
phase3(kiosk): rebuild weather cell as horizontal stack

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -45,6 +45,10 @@ views:
 
       # ============================================================
       # WEATHER + CLOCK (top-left, spans 2 cols)
+      # Horizontal-stack: clock-weather-card LEFT, current conditions
+      # mushroom-template-card RIGHT. clock-weather-card is portrait
+      # by nature; constraining it to ~420px and filling the right
+      # half with a current-conditions summary uses the full 840px.
       # ============================================================
       - type: custom:mod-card
         view_layout: { grid-area: weather }
@@ -58,11 +62,83 @@ views:
               background: linear-gradient(135deg, #1e3a5f 0%, #0f1f3a 100%);
             }
         card:
-          type: custom:clock-weather-card
-          entity: weather.forecast_home
-          forecast_rows: 4
-          time_format: 12
-          date_pattern: "EEEE, MMM d"
+          type: horizontal-stack
+          cards:
+
+            # LEFT: clock + date + weather condition (the card we know works)
+            - type: custom:clock-weather-card
+              entity: weather.forecast_home
+              forecast_rows: 0
+              time_format: 12
+              date_pattern: "EEEE, MMM d"
+              card_mod:
+                style: |
+                  ha-card {
+                    background: transparent !important;
+                    border: none !important;
+                    box-shadow: none !important;
+                    max-width: 420px;
+                  }
+
+            # RIGHT: hero current-conditions summary
+            - type: custom:mushroom-template-card
+              primary: |-
+                {% set cond = states("weather.forecast_home") %}
+                {{ cond | replace("-", " ") | replace("partlycloudy", "partly cloudy") | title }}
+              secondary: |-
+                {% set t = state_attr("weather.forecast_home", "temperature") %}
+                {% set h = state_attr("weather.forecast_home", "humidity") %}
+                {% set w = state_attr("weather.forecast_home", "wind_speed") %}
+                {{ t | round }}°F · Humidity {{ h | round }}% · Wind {{ w | round }} mph
+              icon: |-
+                {% set cond = states("weather.forecast_home") %}
+                {% if cond == "clear-night" %}mdi:weather-night
+                {% elif cond in ["sunny","clear"] %}mdi:weather-sunny
+                {% elif cond in ["partlycloudy","partly-cloudy","partly-cloudy-day"] %}mdi:weather-partly-cloudy
+                {% elif cond == "partly-cloudy-night" %}mdi:weather-night-partly-cloudy
+                {% elif cond == "cloudy" %}mdi:weather-cloudy
+                {% elif cond in ["rainy","pouring"] %}mdi:weather-pouring
+                {% elif cond == "snowy" %}mdi:weather-snowy
+                {% elif cond == "snowy-rainy" %}mdi:weather-snowy-rainy
+                {% elif cond == "lightning-rainy" %}mdi:weather-lightning-rainy
+                {% elif cond == "lightning" %}mdi:weather-lightning
+                {% elif cond == "fog" %}mdi:weather-fog
+                {% elif cond == "windy" %}mdi:weather-windy
+                {% elif cond == "hail" %}mdi:weather-hail
+                {% else %}mdi:weather-cloudy
+                {% endif %}
+              icon_color: |-
+                {% set cond = states("weather.forecast_home") %}
+                {% if cond == "clear-night" %}deep-purple
+                {% elif cond in ["sunny","clear"] %}amber
+                {% elif "cloud" in cond %}grey
+                {% elif "rain" in cond or cond == "pouring" %}blue
+                {% elif "snow" in cond %}light-blue
+                {% elif cond == "lightning" %}yellow
+                {% else %}grey
+                {% endif %}
+              fill_container: true
+              multiline_secondary: true
+              card_mod:
+                style: |
+                  ha-card {
+                    background: transparent !important;
+                    border: none !important;
+                    box-shadow: none !important;
+                    padding: 16px 20px !important;
+                  }
+                  mushroom-state-info {
+                    --card-primary-font-size: 28px;
+                    --card-primary-font-weight: 600;
+                    --card-primary-color: var(--kiosk-text-primary);
+                    --card-secondary-font-size: 16px;
+                    --card-secondary-font-weight: 500;
+                    --card-secondary-color: var(--kiosk-text-secondary);
+                  }
+                  mushroom-shape-icon {
+                    --icon-size: 80px;
+                    --shape-color: rgba(255, 255, 255, 0.08);
+                  }
 
       # ============================================================
       # ALARM HERO (top-right, spans 2 cols)


### PR DESCRIPTION
## Summary

Weather cell is ~840×195. `clock-weather-card` is portrait by nature — the card renders correctly in the left third of the cell and leaves ~560px of black void on the right.

Replace the single card with a `horizontal-stack` of two:
- **LEFT (~420px)**: `clock-weather-card` constrained via `max-width: 420px` with transparent background so it renders at its natural width and the wrapper gradient shows through.
- **RIGHT**: `mushroom-template-card` with templated condition icon (~80px), hero-scale condition text, and a `Temp · Humidity · Wind` summary line pulling from `weather.forecast_home` attributes.

Wrapper `mod-card` preserved with the existing gradient background and `overflow: hidden`. Icon/color templates cover Met.no condition strings with a cloud-icon fallback in the `else` clause.

## Changes

- `dashboards/kiosk.yaml`: WEATHER + CLOCK block (lines 46-65) replaced with horizontal-stack rebuild (+81/−5).

## Test plan

- [ ] GitOps applies; lovelace reloads
- [ ] Weather cell LEFT half shows clock + condition + date constrained to ~420px
- [ ] Weather cell RIGHT half shows large condition icon, hero condition text, and `temp · humidity · wind` line
- [ ] Black void on the right is gone; cell visually balances
- [ ] Time ticks every minute
- [ ] Background gradient extends across both halves uniformly
- [ ] Alarm and meeting heroes unchanged
- [ ] No scroll bars introduced
- [ ] Templates do not render `None` / `unknown` (verify weather entity exposes `temperature`, `humidity`, `wind_speed`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QAt2xLHpRwTMMpi2JDx4aT)_