### PR TITLE
phase5(kiosk): stabilize media column tile heights

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -977,6 +977,21 @@ views:
             - type: grid
               columns: 2
               square: false
+              card_mod:
+                style: |
+                  :host {
+                    height: 100%;
+                    display: block;
+                  }
+                  #root {
+                    height: 100%;
+                    grid-template-rows: repeat(3, 1fr) !important;
+                    gap: 6px !important;
+                  }
+                  #root > * {
+                    height: 100% !important;
+                    min-height: 0 !important;
+                  }
               cards:
                 - type: custom:mini-media-player
                   entity: media_player.master_bedroom
@@ -989,9 +1004,11 @@ views:
                     style: |
                       ha-card {
                         height: 100%;
+                        min-height: 100px;
                         border-radius: 6px;
                         border: none;
                         overflow: hidden;
+                        background: var(--kiosk-bg-tile);
                         {% set members = state_attr(config.entity, 'group_members') or [] %}
                         {% if members | length > 1 and members[0] != config.entity %}
                           opacity: 0.5;
@@ -1023,9 +1040,11 @@ views:
                     style: |
                       ha-card {
                         height: 100%;
+                        min-height: 100px;
                         border-radius: 6px;
                         border: none;
                         overflow: hidden;
+                        background: var(--kiosk-bg-tile);
                         {% set members = state_attr(config.entity, 'group_members') or [] %}
                         {% if members | length > 1 and members[0] != config.entity %}
                           opacity: 0.5;
@@ -1057,9 +1076,11 @@ views:
                     style: |
                       ha-card {
                         height: 100%;
+                        min-height: 100px;
                         border-radius: 6px;
                         border: none;
                         overflow: hidden;
+                        background: var(--kiosk-bg-tile);
                         {% set members = state_attr(config.entity, 'group_members') or [] %}
                         {% if members | length > 1 and members[0] != config.entity %}
                           opacity: 0.5;
@@ -1091,9 +1112,11 @@ views:
                     style: |
                       ha-card {
                         height: 100%;
+                        min-height: 100px;
                         border-radius: 6px;
                         border: none;
                         overflow: hidden;
+                        background: var(--kiosk-bg-tile);
                         {% set members = state_attr(config.entity, 'group_members') or [] %}
                         {% if members | length > 1 and members[0] != config.entity %}
                           opacity: 0.5;
@@ -1125,9 +1148,11 @@ views:
                     style: |
                       ha-card {
                         height: 100%;
+                        min-height: 100px;
                         border-radius: 6px;
                         border: none;
                         overflow: hidden;
+                        background: var(--kiosk-bg-tile);
                         {% set members = state_attr(config.entity, 'group_members') or [] %}
                         {% if members | length > 1 and members[0] != config.entity %}
                           opacity: 0.5;
@@ -1159,9 +1184,11 @@ views:
                     style: |
                       ha-card {
                         height: 100%;
+                        min-height: 100px;
                         border-radius: 6px;
                         border: none;
                         overflow: hidden;
+                        background: var(--kiosk-bg-tile);
                         {% set members = state_attr(config.entity, 'group_members') or [] %}
                         {% if members | length > 1 and members[0] != config.entity %}
                           opacity: 0.5;


### PR DESCRIPTION
## Summary

Media column rendered with inconsistent tile heights — a playing speaker (Office with album art ~140px) towered over idle pills (~30px). Two fixes lock the 2×3 speaker grid to equal heights regardless of playback state.

- **Grid row distribution**: apply Phase 1's `#root > *` pattern to the media grid card so `grid-template-rows: repeat(3, 1fr)` is enforced and each cell stretches to its share of column height.
- **Per-tile floor**: add `min-height: 100px` and `background: var(--kiosk-bg-tile)` to each of the 6 `mini-media-player` `card_mod` blocks. Idle players still collapse their internal layout, but the wrapper stays sized and visible.

Does NOT touch the TVs row (already fixed at 70px) or the existing group-member dimming Jinja.

## Test plan

- [ ] GitOps sync applies; lovelace reload picks up changes
- [ ] All 6 speaker tiles render at equal heights (~265px) in 2×3 grid
- [ ] Currently-playing speakers still show full album art via `artwork: full-cover-fit`
- [ ] Idle/unavailable tiles show speaker icon + name on a tile background — no floating pills
- [ ] Group-member dimming still works (followers at 50% opacity with leader caption)
- [ ] TVs row at the bottom unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)