### PR TITLE
phase6(kiosk): polish pass — setpoint chip, media bg, scrollbar

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -35,6 +35,7 @@ views:
       height: 100vh
       margin: 0
       padding: 8px
+      overflow: hidden
       grid-gap: 8px
       grid-template-columns: 1fr 1fr 1.4fr 1fr
       grid-template-rows: 200px 1fr
@@ -370,7 +371,13 @@ views:
                       - type: template
                         icon: mdi:thermometer
                         icon_color: amber
-                        content: 'Set {{ state_attr("climate.upstairs", "temperature") | round }}°'
+                        content: |-
+                          {% set t = state_attr("climate.upstairs", "temperature") %}
+                          {% set tl = state_attr("climate.upstairs", "target_temp_low") %}
+                          {% set th = state_attr("climate.upstairs", "target_temp_high") %}
+                          {% if t is not none %}Set {{ t | round }}°
+                          {% elif tl is not none and th is not none %}{{ tl | round }}–{{ th | round }}°
+                          {% else %}—{% endif %}
                       - type: template
                         icon: |-
                           {% set a = state_attr("climate.upstairs", "hvac_action") %}
@@ -433,7 +440,13 @@ views:
                       - type: template
                         icon: mdi:thermometer
                         icon_color: amber
-                        content: 'Set {{ state_attr("climate.downstairs", "temperature") | round }}°'
+                        content: |-
+                          {% set t = state_attr("climate.downstairs", "temperature") %}
+                          {% set tl = state_attr("climate.downstairs", "target_temp_low") %}
+                          {% set th = state_attr("climate.downstairs", "target_temp_high") %}
+                          {% if t is not none %}Set {{ t | round }}°
+                          {% elif tl is not none and th is not none %}{{ tl | round }}–{{ th | round }}°
+                          {% else %}—{% endif %}
                       - type: template
                         icon: |-
                           {% set a = state_attr("climate.downstairs", "hvac_action") %}
@@ -993,221 +1006,269 @@ views:
                     min-height: 0 !important;
                   }
               cards:
-                - type: custom:mini-media-player
-                  entity: media_player.master_bedroom
-                  name: Master Bedroom
-                  artwork: full-cover-fit
-                  info: scroll
-                  hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-                  tap_action: { action: none }
+                - type: custom:mod-card
                   card_mod:
                     style: |
                       ha-card {
                         height: 100%;
                         min-height: 100px;
+                        background: var(--kiosk-bg-tile);
                         border-radius: 6px;
                         border: none;
                         overflow: hidden;
-                        background: var(--kiosk-bg-tile);
+                      }
+                  card:
+                    type: custom:mini-media-player
+                    entity: media_player.master_bedroom
+                    name: Master Bedroom
+                    artwork: full-cover-fit
+                    info: scroll
+                    hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
+                    tap_action: { action: none }
+                    card_mod:
+                      style: |
+                        ha-card {
+                          background: transparent !important;
+                          border: none !important;
+                          {% set members = state_attr(config.entity, 'group_members') or [] %}
+                          {% if members | length > 1 and members[0] != config.entity %}
+                            opacity: 0.5;
+                            filter: grayscale(0.4);
+                          {% endif %}
+                        }
                         {% set members = state_attr(config.entity, 'group_members') or [] %}
                         {% if members | length > 1 and members[0] != config.entity %}
-                          opacity: 0.5;
-                          filter: grayscale(0.4);
+                        ha-card::after {
+                          content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                          position: absolute;
+                          bottom: 6px;
+                          left: 8px;
+                          font-size: 10px;
+                          color: white;
+                          text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                          z-index: 10;
+                        }
                         {% endif %}
-                      }
-                      {% set members = state_attr(config.entity, 'group_members') or [] %}
-                      {% if members | length > 1 and members[0] != config.entity %}
-                      ha-card::after {
-                        content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
-                        position: absolute;
-                        bottom: 6px;
-                        left: 8px;
-                        font-size: 10px;
-                        color: white;
-                        text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-                        z-index: 10;
-                      }
-                      {% endif %}
 
-                - type: custom:mini-media-player
-                  entity: media_player.basement
-                  name: Basement
-                  artwork: full-cover-fit
-                  info: scroll
-                  hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-                  tap_action: { action: none }
+                - type: custom:mod-card
                   card_mod:
                     style: |
                       ha-card {
                         height: 100%;
                         min-height: 100px;
+                        background: var(--kiosk-bg-tile);
                         border-radius: 6px;
                         border: none;
                         overflow: hidden;
-                        background: var(--kiosk-bg-tile);
+                      }
+                  card:
+                    type: custom:mini-media-player
+                    entity: media_player.basement
+                    name: Basement
+                    artwork: full-cover-fit
+                    info: scroll
+                    hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
+                    tap_action: { action: none }
+                    card_mod:
+                      style: |
+                        ha-card {
+                          background: transparent !important;
+                          border: none !important;
+                          {% set members = state_attr(config.entity, 'group_members') or [] %}
+                          {% if members | length > 1 and members[0] != config.entity %}
+                            opacity: 0.5;
+                            filter: grayscale(0.4);
+                          {% endif %}
+                        }
                         {% set members = state_attr(config.entity, 'group_members') or [] %}
                         {% if members | length > 1 and members[0] != config.entity %}
-                          opacity: 0.5;
-                          filter: grayscale(0.4);
+                        ha-card::after {
+                          content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                          position: absolute;
+                          bottom: 6px;
+                          left: 8px;
+                          font-size: 10px;
+                          color: white;
+                          text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                          z-index: 10;
+                        }
                         {% endif %}
-                      }
-                      {% set members = state_attr(config.entity, 'group_members') or [] %}
-                      {% if members | length > 1 and members[0] != config.entity %}
-                      ha-card::after {
-                        content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
-                        position: absolute;
-                        bottom: 6px;
-                        left: 8px;
-                        font-size: 10px;
-                        color: white;
-                        text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-                        z-index: 10;
-                      }
-                      {% endif %}
 
-                - type: custom:mini-media-player
-                  entity: media_player.office
-                  name: Office
-                  artwork: full-cover-fit
-                  info: scroll
-                  hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-                  tap_action: { action: none }
+                - type: custom:mod-card
                   card_mod:
                     style: |
                       ha-card {
                         height: 100%;
                         min-height: 100px;
+                        background: var(--kiosk-bg-tile);
                         border-radius: 6px;
                         border: none;
                         overflow: hidden;
-                        background: var(--kiosk-bg-tile);
+                      }
+                  card:
+                    type: custom:mini-media-player
+                    entity: media_player.office
+                    name: Office
+                    artwork: full-cover-fit
+                    info: scroll
+                    hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
+                    tap_action: { action: none }
+                    card_mod:
+                      style: |
+                        ha-card {
+                          background: transparent !important;
+                          border: none !important;
+                          {% set members = state_attr(config.entity, 'group_members') or [] %}
+                          {% if members | length > 1 and members[0] != config.entity %}
+                            opacity: 0.5;
+                            filter: grayscale(0.4);
+                          {% endif %}
+                        }
                         {% set members = state_attr(config.entity, 'group_members') or [] %}
                         {% if members | length > 1 and members[0] != config.entity %}
-                          opacity: 0.5;
-                          filter: grayscale(0.4);
+                        ha-card::after {
+                          content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                          position: absolute;
+                          bottom: 6px;
+                          left: 8px;
+                          font-size: 10px;
+                          color: white;
+                          text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                          z-index: 10;
+                        }
                         {% endif %}
-                      }
-                      {% set members = state_attr(config.entity, 'group_members') or [] %}
-                      {% if members | length > 1 and members[0] != config.entity %}
-                      ha-card::after {
-                        content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
-                        position: absolute;
-                        bottom: 6px;
-                        left: 8px;
-                        font-size: 10px;
-                        color: white;
-                        text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-                        z-index: 10;
-                      }
-                      {% endif %}
 
-                - type: custom:mini-media-player
-                  entity: media_player.kitchen
-                  name: Kitchen
-                  artwork: full-cover-fit
-                  info: scroll
-                  hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-                  tap_action: { action: none }
+                - type: custom:mod-card
                   card_mod:
                     style: |
                       ha-card {
                         height: 100%;
                         min-height: 100px;
+                        background: var(--kiosk-bg-tile);
                         border-radius: 6px;
                         border: none;
                         overflow: hidden;
-                        background: var(--kiosk-bg-tile);
+                      }
+                  card:
+                    type: custom:mini-media-player
+                    entity: media_player.kitchen
+                    name: Kitchen
+                    artwork: full-cover-fit
+                    info: scroll
+                    hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
+                    tap_action: { action: none }
+                    card_mod:
+                      style: |
+                        ha-card {
+                          background: transparent !important;
+                          border: none !important;
+                          {% set members = state_attr(config.entity, 'group_members') or [] %}
+                          {% if members | length > 1 and members[0] != config.entity %}
+                            opacity: 0.5;
+                            filter: grayscale(0.4);
+                          {% endif %}
+                        }
                         {% set members = state_attr(config.entity, 'group_members') or [] %}
                         {% if members | length > 1 and members[0] != config.entity %}
-                          opacity: 0.5;
-                          filter: grayscale(0.4);
+                        ha-card::after {
+                          content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                          position: absolute;
+                          bottom: 6px;
+                          left: 8px;
+                          font-size: 10px;
+                          color: white;
+                          text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                          z-index: 10;
+                        }
                         {% endif %}
-                      }
-                      {% set members = state_attr(config.entity, 'group_members') or [] %}
-                      {% if members | length > 1 and members[0] != config.entity %}
-                      ha-card::after {
-                        content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
-                        position: absolute;
-                        bottom: 6px;
-                        left: 8px;
-                        font-size: 10px;
-                        color: white;
-                        text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-                        z-index: 10;
-                      }
-                      {% endif %}
 
-                - type: custom:mini-media-player
-                  entity: media_player.dining_room
-                  name: Dining Room
-                  artwork: full-cover-fit
-                  info: scroll
-                  hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-                  tap_action: { action: none }
+                - type: custom:mod-card
                   card_mod:
                     style: |
                       ha-card {
                         height: 100%;
                         min-height: 100px;
+                        background: var(--kiosk-bg-tile);
                         border-radius: 6px;
                         border: none;
                         overflow: hidden;
-                        background: var(--kiosk-bg-tile);
+                      }
+                  card:
+                    type: custom:mini-media-player
+                    entity: media_player.dining_room
+                    name: Dining Room
+                    artwork: full-cover-fit
+                    info: scroll
+                    hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
+                    tap_action: { action: none }
+                    card_mod:
+                      style: |
+                        ha-card {
+                          background: transparent !important;
+                          border: none !important;
+                          {% set members = state_attr(config.entity, 'group_members') or [] %}
+                          {% if members | length > 1 and members[0] != config.entity %}
+                            opacity: 0.5;
+                            filter: grayscale(0.4);
+                          {% endif %}
+                        }
                         {% set members = state_attr(config.entity, 'group_members') or [] %}
                         {% if members | length > 1 and members[0] != config.entity %}
-                          opacity: 0.5;
-                          filter: grayscale(0.4);
+                        ha-card::after {
+                          content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                          position: absolute;
+                          bottom: 6px;
+                          left: 8px;
+                          font-size: 10px;
+                          color: white;
+                          text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                          z-index: 10;
+                        }
                         {% endif %}
-                      }
-                      {% set members = state_attr(config.entity, 'group_members') or [] %}
-                      {% if members | length > 1 and members[0] != config.entity %}
-                      ha-card::after {
-                        content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
-                        position: absolute;
-                        bottom: 6px;
-                        left: 8px;
-                        font-size: 10px;
-                        color: white;
-                        text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-                        z-index: 10;
-                      }
-                      {% endif %}
 
-                - type: custom:mini-media-player
-                  entity: media_player.roam_2
-                  name: Roam 2
-                  artwork: full-cover-fit
-                  info: scroll
-                  hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-                  tap_action: { action: none }
+                - type: custom:mod-card
                   card_mod:
                     style: |
                       ha-card {
                         height: 100%;
                         min-height: 100px;
+                        background: var(--kiosk-bg-tile);
                         border-radius: 6px;
                         border: none;
                         overflow: hidden;
-                        background: var(--kiosk-bg-tile);
+                      }
+                  card:
+                    type: custom:mini-media-player
+                    entity: media_player.roam_2
+                    name: Roam 2
+                    artwork: full-cover-fit
+                    info: scroll
+                    hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
+                    tap_action: { action: none }
+                    card_mod:
+                      style: |
+                        ha-card {
+                          background: transparent !important;
+                          border: none !important;
+                          {% set members = state_attr(config.entity, 'group_members') or [] %}
+                          {% if members | length > 1 and members[0] != config.entity %}
+                            opacity: 0.5;
+                            filter: grayscale(0.4);
+                          {% endif %}
+                        }
                         {% set members = state_attr(config.entity, 'group_members') or [] %}
                         {% if members | length > 1 and members[0] != config.entity %}
-                          opacity: 0.5;
-                          filter: grayscale(0.4);
+                        ha-card::after {
+                          content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
+                          position: absolute;
+                          bottom: 6px;
+                          left: 8px;
+                          font-size: 10px;
+                          color: white;
+                          text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+                          z-index: 10;
+                        }
                         {% endif %}
-                      }
-                      {% set members = state_attr(config.entity, 'group_members') or [] %}
-                      {% if members | length > 1 and members[0] != config.entity %}
-                      ha-card::after {
-                        content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
-                        position: absolute;
-                        bottom: 6px;
-                        left: 8px;
-                        font-size: 10px;
-                        color: white;
-                        text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-                        z-index: 10;
-                      }
-                      {% endif %}
 
             # --- TVs row (spans both cols) ---
             - type: horizontal-stack


### PR DESCRIPTION
## Summary

Phase 5 shipped the structural fix (media grid distribution) but three polish items remained: idle media tiles had no background (mini-media-player overrides host bg in idle state), the climate setpoint chip rendered empty for some HVAC modes, and a sub-pixel phantom scrollbar persisted from Phase 1.5. This phase closes all three.

### Fix 1 — Robust setpoint chip template (upstairs + downstairs)

Replace `'Set {{ state_attr(..., "temperature") | round }}°'` with a multi-attribute fallback chain:
- `temperature` (heat/cool mode standard)
- `target_temp_low` / `target_temp_high` (auto mode → renders as `low–high°`)
- dash `—` (off mode / entity not loaded)

### Fix 2 — Idle media tile backgrounds

Wrap each of the 6 mini-media-players in a `custom:mod-card` (same pattern as Phase 4 climate). The wrapper owns `background: var(--kiosk-bg-tile)`, `min-height`, `border-radius`, `overflow`. The inner player gets `background: transparent !important` so the wrapper background bleeds through in idle/unavailable states. Group-member dimming + leader-tag `::after` logic preserved on the inner player so opacity + grayscale still apply.

### Fix 3 — Scrollbar squash

Add `overflow: hidden` to the view-grid `layout:` block. One line — kills the phantom 1-2px overflow at exactly `100vh`.

## Notes

Step 0 diagnostic (HA Developer Tools attribute lookup) wasn't run from CLI, but the robust template in Fix 1 is designed to handle the common attribute names without prior knowledge. If a vendor-specific attr like `bt_target_temp_heat` is the real source of truth for better-thermostat, a quick follow-up can prepend it as the first check.

## Changes

- `dashboards/kiosk.yaml` (+207 / −146):
  - Climate upstairs setpoint chip → robust template
  - Climate downstairs setpoint chip → robust template
  - 6 × mini-media-player → wrapped in `custom:mod-card` (bg/min-height moved to wrapper, transparent inner with dimming/leader-tag preserved)
  - View `layout:` → added `overflow: hidden`

## Test plan

- [ ] GitOps applies; lovelace reloads
- [ ] Climate column: both chip rows show humidity, setpoint, HVAC action; setpoint shows `Set 69°` in heat mode, `low–high°` in auto, `—` in off mode
- [ ] Media column: all 6 speaker tiles have visible `--kiosk-bg-tile` background in idle state
- [ ] Playing speakers still render album art correctly (artwork fills wrapper)
- [ ] Group-member dimming (50% opacity + grayscale) still works for grouped followers
- [ ] No vertical scrollbar at 1920×1080 (resize to confirm)
- [ ] Alarm hero, meeting hero, weather, lights unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01QAt2xLHpRwTMMpi2JDx4aT)_