### PR TITLE
add(dashboard): Command Deck — desktop control dashboard

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -70,6 +70,12 @@ lovelace:
       icon: mdi:monitor-dashboard
       show_in_sidebar: false
       filename: dashboards/kiosk.yaml
+    dashboard-command-deck:
+      mode: yaml
+      filename: dashboards/command-deck.yaml
+      title: Command Deck
+      icon: mdi:gamepad-variant
+      show_in_sidebar: true
 
 # Prometheus
 prometheus:

--- a/dashboards/command-deck.yaml
+++ b/dashboards/command-deck.yaml
@@ -1,0 +1,161 @@
+views:
+  - title: Command Deck
+    path: home
+    icon: mdi:gamepad-variant
+    cards:
+      # ============================================================
+      # ROW 1 — Alarm + Weather + Climate
+      # ============================================================
+      - type: horizontal-stack
+        cards:
+          - type: vertical-stack
+            cards:
+              - type: alarm-panel
+                entity: alarm_control_panel.home_alarm
+                name: Home Alarm
+                states:
+                  - arm_away
+                  - arm_home
+              - type: grid
+                columns: 3
+                square: false
+                cards:
+                  - type: tile
+                    entity: binary_sensor.main_panel_front_door
+                    name: Front
+                    icon: mdi:door
+                  - type: tile
+                    entity: binary_sensor.main_panel_garage_door
+                    name: Garage
+                    icon: mdi:garage
+                  - type: tile
+                    entity: binary_sensor.main_panel_basement_door
+                    name: Basement
+                    icon: mdi:door
+                  - type: tile
+                    entity: binary_sensor.main_panel_sliding_door
+                    name: Sliding
+                    icon: mdi:door-sliding
+                  - type: tile
+                    entity: binary_sensor.main_panel_office_motion
+                    name: Office Mtn
+                    icon: mdi:motion-sensor
+                  - type: tile
+                    entity: binary_sensor.main_panel_family_room_motion
+                    name: Family Mtn
+                    icon: mdi:motion-sensor
+
+          - type: weather-forecast
+            entity: weather.forecast_home
+            show_forecast: true
+            forecast_type: daily
+
+          - type: vertical-stack
+            cards:
+              - type: thermostat
+                entity: climate.upstairs
+                name: Upstairs
+              - type: thermostat
+                entity: climate.downstairs
+                name: Downstairs
+
+      # ============================================================
+      # ROW 2 — Lights by room (one tile per light)
+      # ============================================================
+      - type: horizontal-stack
+        cards:
+          - type: entities
+            title: Kitchen
+            show_header_toggle: true
+            entities:
+              - light.kitchen_main
+              - light.kitchen_island
+              - light.kitchen_table
+              - light.kitchen_sink
+
+          - type: entities
+            title: Office
+            show_header_toggle: true
+            entities:
+              - light.office
+              - light.office_lamp
+              - light.office_bookcase
+              - light.office_corner
+              - light.office_door
+              - light.desk_lamp
+              - light.desk_lamp_2
+
+          - type: entities
+            title: Play Room
+            show_header_toggle: true
+            entities:
+              - light.play_room
+              - light.play_room_1
+              - light.play_room_2
+              - light.play_room_3
+              - light.play_room_4
+
+      - type: horizontal-stack
+        cards:
+          - type: entities
+            title: Family Room
+            show_header_toggle: true
+            entities:
+              - light.family_room
+              - light.family_room_2
+              - light.floor_lamp
+              - switch.family_room_outlets
+
+          - type: entities
+            title: Entry / Hallways
+            show_header_toggle: true
+            entities:
+              - light.entry_1
+              - light.entry_2
+              - light.downstairs_hallway
+              - light.upstairs_hallway_light
+              - light.meeting_light
+
+          - type: entities
+            title: Outdoor
+            show_header_toggle: true
+            entities:
+              - light.front_door
+              - light.front_lantern
+              - light.garage_front
+              - light.garage_side
+              - light.shed
+              - switch.back_porch
+              - switch.garden
+
+      # ============================================================
+      # ROW 3 — Switches + Media
+      # ============================================================
+      - type: horizontal-stack
+        cards:
+          - type: entities
+            title: Switches
+            entities:
+              - switch.play_room_outlet
+              - switch.bonus_room
+              - switch.basement_1
+
+          - type: media-control
+            entity: media_player.office
+
+          - type: media-control
+            entity: media_player.kitchen
+
+      - type: horizontal-stack
+        cards:
+          - type: media-control
+            entity: media_player.dining_room
+
+          - type: media-control
+            entity: media_player.master_bedroom
+
+          - type: media-control
+            entity: media_player.basement
+
+          - type: media-control
+            entity: media_player.roam_2


### PR DESCRIPTION
## Summary

A new stock-cards-only dashboard for clicking-around-from-the-desktop control. No HACS dependencies, no per-card polish — just functional rows of standard HA cards.

- **Path**: \`/dashboard-command-deck/home\`
- **Sidebar**: visible to all users (\`show_in_sidebar: true\`)
- **Icon**: \`mdi:gamepad-variant\`
- **Cards used** (all stock): alarm-panel, weather-forecast, thermostat, tile, entities, media-control, grid, horizontal-stack, vertical-stack

## Layout

- **Row 1** — alarm panel + 6-tile door/motion grid, weather forecast, both thermostats stacked
- **Row 2** — per-room \`entities\` cards with header toggles (Kitchen, Office, Play Room, Family Room, Entry/Hallways, Outdoor)
- **Row 3** — indoor switches + 6 Sonos \`media-control\` cards

## Test plan

- [ ] GitOps sync applies; dashboard registration picks up after reload
- [ ] "Command Deck" appears in the sidebar for non-Kiosk users
- [ ] Visiting \`/dashboard-command-deck/home\` renders all three rows
- [ ] Alarm arm/disarm, light toggles, thermostat setpoint adjustments, and Sonos transport controls all work
- [ ] Header toggles on the per-room \`entities\` cards turn all room lights on/off

🤖 Generated with [Claude Code](https://claude.com/claude-code)