### PR TITLE
chore: shared Claude Code permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git fetch *)",
+      "Bash(yamllint *)",
+      "Bash(shellcheck *)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a project-level \`.claude/settings.json\` with three read-only Bash patterns that currently prompt on every run for anyone working in the repo with Claude Code:

- \`Bash(git fetch *)\` — updates remote-tracking refs only
- \`Bash(yamllint *)\` — pure linter
- \`Bash(shellcheck *)\` — pure linter

Per-user \`.claude/settings.local.json\` is already covered by the user's global gitignore (\`**/.claude/settings.local.json\`), so personal overrides won't accidentally land here.

## Test plan

- [ ] After this merges, opening Claude Code in this repo no longer prompts for \`git fetch\`, \`yamllint\`, or \`shellcheck\` invocations
- [ ] Personal \`.claude/settings.local.json\` (if present) continues to be gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)