### PR TITLE
fix(meeting): full brightness when meeting light turns on

### DIFF
--- a/automations/meeting.yaml
+++ b/automations/meeting.yaml
@@ -12,7 +12,7 @@
       - 255
       - 0
       - 0
-      brightness: 150
+      brightness: 255
       transition: 1
     target:
       device_id: caa9c445375f8b67c1a29b11c8ae61c3
@@ -67,7 +67,7 @@
           - 255
           - 0
           - 0
-          brightness: 150
+          brightness: 255
           transition: 1
         target:
           device_id: caa9c445375f8b67c1a29b11c8ae61c3


### PR DESCRIPTION
## Summary
- Bumps the meeting hallway light brightness from `150` → `255` in `automations/meeting.yaml` so it comes up at full output when a meeting starts.
- Applies to both the normal status-on path and the button-reconnect re-sync path, so brightness is consistent whether the button toggles on or the ESP32 just rejoined.

## Test plan
- [ ] Toggle `switch.meeting_button_in_meeting` on → confirm hallway light goes red at full brightness
- [ ] Toggle off → confirm light turns off (unchanged)
- [ ] Power-cycle the meeting button while it's "in meeting" → on reconnect, hallway re-syncs to red at full brightness

🤖 Generated with [Claude Code](https://claude.com/claude-code)