### PR TITLE
feat(automation): Sonoff button 1 → Kitchen + Family Room lights at 100%

### DIFF
--- a/automations/sonoff_button_kitchen_family.yaml
+++ b/automations/sonoff_button_kitchen_family.yaml
@@ -1,0 +1,23 @@
+- id: sonoff_button_1_kitchen_family_full_on
+  alias: 'Sonoff Button 1: Kitchen + Family Room lights to 100%'
+  triggers:
+  - entity_id: event.button_1_1
+    trigger: state
+  conditions: []
+  actions:
+  - action: switch.turn_on
+    target:
+      entity_id: switch.family_room_outlets
+  - action: light.turn_on
+    data:
+      brightness: 255
+    target:
+      entity_id:
+      - light.kitchen_main
+      - light.kitchen_island
+      - light.kitchen_table
+      - light.kitchen_sink
+      - light.family_room
+      - light.family_room_2
+      - light.floor_lamp
+  mode: single


### PR DESCRIPTION
## Summary
- Adds [automations/sonoff_button_kitchen_family.yaml](automations/sonoff_button_kitchen_family.yaml): on any press of Sonoff `button_1`, turn on all kitchen + family-room lights at full brightness.
- Targets: `light.kitchen_{main,island,table,sink}` + `light.family_room`, `light.family_room_2`, `light.floor_lamp`.
- Also turns on `switch.family_room_outlets` first since the floor lamp is a smart bulb on that switched outlet — without it, the bulb would be unreachable.

## Notes
- One of two newly-paired Sonoff buttons in the entity inventory: `button_1` and `button_2` (both 100% battery, names not yet customized in HA's device registry). I picked `button_1`; flip to `button_2` by changing `event.button_1_1` → `event.button_2_1` in the trigger if preferred.
- Trigger entity ID assumes ZHA's standard `event.<device_slug>_<action>` naming, matching the existing `event.office_button_1` pattern. If the event entity name differs after the first physical press, update the `entity_id` in the automation.
- Brightness style (`brightness: 255`) matches the existing [automations/meeting.yaml](automations/meeting.yaml) convention.
- Renaming the device (e.g. "button 1" → "Kitchen + Family Lights Button") lives in HA's device registry, not git — left as a follow-up for the UI.

## Test plan
- [ ] CI: `YAML Lint` passes
- [ ] CI: `HA config check` passes
- [ ] After merge + GitOps sync, press `button_1` once and confirm all 4 kitchen + 2 family-room ceiling fixtures + floor lamp ramp to 100%
- [ ] Confirm `switch.family_room_outlets` is on after the press (so the floor lamp is reachable)
- [ ] If the floor lamp doesn't respond on the first press because the outlet was off, press a second time once the bulb has rejoined Zigbee

Closes #N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)