### PR TITLE
feat(automation): Sonoff button 1 → downstairs lights single/double toggle

### DIFF
--- a/automations/sonoff_button_kitchen_family.yaml
+++ b/automations/sonoff_button_kitchen_family.yaml
@@ -1,0 +1,47 @@
+- id: sonoff_button_1_kitchen_family_on
+  alias: 'Sonoff Button 1: Single press → Kitchen + Family Room ON'
+  triggers:
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      device_ieee: f0:44:d3:ff:fe:f6:94:01
+      command: single
+  conditions: []
+  actions:
+  - action: switch.turn_on
+    target:
+      entity_id: switch.family_room_outlets
+  - action: light.turn_on
+    data:
+      brightness: 255
+    target:
+      entity_id:
+      - light.kitchen_main
+      - light.kitchen_island
+      - light.kitchen_table
+      - light.kitchen_sink
+      - light.family_room
+      - light.family_room_2
+      - light.floor_lamp
+  mode: single
+- id: sonoff_button_1_kitchen_family_off
+  alias: 'Sonoff Button 1: Double press → Kitchen + Family Room OFF'
+  triggers:
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      device_ieee: f0:44:d3:ff:fe:f6:94:01
+      command: double
+  conditions: []
+  actions:
+  - action: light.turn_off
+    target:
+      entity_id:
+      - light.kitchen_main
+      - light.kitchen_island
+      - light.kitchen_table
+      - light.kitchen_sink
+      - light.family_room
+      - light.family_room_2
+      - light.floor_lamp
+  mode: single


### PR DESCRIPTION
## Summary
- Adds [automations/sonoff_button_kitchen_family.yaml](automations/sonoff_button_kitchen_family.yaml) with two automations driven by the ZHA event bus, filtered by device IEEE \`f0:44:d3:ff:fe:f6:94:01\` (button 1 of the two new Sonoff SNZB buttons in the office).
  - **Single press** → kitchen + family-room lights ON at 100% (also flips \`switch.family_room_outlets\` on so the floor-lamp smart bulb is reachable).
  - **Double press** → same lights OFF.
- Lights covered: \`light.kitchen_{main,island,table,sink}\`, \`light.family_room\`, \`light.family_room_2\`, \`light.floor_lamp\`.
- Button 2 (\`18:69:0a:ff:fe:13:a1:01\`) is untouched — left for a future use.

## Why \`zha_event\` (not the \`event.*\` entity)
ZHA only creates the per-action \`event.*\` entity after the first physical press; the prior PR (#146, since reverted) tripped on this. Triggering off the \`zha_event\` bus with an IEEE filter sidesteps the bootstrap entirely.

## Possible command-name caveat
The triggers use \`command: single\` and \`command: double\`, which are the modern ZHA quirk values for Sonoff SNZB-01P. If your specific model emits older OnOff-cluster names, you'll see no firing. Test plan below covers it; if needed, swap \`single\` → \`toggle\` and \`double\` → \`on\` (older SNZB-01 convention) in the trigger \`event_data\`.

## Test plan
- [ ] CI: \`YAML Lint\` passes
- [ ] CI: \`HA config check\` passes
- [ ] After GitOps sync, single-press button 1 → all 4 kitchen + 2 family-room ceiling fixtures + floor lamp light to 100%
- [ ] Confirm \`switch.family_room_outlets\` is on after the press
- [ ] Double-press button 1 → all 7 lights turn off
- [ ] If neither press fires the automation, open Developer Tools → Events, listen for \`zha_event\`, press the button, copy the \`command\` value from the captured event, and PR a follow-up that updates the trigger \`event_data.command\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)