### PR TITLE
Sonoff Button 2 → outdoor OFF; light groups for outdoor + downstairs

### DIFF
--- a/automations/sonoff_button_kitchen_family.yaml
+++ b/automations/sonoff_button_kitchen_family.yaml
@@ -15,14 +15,7 @@
     data:
       brightness: 255
     target:
-      entity_id:
-      - light.kitchen_main
-      - light.kitchen_island
-      - light.kitchen_table
-      - light.kitchen_sink
-      - light.family_room
-      - light.family_room_2
-      - light.floor_lamp
+      entity_id: light.downstairs
   mode: single
 - id: sonoff_button_1_kitchen_family_off
   alias: 'Sonoff Button 1: Double press → Kitchen + Family Room OFF'
@@ -36,12 +29,5 @@
   actions:
   - action: light.turn_off
     target:
-      entity_id:
-      - light.kitchen_main
-      - light.kitchen_island
-      - light.kitchen_table
-      - light.kitchen_sink
-      - light.family_room
-      - light.family_room_2
-      - light.floor_lamp
+      entity_id: light.downstairs
   mode: single

--- a/automations/sonoff_button_outdoor.yaml
+++ b/automations/sonoff_button_outdoor.yaml
@@ -1,0 +1,18 @@
+# device_ieee 18:69:0a:ff:fe:13:a1:01 = Sonoff Button 2 (outdoor)
+- id: sonoff_button_2_outdoor_off
+  alias: 'Sonoff Button 2: Double press → Outdoor lights OFF'
+  triggers:
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      device_ieee: 18:69:0a:ff:fe:13:a1:01
+      command: double
+  conditions: []
+  actions:
+  - action: light.turn_off
+    target:
+      entity_id: light.outdoor
+  - action: switch.turn_off
+    target:
+      entity_id: switch.back_porch
+  mode: single

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -80,6 +80,33 @@ lovelace:
 # Prometheus
 prometheus:
 
+# Light groups — referenced by Sonoff button automations and dashboards.
+# `switch.back_porch` is outdoor lighting too but lives in a separate action
+# in `automations/sonoff_button_outdoor.yaml` because light groups can't hold
+# switches.
+light:
+  - platform: group
+    name: Outdoor
+    unique_id: outdoor
+    entities:
+      - light.front_door
+      - light.front_lantern
+      - light.garage_front
+      - light.garage_side
+      - light.shed
+
+  - platform: group
+    name: Downstairs
+    unique_id: downstairs
+    entities:
+      - light.kitchen_main
+      - light.kitchen_island
+      - light.kitchen_table
+      - light.kitchen_sink
+      - light.family_room
+      - light.family_room_2
+      - light.floor_lamp
+
 # Template sensors for Sonos group-aware dashboard
 template:
   - binary_sensor:
@@ -176,13 +203,8 @@ template:
       - name: "Outdoor Lights On"
         unique_id: outdoor_lights_on
         state: >
-          {{ is_state('light.front_door', 'on')
-             or is_state('light.front_lantern', 'on')
-             or is_state('light.garage_front', 'on')
-             or is_state('light.garage_side', 'on')
-             or is_state('light.shed', 'on')
-             or is_state('switch.back_porch', 'on')
-             or is_state('switch.garden', 'on') }}
+          {{ is_state('light.outdoor', 'on')
+             or is_state('switch.back_porch', 'on') }}
 
       - name: "Any Switch On"
         unique_id: any_switch_on

--- a/dashboards/command-deck.yaml
+++ b/dashboards/command-deck.yaml
@@ -126,7 +126,6 @@ views:
               - light.garage_side
               - light.shed
               - switch.back_porch
-              - switch.garden
 
       # ============================================================
       # ROW 3 — Switches + Media

--- a/dashboards/home.yaml
+++ b/dashboards/home.yaml
@@ -475,16 +475,6 @@ views:
               entity: switch.back_porch
               name: Back Porch
               icon: mdi:outdoor-lamp
-          - type: conditional
-            conditions:
-              - condition: state
-                entity: switch.garden
-                state: "on"
-            card:
-              type: tile
-              entity: switch.garden
-              name: Garden
-              icon: mdi:flower
 
       # --- Switches ---
       - type: vertical-stack


### PR DESCRIPTION
## Summary
- Adds two `light: platform: group` entities — `light.outdoor` (5 lights) and `light.downstairs` (7 lights) — so button automations and dashboards can target a single entity instead of duplicating entity lists.
- New automation `sonoff_button_2_outdoor_off` (zha_event, device IEEE `18:69:0a:ff:fe:13:a1:01`, double press) → `light.turn_off light.outdoor` + `switch.turn_off switch.back_porch`. `switch.back_porch` stays a sidecar action because light groups can't hold switch entities.
- Refactors the existing Sonoff Button 1 ON/OFF automations to target `light.downstairs`. Brightness on the ON path is preserved because it stays a `light.turn_on` call against a `light:` platform group.
- Drops `switch.garden` (long-dead entity) from the outdoor template sensor, the home dashboard tile list, and the command-deck outdoor entities card.

## Files
- `configuration.yaml` — new top-level `light:` block with the two groups; outdoor template sensor simplified to `is_state('light.outdoor', 'on') or is_state('switch.back_porch', 'on')`.
- `automations/sonoff_button_outdoor.yaml` — new file.
- `automations/sonoff_button_kitchen_family.yaml` — entity lists collapsed to `light.downstairs`.
- `dashboards/home.yaml`, `dashboards/command-deck.yaml` — `switch.garden` references removed.

## Test plan
- [ ] `YAML Lint` and `claude-review` pass.
- [ ] After merge, GitOps poller picks up `configuration.yaml` change → triggers HA Core restart (template + light groups need core reload, not just lovelace).
- [ ] `light.outdoor` and `light.downstairs` appear as entities and report `on` when any member is on.
- [ ] Sonoff Button 1 single press still brings kitchen + family lights to 100% (regression check on the refactor).
- [ ] Sonoff Button 1 double press turns kitchen + family OFF.
- [ ] Sonoff Button 2 double press turns outdoor lights + back porch OFF.
- [ ] `binary_sensor.outdoor_lights_on` still reflects outdoor activity correctly on the home dashboard.

Closes #151