### PR TITLE
cleanup: remove dead light.kitchen_sink entity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Automations are split across two locations with different governance models:
 ### Lights
 | Room | Entities |
 |------|----------|
-| Kitchen | `light.kitchen_main`, `light.kitchen_island`, `light.kitchen_table`, `light.kitchen_sink` |
+| Kitchen | `light.kitchen_main`, `light.kitchen_island`, `light.kitchen_table` |
 | Office | `light.office`, `light.office_lamp`, `light.office_bookcase`, `light.office_corner`, `light.office_door`, `light.desk_lamp`, `light.desk_lamp_2` |
 | Play Room | `light.play_room`, `light.play_room_1`, `light.play_room_2`, `light.play_room_3`, `light.play_room_4` |
 | Family Room | `light.family_room`, `light.family_room_2`, `light.floor_lamp` |

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -102,7 +102,6 @@ light:
       - light.kitchen_main
       - light.kitchen_island
       - light.kitchen_table
-      - light.kitchen_sink
       - light.family_room
       - light.family_room_2
       - light.floor_lamp
@@ -160,8 +159,7 @@ template:
         state: >
           {{ is_state('light.kitchen_main', 'on')
              or is_state('light.kitchen_island', 'on')
-             or is_state('light.kitchen_table', 'on')
-             or is_state('light.kitchen_sink', 'on') }}
+             or is_state('light.kitchen_table', 'on') }}
 
       - name: "Office Lights On"
         unique_id: office_lights_on

--- a/dashboards/command-deck.yaml
+++ b/dashboards/command-deck.yaml
@@ -71,7 +71,6 @@ views:
               - light.kitchen_main
               - light.kitchen_island
               - light.kitchen_table
-              - light.kitchen_sink
 
           - type: entities
             title: Office

--- a/dashboards/home.yaml
+++ b/dashboards/home.yaml
@@ -146,15 +146,6 @@ views:
               type: tile
               entity: light.kitchen_table
               name: Table
-          - type: conditional
-            conditions:
-              - condition: state
-                entity: light.kitchen_sink
-                state: "on"
-            card:
-              type: tile
-              entity: light.kitchen_sink
-              name: Sink
 
       # --- Office ---
       - type: vertical-stack

--- a/groups.yaml
+++ b/groups.yaml
@@ -20,7 +20,6 @@ downstairs_lights:
     - light.kitchen_main
     - light.kitchen_island
     - light.kitchen_table
-    - light.kitchen_sink
     - light.family_room
     - light.family_room_2
     - light.floor_lamp_composite


### PR DESCRIPTION
## Summary

`light.kitchen_sink` is a dead entity. Stripping all references across config, groups, dashboards, and docs.

## Changes

- `groups.yaml` — removed from `downstairs_lights` group
- `configuration.yaml` — removed from `light_group.downstairs` entities; removed from `kitchen_lights_on` template sensor OR-chain
- `dashboards/command-deck.yaml` — removed from Kitchen entities card
- `dashboards/home.yaml` — removed Sink conditional + tile block
- `CLAUDE.md` — removed from Kitchen lights reference table

No automations referenced the entity (verified via repo-wide grep). After this lands `grep -rn "kitchen_sink"` returns zero hits.

## Test plan

- [ ] GitOps applies; HA reloads cleanly with no missing-entity warnings
- [ ] Home dashboard Kitchen section renders Main / Island / Table tiles only
- [ ] `binary_sensor.kitchen_lights_on` still flips correctly when Main / Island / Table are on
- [ ] `light.downstairs` group works without the dead member


---
_Generated by [Claude Code](https://claude.ai/code/session_01QAt2xLHpRwTMMpi2JDx4aT)_