### PR TITLE
Add ha-context-sync workflow for autonomous context snapshot PRs

### DIFF
--- a/.github/workflows/ha-context-sync.yml
+++ b/.github/workflows/ha-context-sync.yml
@@ -1,0 +1,90 @@
+name: HA Context Sync
+
+# Triggered by HA-side dump script after it pushes a context-sync/<timestamp> branch.
+# Opens a PR from that branch to main, applies the context-snapshot label,
+# and enables auto-merge. The PR uses HA_SYNC_PAT (not GITHUB_TOKEN) so that
+# downstream workflows (ha-config-check, claude-code-review) fire on the resulting
+# pull_request event — same reasoning as ha-version-sync.yml.
+
+on:
+  repository_dispatch:
+    types: [ha-context-report]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-context-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate dispatch payload
+        env:
+          BRANCH: ${{ github.event.client_payload.branch }}
+        run: |
+          if [[ ! "$BRANCH" =~ ^context-sync/[0-9]{8}-[0-9]{6}$ ]]; then
+            echo "::error::Invalid branch name pattern: $BRANCH"
+            echo "::error::Expected: context-sync/YYYYMMDD-HHMMSS"
+            exit 1
+          fi
+          echo "Branch validated: $BRANCH"
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.HA_SYNC_PAT }}
+          fetch-depth: 0
+
+      - name: Verify branch exists on remote
+        env:
+          BRANCH: ${{ github.event.client_payload.branch }}
+        run: |
+          if ! git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null; then
+            echo "::error::Branch not found on remote: $BRANCH"
+            echo "::error::HA-side push may have failed; check /config/ha-context-dump.log"
+            exit 1
+          fi
+          echo "Branch present on remote"
+
+      - name: Ensure context-snapshot label exists
+        env:
+          GH_TOKEN: ${{ secrets.HA_SYNC_PAT }}
+        run: |
+          gh label create context-snapshot \
+            --color "BFD4F2" \
+            --description "Automated HA state snapshot — auto-generated, do not edit" \
+            --force
+
+      - name: Open PR (idempotent)
+        env:
+          GH_TOKEN: ${{ secrets.HA_SYNC_PAT }}
+          BRANCH: ${{ github.event.client_payload.branch }}
+        run: |
+          # If a PR is already open for this branch, exit cleanly.
+          # Handles dispatch retries / rapid-fire from the HA side.
+          existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' || true)
+          if [[ -n "$existing" ]]; then
+            echo "PR already open for $BRANCH: #$existing"
+            exit 0
+          fi
+
+          # Timestamp portion of the branch name becomes the PR title suffix
+          stamp="${BRANCH#context-sync/}"
+
+          pr_url=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "context-snapshot: ${stamp}" \
+            --body "Automated HA state snapshot from \`shell_command.ha_context_dump\`.
+
+          Updates the read-only \`context/\` directory with the latest entity registry, area registry, device registry, and UI-managed automations. This directory is the canonical reference Claude Code consults before writing HA config — see \`CLAUDE.md\`.
+
+          No human review required. Auto-merged once CI passes." \
+            --label "context-snapshot")
+
+          echo "Opened: $pr_url"
+
+          # Enable auto-merge with squash strategy.
+          # CI gates (ha-config-check, claude-code-review) still must pass.
+          gh pr merge --auto --squash "$pr_url"
+          echo "Auto-merge enabled"

--- a/.github/workflows/ha-context-sync.yml
+++ b/.github/workflows/ha-context-sync.yml
@@ -60,31 +60,22 @@ jobs:
           GH_TOKEN: ${{ secrets.HA_SYNC_PAT }}
           BRANCH: ${{ github.event.client_payload.branch }}
         run: |
-          # If a PR is already open for this branch, exit cleanly.
-          # Handles dispatch retries / rapid-fire from the HA side.
           existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' || true)
           if [[ -n "$existing" ]]; then
             echo "PR already open for $BRANCH: #$existing"
             exit 0
           fi
 
-          # Timestamp portion of the branch name becomes the PR title suffix
           stamp="${BRANCH#context-sync/}"
 
           pr_url=$(gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "context-snapshot: ${stamp}" \
-            --body "Automated HA state snapshot from \`shell_command.ha_context_dump\`.
-
-          Updates the read-only \`context/\` directory with the latest entity registry, area registry, device registry, and UI-managed automations. This directory is the canonical reference Claude Code consults before writing HA config — see \`CLAUDE.md\`.
-
-          No human review required. Auto-merged once CI passes." \
+            --body "Automated HA state snapshot. See context/README.md for details. Auto-merged once CI passes." \
             --label "context-snapshot")
 
           echo "Opened: $pr_url"
 
-          # Enable auto-merge with squash strategy.
-          # CI gates (ha-config-check, claude-code-review) still must pass.
           gh pr merge --auto --squash "$pr_url"
           echo "Auto-merge enabled"


### PR DESCRIPTION
Adds the workflow that opens PRs from context-sync/* branches pushed by the HA-side dump script. Inert until the HA-side starts firing repository_dispatch events (which will happen after the Card B @claude issue lands). No CI gates affected; existing protections apply to context-sync PRs as normal.