### PR TITLE
fix(office): restore command:on/off triggers — left_press never fires

### DIFF
--- a/packages/office_hue_switch.yaml
+++ b/packages/office_hue_switch.yaml
@@ -4,26 +4,25 @@
 #   device_id: 0ca521afbbfd4474f24f6203d59ab398
 #   area:      office
 #
-# Wiring: the module sits behind a maintained-contact rocker light switch and
-# is configured in Hue "rocker" mode. Events fire on the Hue manufacturer-
-# specific cluster 0xFC00, not the standard on/off cluster:
+# Wiring: the module sits behind a maintained-contact rocker light switch.
+# Observed events (live capture, 2026-05-11):
 #
-#   Rocker flips UP   → `left_press`  (once)
-#                       `left_hold`   (repeated while held in the up position)
-#                       `left_long_release` (once, when rocker leaves up)
-#   Rocker flips DOWN → `right_press` (once)
-#                       `right_hold`  (repeated while held in the down position)
-#                       `right_long_release` (once, when rocker leaves down)
+#   Rocker flips UP   → cluster 6 (on/off): `attribute_updated` then `command: on`
+#                       cluster 0xFC00: `left_hold` (repeats until rocker leaves)
+#   Rocker flips DOWN → cluster 6 (on/off): `attribute_updated` then `command: off`
+#                       cluster 0xFC00: `left_long_release` (once)
+#                       (then `right_*` would repeat in the same shape)
 #
-# We trigger only on `*_press` so each rocker flip causes exactly one action;
-# the repeated `*_hold` events are ignored.
+# We trigger on the cluster-6 `command: on` / `command: off` events — they fire
+# exactly once per rocker transition and are reliable across the device's
+# operating modes. The `*_hold` flood on the manufacturer cluster is ignored.
 #
 # Behavior:
-#   - Rocker up (left_press)   → if office lights are off, apply scene 1.
-#                                Otherwise advance the counter (wraps 5 → 1)
-#                                and apply the matching scene. Flipping down
-#                                then up again is how you cycle scenes.
-#   - Rocker down (right_press) → all office lights off; reset counter.
+#   - Rocker up (command: on)   → if office lights are off, apply scene 1.
+#                                 Otherwise advance the counter (wraps 5 → 1)
+#                                 and apply the matching scene. Flipping down
+#                                 then up again is how you cycle scenes.
+#   - Rocker down (command: off) → all office lights off; reset counter.
 #
 # Scenes:
 #   1 Bright   — all 6 lights, 100% / 4000K  (general illumination)
@@ -49,7 +48,8 @@ automation:
         event_type: zha_event
         event_data:
           device_id: 0ca521afbbfd4474f24f6203d59ab398
-          command: left_press
+          cluster_id: 6
+          command: 'on'
     actions:
       # Decide which scene index to land on before applying it.
       - choose:
@@ -188,7 +188,8 @@ automation:
         event_type: zha_event
         event_data:
           device_id: 0ca521afbbfd4474f24f6203d59ab398
-          command: right_press
+          cluster_id: 6
+          command: 'off'
     actions:
       - action: light.turn_off
         target:


### PR DESCRIPTION
## Summary

PR #186 was a misdiagnosis. A live capture from the device shows that flipping the rocker emits cluster 6 (`on/off`) events `command: on` / `command: off` exactly once per transition. `left_press` is not emitted at all by this firmware — only `left_hold` (repeating) and `left_long_release` on the manufacturer cluster 0xFC00. Switching triggers to `left_press` in #186 silently broke both automations.

Captured flip-up sequence:

```
cluster 6      command: attribute_updated  (on_off → 1)
cluster 6      command: on
cluster 0xFC00 command: left_hold          (repeats every ~0.8s)
```

Flip-down ends with `left_long_release` on 0xFC00 plus the symmetric `attribute_updated` + `command: off` on cluster 6.

Change:

- `office_hue_switch_top_cycle` trigger → `cluster_id: 6, command: 'on'`
- `office_hue_switch_bottom_off` trigger → `cluster_id: 6, command: 'off'`
- Explicit `cluster_id: 6` filter so the `left_hold` flood on 0xFC00 can never be confused for our triggers, and the file-header comment now documents the actual event model from live observation.

Scene-cycling logic is unchanged.

## Test plan

- [ ] Room dark, flip rocker up → all six office lights come on at scene 1 (Bright).
- [ ] Flip rocker down, then up → scene 2 (Focus). Repeat through 3 → 4 → 5 → wraps to 1.
- [ ] Flip rocker down → all six office lights off; `counter.office_scene_index` resets to 1.
- [ ] Holding the rocker in the up position does NOT advance the counter (the `left_hold` flood is ignored).
- [ ] yamllint + ha-config-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017mzYeJZ2zawiWAkAcw7QUp)_