### PR TITLE
feat(office): scripts to set RDM001 device mode via mfg command

### DIFF
--- a/packages/office_hue_switch_modeset.yaml
+++ b/packages/office_hue_switch_modeset.yaml
@@ -1,0 +1,76 @@
+# Office Hue Switch — device mode setter (one-shot diagnostic scripts)
+#
+# The Office Switch (Signify RDM001, ieee 00:17:88:01:0b:03:51:1e) is currently
+# in "single momentary" mode, which makes a maintained-contact rocker emit an
+# endless `left_hold` stream on cluster 0xFC00 while the rocker rests in the
+# up position. We want "dual rocker" mode so each flip emits one event and
+# nothing else.
+#
+# An earlier `zha.set_zigbee_cluster_attribute` write to attribute 0x0034
+# failed with "Unknown error". These scripts try alternative paths via
+# `zha.issue_zigbee_cluster_command` (manufacturer command) and a refined
+# attribute-write variant. Run each in Developer Tools → Services, watch the
+# device's event stream, and report back which one takes.
+#
+# Cluster 0xFC00 device-mode values (from zha-device-handlers Philips quirk):
+#   0 = unknown / factory default
+#   1 = single rocker        (1 wall switch, 1 zone)
+#   2 = single push button   (1 momentary button)
+#   3 = dual rocker          (2 wall switches OR a 2-position rocker)  ← target
+#   4 = dual push button     (2 momentary buttons)
+#
+# Manufacturer code: 0x100B (Signify Netherlands / Philips) = 4107.
+
+script:
+  office_switch_set_mode_via_command_0:
+    alias: 'Office Switch: try mfg command 0x00 with mode=3 (dual rocker)'
+    sequence:
+      - action: zha.issue_zigbee_cluster_command
+        data:
+          ieee: 00:17:88:01:0b:03:51:1e
+          endpoint_id: 1
+          cluster_id: 64512        # 0xFC00
+          cluster_type: in
+          command: 0               # 0x00
+          command_type: server
+          manufacturer: 4107       # 0x100B
+          args: [3]                # dual rocker
+
+  office_switch_set_mode_via_command_2:
+    alias: 'Office Switch: try mfg command 0x02 with mode=3 (dual rocker)'
+    sequence:
+      - action: zha.issue_zigbee_cluster_command
+        data:
+          ieee: 00:17:88:01:0b:03:51:1e
+          endpoint_id: 1
+          cluster_id: 64512
+          cluster_type: in
+          command: 2               # 0x02
+          command_type: server
+          manufacturer: 4107
+          args: [3]
+
+  office_switch_set_mode_via_attr_hex:
+    alias: 'Office Switch: try attribute write 0x0034 = 3 (no mfg code)'
+    sequence:
+      - action: zha.set_zigbee_cluster_attribute
+        data:
+          ieee: 00:17:88:01:0b:03:51:1e
+          endpoint_id: 1
+          cluster_id: 64512
+          cluster_type: in
+          attribute: 0x0034
+          value: 3
+
+  office_switch_set_mode_via_attr_with_mfg:
+    alias: 'Office Switch: try attribute write 0x0034 = 3 (mfg 0x100B)'
+    sequence:
+      - action: zha.set_zigbee_cluster_attribute
+        data:
+          ieee: 00:17:88:01:0b:03:51:1e
+          endpoint_id: 1
+          cluster_id: 64512
+          cluster_type: in
+          attribute: 0x0034
+          value: 3
+          manufacturer: 0x100B


### PR DESCRIPTION
## Summary

The Office Switch (RDM001) is in "single momentary" mode and streams `left_hold` continuously while the maintained-contact rocker rests in the up position. We want **dual rocker** mode (one event per flip). A direct `zha.set_zigbee_cluster_attribute` to attribute `0x0034` failed with "Unknown error", so this PR adds four diagnostic scripts that try alternative paths via `zha.issue_zigbee_cluster_command` and a refined attribute write.

New file: `packages/office_hue_switch_modeset.yaml`

| Script | Approach |
|---|---|
| `script.office_switch_set_mode_via_command_0` | Manufacturer command `0x00` on cluster `0xFC00`, mfg `0x100B`, `args: [3]` |
| `script.office_switch_set_mode_via_command_2` | Same but command `0x02` |
| `script.office_switch_set_mode_via_attr_hex` | Attribute write `0x0034 = 3`, no mfg code |
| `script.office_switch_set_mode_via_attr_with_mfg` | Attribute write `0x0034 = 3`, mfg `0x100B` |

Each is run once from Developer Tools → Services. We inspect the event log afterward: success looks like the `left_hold` flood stopping after the next rocker flip. Once we identify the working path, follow-up PR removes the failing variants and keeps the working one as the canonical recipe (likely fired on `homeassistant_started` as a safety net).

Mode value `3` is dual rocker per the Philips quirk in zha-device-handlers.

## Test plan

- [ ] Call each script from Developer Tools → Services one at a time.
- [ ] After each call, flip the rocker up/down and observe the event stream.
- [ ] The path that worked: single `command: on` / `command: off` on cluster 6 per flip, and the cluster 0xFC00 `left_hold` flood is GONE.
- [ ] Existing automations (rocker up = cycle, rocker down = off) still behave correctly.
- [ ] yamllint + ha-config-check green.

## Out of scope

- Removing the failing variants — that happens in a follow-up once we know which path the firmware accepts.
- Persisting the mode across firmware updates (will add a `homeassistant_started` automation once the working call is known).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017mzYeJZ2zawiWAkAcw7QUp)_