### PR TITLE
fix(office): write device_mode on Basic cluster, not 0xFC00 (KeyError: 52)

### DIFF
--- a/packages/office_hue_switch_modeset.yaml
+++ b/packages/office_hue_switch_modeset.yaml
@@ -1,34 +1,36 @@
-# Office Hue Switch — device mode setter (one-shot diagnostic)
+# Office Hue Switch — device mode setter
 #
-# The Office Switch is on the `zhaquirks.philips.wall_switch.PhilipsWallSwitchNewFirmware`
-# quirk. Cluster 0xFC00 is on the input (server) side at endpoint 1, so the
-# `device_mode` attribute at 0x0034 is reachable via `zha.set_zigbee_cluster_attribute`.
+# Device: Office Switch (Signify RDM001) on the
+#   zhaquirks.philips.wall_switch.PhilipsWallSwitchNewFirmware quirk.
 #
-# Wiring: ONE traditional SPST/SPDT wall rocker. Target mode = 1 (single rocker)
-# — the device currently behaves as if it's in a dual-button mode and interprets
-# each rocker position as a button held continuously, hence the `left_hold` /
-# `right_hold` event flood.
+# The Philips quirk extends the **standard Basic cluster (0x0000)** with two
+# manufacturer-specific attributes, NOT cluster 0xFC00:
+#   0x0031  philips  (bitmap16, mfg-specific)
+#   0x0034  mode     (enum8,   mfg-specific)  ← what we write
 #
-# Mode values (Philips device_mode enum8 on cluster 0xFC00):
-#   0 = unknown / factory default
-#   1 = single rocker      ← target for a 1-position SPST/SPDT wall switch
-#   2 = single push button
-#   3 = dual rocker
-#   4 = dual push button
+# device_mode enum (0-indexed):
+#   0 = single rocker        ← target for one SPST/SPDT wall switch
+#   1 = single push button
+#   2 = dual rocker
+#   3 = dual push button     ← current state (causes left/right hold flood)
 #
-# Run from Developer Tools → Services. Earlier attempts that passed
-# `manufacturer: 4107` (0x100B) all failed — the loaded quirk applies the mfg
-# code automatically, and passing it explicitly appears to break the call.
+# Because the attribute is manufacturer-specific on a STANDARD cluster, the
+# manufacturer code (0x100B = 4107, Philips/Signify) is REQUIRED on the
+# service call so zigpy looks up the right attribute table.
+#
+# Earlier attempts targeted cluster 0xFC00 — that's why every variant raised
+# `KeyError: 52` from `find_attributes`. Right cluster is Basic (0x0000).
 
 script:
   office_switch_set_mode_single_rocker:
-    alias: 'Office Switch: set device_mode = 1 (single rocker)'
+    alias: 'Office Switch: set device_mode = 0 (single rocker)'
     sequence:
       - action: zha.set_zigbee_cluster_attribute
         data:
           ieee: 00:17:88:01:0b:03:51:1e
           endpoint_id: 1
-          cluster_id: 64512        # 0xFC00 — Philips manufacturer cluster
+          cluster_id: 0          # Basic cluster (Philips quirk extends it)
           cluster_type: in
-          attribute: 0x0034        # device_mode (enum8)
-          value: 1                 # single rocker
+          attribute: 0x0034      # device_mode (enum8, mfg-specific)
+          value: 0               # single rocker
+          manufacturer: 4107     # 0x100B Philips/Signify — required for mfg-specific attr


### PR DESCRIPTION
## Summary

The HA log produced the definitive error from #190's failed script:

```
File "zigpy/zcl/__init__.py", line 547, in find_attributes
    candidates = cls._attributes_by_id[name_or_id]
KeyError: 52
```

`KeyError: 52` from `Cluster._attributes_by_id` means attribute `0x0034` does not exist on the cluster we targeted. I had the cluster wrong: the Philips quirk (`zhaquirks.philips.wall_switch.PhilipsWallSwitchNewFirmware`, via `zhaquirks.philips.PhilipsBasicCluster`) extends the **standard Basic cluster `0x0000`** with the manufacturer-specific attributes, not the manufacturer-specific cluster `0xFC00`. The endpoint signature lists `0x0000` on the input side, so the attribute IS reachable — we just have to write to the right cluster.

Two other things change at the same time:

1. **Enum is 0-indexed.** Per the quirk's `DeviceMode` enum: `0 = single rocker`, `1 = single push button`, `2 = dual rocker`, `3 = dual push button`. For one SPST/SPDT rocker wired to the module, target value is **`0`**. The current `left/right hold` flood behavior matches mode 3 (dual push button) — the firmware is interpreting each rocker position as a button held continuously.
2. **`manufacturer: 4107` is required this time.** Because the attribute is manufacturer-specific on a *standard* cluster, zigpy only finds it when the manufacturer code is passed — otherwise it consults the standard Basic attribute table only and `0x0034` isn't there. (On the manufacturer-specific `0xFC00` cluster the mfg code would have been redundant; on the standard Basic cluster it's mandatory.)

Final call:

```yaml
action: zha.set_zigbee_cluster_attribute
data:
  ieee: 00:17:88:01:0b:03:51:1e
  endpoint_id: 1
  cluster_id: 0          # Basic cluster
  cluster_type: in
  attribute: 0x0034      # device_mode (enum8, mfg-specific)
  value: 0               # single rocker
  manufacturer: 4107     # 0x100B Philips/Signify
```

## Test plan

- [ ] Run `script.office_switch_set_mode_single_rocker` from Developer Tools → Actions.
- [ ] Service call returns success (no error toast, no traceback in `home-assistant.log`).
- [ ] Flip the rocker up and down once. Success criteria: exactly one `command: on` (or `command: off`) on cluster 6 per flip, and the cluster `0xFC00` `left_hold` / `right_hold` flood is GONE.
- [ ] Scene cycler still works: flip up cycles, flip down kills.
- [ ] If `value: 0` doesn't stop the flood but the call succeeds, try `value: 2` (dual rocker — in case both inputs of the module are actually wired to the rocker's two contacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017mzYeJZ2zawiWAkAcw7QUp)_