### PR TITLE
feat(automations): restore Office Hue wall switch via ZHA events

### DIFF
--- a/automations/office_switch.yaml
+++ b/automations/office_switch.yaml
@@ -1,0 +1,100 @@
+# Office Hue Wall Switch Module (RDM001) → ZHA event automation
+#
+# Replaces the implicit Hue Bridge binding that this switch used to have when
+# we ran a Hue Bridge. The bridge knew which Hue room the switch lived in and
+# toggled that group's lights on/off natively. After migrating to ZHA, the
+# switch fires zha_event entries but no automation existed to act on them, so
+# the office lights stopped responding.
+#
+# Device:   "Office Switch" — Signify RDM001, ZHA, ieee 00:17:88:01:0b:03:51:1e
+# Quirk:    zhaquirks.philips.wall_switch.PhilipsWallSwitchNewFirmware
+# Wiring:   Single rocker on a traditional toggle switch (NOT momentary)
+#
+# Observed event vocabulary (captured live from the device):
+#   Flip UP (rocker closed):
+#     - cluster 6 (OnOff), command alternates between:
+#         "on"
+#         "off"
+#         "off_with_effect"
+#         "on_with_recall_global_scene"
+#       The alternation is the firmware's bound-output state; we ignore the
+#       command name and treat ANY cluster-6 command as "user flipped up".
+#     - cluster 6, command "attribute_updated" — fires simultaneously;
+#       intentionally NOT matched to avoid double-firing.
+#     - cluster 64512 (Hue manufacturer), command "left_hold" — fires
+#       repeatedly every ~750ms while the rocker stays in the up position;
+#       intentionally NOT matched.
+#   Flip DOWN (rocker open):
+#     - cluster 64512, command "left_long_release" — fires exactly once.
+#
+# Action: turn the 6 office Hue lights on/off, restoring their last-known
+# state (color, brightness) — matching the old Hue Bridge "scene resume"
+# behaviour. Lights are listed explicitly rather than by area_id so that
+# adding non-Hue or non-office entities to the area doesn't unexpectedly
+# change the switch's scope.
+
+- id: office_switch_flip_up
+  alias: 'Office Switch: rocker UP — office lights on'
+  triggers:
+    - trigger: event
+      event_type: zha_event
+      event_data:
+        device_ieee: '00:17:88:01:0b:03:51:1e'
+        cluster_id: 6
+        command: 'on'
+      id: rocker_up
+    - trigger: event
+      event_type: zha_event
+      event_data:
+        device_ieee: '00:17:88:01:0b:03:51:1e'
+        cluster_id: 6
+        command: 'off'
+      id: rocker_up
+    - trigger: event
+      event_type: zha_event
+      event_data:
+        device_ieee: '00:17:88:01:0b:03:51:1e'
+        cluster_id: 6
+        command: 'off_with_effect'
+      id: rocker_up
+    - trigger: event
+      event_type: zha_event
+      event_data:
+        device_ieee: '00:17:88:01:0b:03:51:1e'
+        cluster_id: 6
+        command: 'on_with_recall_global_scene'
+      id: rocker_up
+  conditions: []
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id:
+          - light.bookcase_lamp
+          - light.corner_lamp
+          - light.desk_lamp_2
+          - light.desk_lamp_2_2
+          - light.door_lamp
+          - light.table_lamp
+  mode: single
+
+- id: office_switch_flip_down
+  alias: 'Office Switch: rocker DOWN — office lights off'
+  triggers:
+    - trigger: event
+      event_type: zha_event
+      event_data:
+        device_ieee: '00:17:88:01:0b:03:51:1e'
+        cluster_id: 64512
+        command: 'left_long_release'
+  conditions: []
+  actions:
+    - action: light.turn_off
+      target:
+        entity_id:
+          - light.bookcase_lamp
+          - light.corner_lamp
+          - light.desk_lamp_2
+          - light.desk_lamp_2_2
+          - light.door_lamp
+          - light.table_lamp
+  mode: single


### PR DESCRIPTION
Restores the implicit Hue Bridge binding the Office Switch (RDM001) used to have. Flip up -> 6 office lights on, flip down -> off. Event vocabulary captured live: any cluster-6 command on flip-up (firmware alternates names in dual-push-button mode 3), left_long_release on cluster 64512 on flip-down. Follows meeting.yaml pattern under /config/automations/. Compatible with future device_mode=0 refinement (packages/office_hue_switch_modeset.yaml) — would need a trigger rewrite if mode changes.