### PR TITLE
fix(office): counter.configure → counter.set_value (service renamed)

### DIFF
--- a/packages/office_hue_switch.yaml
+++ b/packages/office_hue_switch.yaml
@@ -92,7 +92,7 @@ automation:
                 entity_id: binary_sensor.office_lights_on
                 state: 'off'
             sequence:
-              - action: counter.configure
+              - action: counter.set_value
                 target:
                   entity_id: counter.office_scene_index
                 data:
@@ -103,7 +103,7 @@ automation:
                 entity_id: counter.office_scene_index
                 state: '5'
             then:
-              - action: counter.configure
+              - action: counter.set_value
                 target:
                   entity_id: counter.office_scene_index
                 data:
@@ -243,7 +243,7 @@ automation:
             - light.desk_lamp_2
             - light.desk_lamp_2_2
             - light.table_lamp
-      - action: counter.configure
+      - action: counter.set_value
         target:
           entity_id: counter.office_scene_index
         data:


### PR DESCRIPTION
The `counter.configure` service was renamed to `counter.set_value` in a recent HA release. Every code path in the office scene cycler that resets the counter to 1 was raising `Action counter.configure not found` at runtime, aborting the automation before action[1] (scene application) could fire.

This is the *exact* root cause of the inconsistent behavior. Confirmed from the trace at 2026-05-12T11:58:48Z (state: stopped, last_step: action/0/default/0/then/0, error: 'Action counter.configure not found').

Failure modes the rename caused:
- Counter at 1-4 + lights on + flip up → counter.increment (still works) → succeeds → scene applied ✓
- Counter at 5 + flip up → counter.set_value reset → ERROR → scene never applied ✗
- Lights off + flip up → counter.set_value reset → ERROR → scene 1 never applied ✗ (the failure the user noticed most)

3 call sites in packages/office_hue_switch.yaml, all swapped.