### PR TITLE
fix(office): kelvin → color_temp_kelvin (light service param renamed)

### DIFF
--- a/packages/office_hue_switch.yaml
+++ b/packages/office_hue_switch.yaml
@@ -126,7 +126,7 @@ automation:
                     - light.table_lamp
                 data:
                   brightness_pct: 100
-                  kelvin: 4000
+                  color_temp_kelvin: 4000
           - conditions: "{{ states('counter.office_scene_index') == '2' }}"
             sequence:
               - action: light.turn_on
@@ -136,7 +136,7 @@ automation:
                     - light.desk_lamp_2_2
                 data:
                   brightness_pct: 100
-                  kelvin: 5000
+                  color_temp_kelvin: 5000
               - action: light.turn_on
                 target:
                   entity_id:
@@ -144,7 +144,7 @@ automation:
                     - light.bookcase_lamp
                 data:
                   brightness_pct: 60
-                  kelvin: 3500
+                  color_temp_kelvin: 3500
               - action: light.turn_off
                 target:
                   entity_id:
@@ -163,7 +163,7 @@ automation:
                     - light.table_lamp
                 data:
                   brightness_pct: 50
-                  kelvin: 2200
+                  color_temp_kelvin: 2200
           - conditions: "{{ states('counter.office_scene_index') == '4' }}"
             sequence:
               - action: light.turn_on
@@ -173,7 +173,7 @@ automation:
                     - light.corner_lamp
                 data:
                   brightness_pct: 20
-                  kelvin: 2000
+                  color_temp_kelvin: 2000
               - action: light.turn_off
                 target:
                   entity_id:


### PR DESCRIPTION
Same flavor of bug as #196 (counter.configure → counter.set_value). HA renamed the `kelvin` parameter on `light.turn_on` to `color_temp_kelvin` in a recent release. The cycler scenes were passing `kelvin: <N>` which now fails service-call validation with:

```
extra keys not allowed @ data['kelvin']
```

This was killing action[1] inside the first scene sequence, so even though #196 unblocked action[0] (counter management), scene 1 (Bright) never actually fired the light turn-on — the user saw 'nothing happens'.

Confirmed from trace at 2026-05-12T12:08:41Z:
- last_step: action/1/choose/0/sequence/0
- error: 'extra keys not allowed @ data[kelvin]'

5 call sites in packages/office_hue_switch.yaml (scenes 1, 2 ×2, 3, 4) renamed. Scene 5 (Color) is RGB-only and unaffected.