### PR TITLE
refactor(office): Sonoff Button 2 single press cycles, double/long press off

### DIFF
--- a/packages/sonoff_button_office.yaml
+++ b/packages/sonoff_button_office.yaml
@@ -7,10 +7,16 @@
 #   command: 'on'    → double press
 #   command: 'off'   → long press (hold)
 #
-# Bindings:
-#   single press → apply the current scene (turn lights on without changing it)
-#   double press → all office lights off (counter persists across off/on)
-#   long press   → advance scene counter (wraps 6 → 1) and apply
+# Bindings (mirror the in-wall Hue rocker's behavior):
+#   single press → if lights are off, reset counter to 1 and apply scene 1;
+#                  otherwise advance the counter (wraps 6 → 1) and apply.
+#                  i.e. first click turns on, subsequent clicks cycle scenes.
+#   double press → all office lights off (counter persists)
+#   long press   → all office lights off (counter persists)
+#
+# Long press is intentionally just an alternative OFF — the hold dwell is too
+# long to be useful for the more frequent cycle action, so single press is the
+# cycler.
 #
 # The counter is independent of `counter.office_scene_index` used by the in-wall
 # Hue rocker (packages/office_hue_switch.yaml) so the two remotes do not stomp
@@ -163,8 +169,8 @@ script:
                 milliseconds: "{{ range(300, 900) | random }}"
 
 automation:
-  - id: sonoff_button_2_office_on
-    alias: 'Sonoff Button 2: Single press → Office lights ON (current scene)'
+  - id: sonoff_button_2_office_cycle
+    alias: 'Sonoff Button 2: Single press → office on / cycle scenes'
     triggers:
       - trigger: event
         event_type: zha_event
@@ -173,17 +179,50 @@ automation:
           command: toggle
     conditions: []
     actions:
+      - choose:
+          - conditions:
+              - condition: state
+                entity_id: binary_sensor.office_lights_on
+                state: 'off'
+            sequence:
+              - action: counter.set_value
+                target:
+                  entity_id: counter.office_sonoff_scene
+                data:
+                  value: 1
+        default:
+          - if:
+              - condition: state
+                entity_id: counter.office_sonoff_scene
+                state: '6'
+            then:
+              - action: counter.set_value
+                target:
+                  entity_id: counter.office_sonoff_scene
+                data:
+                  value: 1
+            else:
+              - action: counter.increment
+                target:
+                  entity_id: counter.office_sonoff_scene
       - action: script.office_sonoff_apply_scene
     mode: single
 
   - id: sonoff_button_2_office_off
-    alias: 'Sonoff Button 2: Double press → Office lights OFF'
+    alias: 'Sonoff Button 2: Double or long press → Office lights OFF'
     triggers:
+      # Double press
       - trigger: event
         event_type: zha_event
         event_data:
           device_ieee: 18:69:0a:ff:fe:13:a1:01
           command: 'on'
+      # Long press
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: 18:69:0a:ff:fe:13:a1:01
+          command: 'off'
     conditions: []
     actions:
       - action: script.turn_off
@@ -198,31 +237,4 @@ automation:
             - light.desk_lamp_2
             - light.desk_lamp_2_2
             - light.table_lamp
-    mode: single
-
-  - id: sonoff_button_2_office_cycle
-    alias: 'Sonoff Button 2: Long press → cycle office scenes'
-    triggers:
-      - trigger: event
-        event_type: zha_event
-        event_data:
-          device_ieee: 18:69:0a:ff:fe:13:a1:01
-          command: 'off'
-    conditions: []
-    actions:
-      - if:
-          - condition: state
-            entity_id: counter.office_sonoff_scene
-            state: '6'
-        then:
-          - action: counter.set_value
-            target:
-              entity_id: counter.office_sonoff_scene
-            data:
-              value: 1
-        else:
-          - action: counter.increment
-            target:
-              entity_id: counter.office_sonoff_scene
-      - action: script.office_sonoff_apply_scene
     mode: single


### PR DESCRIPTION
## Summary
Mirror the in-wall Hue rocker's interaction model on Sonoff Button 2.

**New mapping:**
- **Single press** → if office lights are off, reset counter to 1 and apply scene 1; if already on, advance to the next scene (wraps 6 → 1). i.e. first click turns on, subsequent clicks cycle.
- **Double press** → office off (counter persists).
- **Long press** → office off (counter persists).

Previously single press just re-applied the current scene and long press did the cycling — but the SNZB-01 hold dwell is long enough to be annoying for the most frequent action, so the cycle moves to single press. Long press becomes a redundant OFF alongside double press, since the hold is fine for the occasional shut-down gesture.

The single-press logic now mirrors `automation.office_hue_switch_top_cycle` in [packages/office_hue_switch.yaml](packages/office_hue_switch.yaml) (off → scene 1; on → advance), using `binary_sensor.office_lights_on` for the off-check.

## Test plan
- [ ] From off: single press → scene 1 (Bright White) on all six lamps.
- [ ] From on: each subsequent single press advances scene 1 → 2 → 3 → 4 → 5 → 6 → 1 …
- [ ] Double press at any point → all six lamps off.
- [ ] Long press at any point → all six lamps off (slower but still works).
- [ ] After off, next single press starts at scene 1 again.
- [ ] In-wall Hue rocker scene cycling still works independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)