### PR TITLE
feat(downstairs): add both hallway lights to Sonoff Button 1

### DIFF
--- a/automations/sonoff_button_kitchen_family.yaml
+++ b/automations/sonoff_button_kitchen_family.yaml
@@ -1,6 +1,6 @@
 # device_ieee f0:44:d3:ff:fe:f6:94:01 = Sonoff Button 1 (downstairs)
 - id: sonoff_button_1_kitchen_family_on
-  alias: 'Sonoff Button 1: Single press → Downstairs ON'
+  alias: 'Sonoff Button 1: Single press → Downstairs + Hallways ON'
   triggers:
   - trigger: event
     event_type: zha_event
@@ -13,13 +13,16 @@
     data:
       brightness: 255
     target:
-      entity_id: group.downstairs_lights
+      entity_id:
+        - group.downstairs_lights
+        - light.downstairs_hallway
+        - light.upstairs_hallway_light
   - action: switch.turn_on
     target:
       entity_id: switch.family_room_outlets
   mode: single
 - id: sonoff_button_1_kitchen_family_off
-  alias: 'Sonoff Button 1: Double press → Downstairs OFF'
+  alias: 'Sonoff Button 1: Double press → Downstairs + Hallways OFF'
   triggers:
   - trigger: event
     event_type: zha_event
@@ -30,7 +33,10 @@
   actions:
   - action: homeassistant.turn_off
     target:
-      entity_id: group.downstairs_lights
+      entity_id:
+        - group.downstairs_lights
+        - light.downstairs_hallway
+        - light.upstairs_hallway_light
   - action: switch.turn_off
     target:
       entity_id: switch.family_room_outlets


### PR DESCRIPTION
## Summary
Expand Sonoff Button 1's scope to include the downstairs and upstairs hallway lights at 100% brightness, so one press lights the full kitchen → family room → hallway → stairs path.

- **Single press** → existing `group.downstairs_lights` + `switch.family_room_outlets` actions, plus `light.downstairs_hallway` and `light.upstairs_hallway_light` at brightness 255 (100%).
- **Double press** → corresponding OFF actions extended to the two hallway lights.

The hallway lights are added as additional `entity_id` targets in the existing actions rather than appended to `group.downstairs_lights` — the upstairs hallway doesn't belong in a "downstairs" group, and keeping the group's scope tight avoids surprise behavior if anything else binds to it later.

Aliases updated to reflect the expanded scope ("Downstairs + Hallways ON/OFF").

## Test plan
- [ ] Single press Button 1: kitchen, family room, family-room outlets, downstairs hallway, and upstairs hallway all turn on at 100%.
- [ ] Double press Button 1: all of the above turn off.
- [ ] Hallway lights at 100% (not partial brightness or unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)