### PR TITLE
fix(office): de-synchronize Candle flicker — six independent per-lamp loops

### DIFF
--- a/packages/sonoff_button_office.yaml
+++ b/packages/sonoff_button_office.yaml
@@ -22,9 +22,12 @@
 # Hue rocker (packages/office_hue_switch.yaml) so the two remotes do not stomp
 # on each other's scene library.
 #
-# Every scene applies the same values to all six lamps simultaneously — no
-# per-lamp tiers. Candlelight computes one random RGB + brightness per tick
-# and applies it to all six in unison.
+# Every scene except Candle applies the same values to all six lamps
+# simultaneously — no per-lamp tiers. Candlelight runs six independent per-lamp
+# flicker loops in parallel, each with its own random RGB, brightness, tick
+# interval, and a random startup phase so the lamps don't all brighten or dim
+# on the same beat (unison flicker looks fake; phase-shifted flicker looks
+# like real candles).
 #
 # Scene catalog:
 #   1 Bright    — all 6, 100% / 4000K  (general illumination)
@@ -138,35 +141,133 @@ script:
     alias: 'Office Sonoff: Candlelight flicker loop'
     mode: restart
     sequence:
-      - repeat:
-          while:
-            - condition: state
-              entity_id: counter.office_sonoff_scene
-              state: '6'
-          sequence:
-            - variables:
-                flicker_r: "{{ range(200, 256) | random }}"
-                flicker_g: "{{ range(60, 130) | random }}"
-                flicker_b: "{{ range(0, 30) | random }}"
-                flicker_brightness: "{{ range(40, 101) | random }}"
-            - action: light.turn_on
-              target:
-                entity_id:
-                  - light.bookcase_lamp
-                  - light.corner_lamp
-                  - light.door_lamp
-                  - light.desk_lamp_2
-                  - light.desk_lamp_2_2
-                  - light.table_lamp
-              data:
-                rgb_color:
-                  - "{{ flicker_r }}"
-                  - "{{ flicker_g }}"
-                  - "{{ flicker_b }}"
-                brightness_pct: "{{ flicker_brightness }}"
-                transition: 0.4
-            - delay:
-                milliseconds: "{{ range(300, 900) | random }}"
+      - parallel:
+          - sequence:
+              - delay:
+                  milliseconds: "{{ range(0, 700) | random }}"
+              - repeat:
+                  while:
+                    - condition: state
+                      entity_id: counter.office_sonoff_scene
+                      state: '6'
+                  sequence:
+                    - action: light.turn_on
+                      target:
+                        entity_id: light.bookcase_lamp
+                      data:
+                        rgb_color:
+                          - "{{ range(200, 256) | random }}"
+                          - "{{ range(60, 130) | random }}"
+                          - "{{ range(0, 30) | random }}"
+                        brightness_pct: "{{ range(40, 101) | random }}"
+                        transition: 0.4
+                    - delay:
+                        milliseconds: "{{ range(300, 900) | random }}"
+          - sequence:
+              - delay:
+                  milliseconds: "{{ range(0, 700) | random }}"
+              - repeat:
+                  while:
+                    - condition: state
+                      entity_id: counter.office_sonoff_scene
+                      state: '6'
+                  sequence:
+                    - action: light.turn_on
+                      target:
+                        entity_id: light.corner_lamp
+                      data:
+                        rgb_color:
+                          - "{{ range(200, 256) | random }}"
+                          - "{{ range(60, 130) | random }}"
+                          - "{{ range(0, 30) | random }}"
+                        brightness_pct: "{{ range(40, 101) | random }}"
+                        transition: 0.4
+                    - delay:
+                        milliseconds: "{{ range(300, 900) | random }}"
+          - sequence:
+              - delay:
+                  milliseconds: "{{ range(0, 700) | random }}"
+              - repeat:
+                  while:
+                    - condition: state
+                      entity_id: counter.office_sonoff_scene
+                      state: '6'
+                  sequence:
+                    - action: light.turn_on
+                      target:
+                        entity_id: light.door_lamp
+                      data:
+                        rgb_color:
+                          - "{{ range(200, 256) | random }}"
+                          - "{{ range(60, 130) | random }}"
+                          - "{{ range(0, 30) | random }}"
+                        brightness_pct: "{{ range(40, 101) | random }}"
+                        transition: 0.4
+                    - delay:
+                        milliseconds: "{{ range(300, 900) | random }}"
+          - sequence:
+              - delay:
+                  milliseconds: "{{ range(0, 700) | random }}"
+              - repeat:
+                  while:
+                    - condition: state
+                      entity_id: counter.office_sonoff_scene
+                      state: '6'
+                  sequence:
+                    - action: light.turn_on
+                      target:
+                        entity_id: light.desk_lamp_2
+                      data:
+                        rgb_color:
+                          - "{{ range(200, 256) | random }}"
+                          - "{{ range(60, 130) | random }}"
+                          - "{{ range(0, 30) | random }}"
+                        brightness_pct: "{{ range(40, 101) | random }}"
+                        transition: 0.4
+                    - delay:
+                        milliseconds: "{{ range(300, 900) | random }}"
+          - sequence:
+              - delay:
+                  milliseconds: "{{ range(0, 700) | random }}"
+              - repeat:
+                  while:
+                    - condition: state
+                      entity_id: counter.office_sonoff_scene
+                      state: '6'
+                  sequence:
+                    - action: light.turn_on
+                      target:
+                        entity_id: light.desk_lamp_2_2
+                      data:
+                        rgb_color:
+                          - "{{ range(200, 256) | random }}"
+                          - "{{ range(60, 130) | random }}"
+                          - "{{ range(0, 30) | random }}"
+                        brightness_pct: "{{ range(40, 101) | random }}"
+                        transition: 0.4
+                    - delay:
+                        milliseconds: "{{ range(300, 900) | random }}"
+          - sequence:
+              - delay:
+                  milliseconds: "{{ range(0, 700) | random }}"
+              - repeat:
+                  while:
+                    - condition: state
+                      entity_id: counter.office_sonoff_scene
+                      state: '6'
+                  sequence:
+                    - action: light.turn_on
+                      target:
+                        entity_id: light.table_lamp
+                      data:
+                        rgb_color:
+                          - "{{ range(200, 256) | random }}"
+                          - "{{ range(60, 130) | random }}"
+                          - "{{ range(0, 30) | random }}"
+                        brightness_pct: "{{ range(40, 101) | random }}"
+                        transition: 0.4
+                    - delay:
+                        milliseconds: "{{ range(300, 900) | random }}"
 
 automation:
   - id: sonoff_button_2_office_cycle


### PR DESCRIPTION
## Summary

The Candle scene in `script.office_sonoff_candle_loop` computed one random RGB + brightness per tick and applied it to all six office lamps simultaneously, so every lamp brightened and dimmed on the same beat. That synchronized flicker reads as obviously fake — real candles don't move in lockstep.

Replace the single all-lamps loop with a `parallel:` block of six independent per-lamp branches. Each branch:

- Waits a random **0–700 ms startup phase** so the loops don't all begin on the same instant.
- Picks its own random `rgb_color` (warm-amber range: R 200–255, G 60–129, B 0–29) and `brightness_pct` (40–100) on every tick.
- Sleeps a random **300–900 ms** before the next tick.

Net effect: the six lamps drift in and out of intensity independently and the room reads as actual candlelight, not a stage cue. The loop still exits cleanly when `counter.office_sonoff_scene` leaves `6`, and `mode: restart` still tears down the previous run when the user re-enters the scene.

## Test plan

- [ ] Cycle to scene 6 (Candle) on the office Sonoff button.
- [ ] Watch all six office lamps for at least 30 seconds — verify they're flickering on visibly independent schedules (no synchronized "beats") and that color/brightness varies per lamp.
- [ ] Cycle to any other scene — flicker loop stops; the new scene's static values apply to all six lamps.
- [ ] Cycle back to scene 6 — flicker resumes cleanly (the random-phase startup means the lamps de-synchronize again on every restart).
- [ ] Double-press or long-press the Sonoff to turn off — all six lamps go dark and the loop terminates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017mzYeJZ2zawiWAkAcw7QUp)_