### PR TITLE
tune(office): tighten Candle color/brightness range and speed up flicker

### DIFF
--- a/packages/sonoff_button_office.yaml
+++ b/packages/sonoff_button_office.yaml
@@ -144,7 +144,7 @@ script:
       - parallel:
           - sequence:
               - delay:
-                  milliseconds: "{{ range(0, 700) | random }}"
+                  milliseconds: "{{ range(0, 300) | random }}"
               - repeat:
                   while:
                     - condition: state
@@ -156,16 +156,16 @@ script:
                         entity_id: light.bookcase_lamp
                       data:
                         rgb_color:
-                          - "{{ range(200, 256) | random }}"
-                          - "{{ range(60, 130) | random }}"
-                          - "{{ range(0, 30) | random }}"
-                        brightness_pct: "{{ range(40, 101) | random }}"
-                        transition: 0.4
+                          - "{{ range(230, 256) | random }}"
+                          - "{{ range(85, 111) | random }}"
+                          - "{{ range(5, 21) | random }}"
+                        brightness_pct: "{{ range(65, 96) | random }}"
+                        transition: 0.2
                     - delay:
-                        milliseconds: "{{ range(300, 900) | random }}"
+                        milliseconds: "{{ range(120, 350) | random }}"
           - sequence:
               - delay:
-                  milliseconds: "{{ range(0, 700) | random }}"
+                  milliseconds: "{{ range(0, 300) | random }}"
               - repeat:
                   while:
                     - condition: state
@@ -177,16 +177,16 @@ script:
                         entity_id: light.corner_lamp
                       data:
                         rgb_color:
-                          - "{{ range(200, 256) | random }}"
-                          - "{{ range(60, 130) | random }}"
-                          - "{{ range(0, 30) | random }}"
-                        brightness_pct: "{{ range(40, 101) | random }}"
-                        transition: 0.4
+                          - "{{ range(230, 256) | random }}"
+                          - "{{ range(85, 111) | random }}"
+                          - "{{ range(5, 21) | random }}"
+                        brightness_pct: "{{ range(65, 96) | random }}"
+                        transition: 0.2
                     - delay:
-                        milliseconds: "{{ range(300, 900) | random }}"
+                        milliseconds: "{{ range(120, 350) | random }}"
           - sequence:
               - delay:
-                  milliseconds: "{{ range(0, 700) | random }}"
+                  milliseconds: "{{ range(0, 300) | random }}"
               - repeat:
                   while:
                     - condition: state
@@ -198,16 +198,16 @@ script:
                         entity_id: light.door_lamp
                       data:
                         rgb_color:
-                          - "{{ range(200, 256) | random }}"
-                          - "{{ range(60, 130) | random }}"
-                          - "{{ range(0, 30) | random }}"
-                        brightness_pct: "{{ range(40, 101) | random }}"
-                        transition: 0.4
+                          - "{{ range(230, 256) | random }}"
+                          - "{{ range(85, 111) | random }}"
+                          - "{{ range(5, 21) | random }}"
+                        brightness_pct: "{{ range(65, 96) | random }}"
+                        transition: 0.2
                     - delay:
-                        milliseconds: "{{ range(300, 900) | random }}"
+                        milliseconds: "{{ range(120, 350) | random }}"
           - sequence:
               - delay:
-                  milliseconds: "{{ range(0, 700) | random }}"
+                  milliseconds: "{{ range(0, 300) | random }}"
               - repeat:
                   while:
                     - condition: state
@@ -219,16 +219,16 @@ script:
                         entity_id: light.desk_lamp_2
                       data:
                         rgb_color:
-                          - "{{ range(200, 256) | random }}"
-                          - "{{ range(60, 130) | random }}"
-                          - "{{ range(0, 30) | random }}"
-                        brightness_pct: "{{ range(40, 101) | random }}"
-                        transition: 0.4
+                          - "{{ range(230, 256) | random }}"
+                          - "{{ range(85, 111) | random }}"
+                          - "{{ range(5, 21) | random }}"
+                        brightness_pct: "{{ range(65, 96) | random }}"
+                        transition: 0.2
                     - delay:
-                        milliseconds: "{{ range(300, 900) | random }}"
+                        milliseconds: "{{ range(120, 350) | random }}"
           - sequence:
               - delay:
-                  milliseconds: "{{ range(0, 700) | random }}"
+                  milliseconds: "{{ range(0, 300) | random }}"
               - repeat:
                   while:
                     - condition: state
@@ -240,16 +240,16 @@ script:
                         entity_id: light.desk_lamp_2_2
                       data:
                         rgb_color:
-                          - "{{ range(200, 256) | random }}"
-                          - "{{ range(60, 130) | random }}"
-                          - "{{ range(0, 30) | random }}"
-                        brightness_pct: "{{ range(40, 101) | random }}"
-                        transition: 0.4
+                          - "{{ range(230, 256) | random }}"
+                          - "{{ range(85, 111) | random }}"
+                          - "{{ range(5, 21) | random }}"
+                        brightness_pct: "{{ range(65, 96) | random }}"
+                        transition: 0.2
                     - delay:
-                        milliseconds: "{{ range(300, 900) | random }}"
+                        milliseconds: "{{ range(120, 350) | random }}"
           - sequence:
               - delay:
-                  milliseconds: "{{ range(0, 700) | random }}"
+                  milliseconds: "{{ range(0, 300) | random }}"
               - repeat:
                   while:
                     - condition: state
@@ -261,13 +261,13 @@ script:
                         entity_id: light.table_lamp
                       data:
                         rgb_color:
-                          - "{{ range(200, 256) | random }}"
-                          - "{{ range(60, 130) | random }}"
-                          - "{{ range(0, 30) | random }}"
-                        brightness_pct: "{{ range(40, 101) | random }}"
-                        transition: 0.4
+                          - "{{ range(230, 256) | random }}"
+                          - "{{ range(85, 111) | random }}"
+                          - "{{ range(5, 21) | random }}"
+                        brightness_pct: "{{ range(65, 96) | random }}"
+                        transition: 0.2
                     - delay:
-                        milliseconds: "{{ range(300, 900) | random }}"
+                        milliseconds: "{{ range(120, 350) | random }}"
 
 automation:
   - id: sonoff_button_2_office_cycle


### PR DESCRIPTION
## Summary

Follow-up tuning for the de-synchronized Candle scene (#206). After watching the live result, the warm-amber band was too wide (colors swung from orange-red to yellow-brown), the brightness floor too low (40% reads as nearly-off relative to the peaks), and the tick interval too slow (median 600 ms reads as strobing, not flame).

Tighter:

| | Before | After |
|---|---|---|
| R | 200–255 | **230–255** |
| G | 60–129 | **85–110** |
| B | 0–29 | **5–20** |
| brightness_pct | 40–100 | **65–95** |

Faster:

| | Before | After |
|---|---|---|
| per-tick delay | 300–900 ms | **120–350 ms** |
| startup phase | 0–700 ms | **0–300 ms** |
| transition | 0.4 s | **0.2 s** |

Per-lamp independent loops and the random startup phase from #206 are preserved — the lamps still drift out of sync with each other, just within a tighter envelope and at a quicker cadence.

## Test plan

- [ ] Cycle to scene 6 (Candle) and watch for 30 s. Color stays in the warm-amber band (no sliding into red or yellow-green), brightness varies but never drops to "off-looking" dim, ticks read as flicker rather than strobing.
- [ ] Lamps remain visibly de-synchronized from each other.
- [ ] Cycle to any other scene → flicker stops cleanly.
- [ ] Cycle back to Candle → de-synchronizes again on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017mzYeJZ2zawiWAkAcw7QUp)_