### PR TITLE
tune(office): lock Candle to a single warm-amber hue, instant transitions

### DIFF
--- a/packages/sonoff_button_office.yaml
+++ b/packages/sonoff_button_office.yaml
@@ -24,10 +24,12 @@
 #
 # Every scene except Candle applies the same values to all six lamps
 # simultaneously — no per-lamp tiers. Candlelight runs six independent per-lamp
-# flicker loops in parallel, each with its own random RGB, brightness, tick
-# interval, and a random startup phase so the lamps don't all brighten or dim
-# on the same beat (unison flicker looks fake; phase-shifted flicker looks
-# like real candles).
+# flicker loops in parallel: each lamp holds a fixed warm-amber hue
+# (rgb 255,100,15) and only the brightness flickers, with a per-tick random
+# brightness in 65-95%, a per-tick random delay of 120-350ms, and a random
+# 0-300ms startup phase so the lamps don't all brighten or dim on the same
+# beat. Transitions are instant (transition: 0) so each tick reads as a
+# hard step — true flicker rather than a smooth pulse.
 #
 # Scene catalog:
 #   1 Bright    — all 6, 100% / 4000K  (general illumination)
@@ -155,12 +157,9 @@ script:
                       target:
                         entity_id: light.bookcase_lamp
                       data:
-                        rgb_color:
-                          - "{{ range(230, 256) | random }}"
-                          - "{{ range(85, 111) | random }}"
-                          - "{{ range(5, 21) | random }}"
+                        rgb_color: [255, 100, 15]
                         brightness_pct: "{{ range(65, 96) | random }}"
-                        transition: 0.2
+                        transition: 0
                     - delay:
                         milliseconds: "{{ range(120, 350) | random }}"
           - sequence:
@@ -176,12 +175,9 @@ script:
                       target:
                         entity_id: light.corner_lamp
                       data:
-                        rgb_color:
-                          - "{{ range(230, 256) | random }}"
-                          - "{{ range(85, 111) | random }}"
-                          - "{{ range(5, 21) | random }}"
+                        rgb_color: [255, 100, 15]
                         brightness_pct: "{{ range(65, 96) | random }}"
-                        transition: 0.2
+                        transition: 0
                     - delay:
                         milliseconds: "{{ range(120, 350) | random }}"
           - sequence:
@@ -197,12 +193,9 @@ script:
                       target:
                         entity_id: light.door_lamp
                       data:
-                        rgb_color:
-                          - "{{ range(230, 256) | random }}"
-                          - "{{ range(85, 111) | random }}"
-                          - "{{ range(5, 21) | random }}"
+                        rgb_color: [255, 100, 15]
                         brightness_pct: "{{ range(65, 96) | random }}"
-                        transition: 0.2
+                        transition: 0
                     - delay:
                         milliseconds: "{{ range(120, 350) | random }}"
           - sequence:
@@ -218,12 +211,9 @@ script:
                       target:
                         entity_id: light.desk_lamp_2
                       data:
-                        rgb_color:
-                          - "{{ range(230, 256) | random }}"
-                          - "{{ range(85, 111) | random }}"
-                          - "{{ range(5, 21) | random }}"
+                        rgb_color: [255, 100, 15]
                         brightness_pct: "{{ range(65, 96) | random }}"
-                        transition: 0.2
+                        transition: 0
                     - delay:
                         milliseconds: "{{ range(120, 350) | random }}"
           - sequence:
@@ -239,12 +229,9 @@ script:
                       target:
                         entity_id: light.desk_lamp_2_2
                       data:
-                        rgb_color:
-                          - "{{ range(230, 256) | random }}"
-                          - "{{ range(85, 111) | random }}"
-                          - "{{ range(5, 21) | random }}"
+                        rgb_color: [255, 100, 15]
                         brightness_pct: "{{ range(65, 96) | random }}"
-                        transition: 0.2
+                        transition: 0
                     - delay:
                         milliseconds: "{{ range(120, 350) | random }}"
           - sequence:
@@ -260,12 +247,9 @@ script:
                       target:
                         entity_id: light.table_lamp
                       data:
-                        rgb_color:
-                          - "{{ range(230, 256) | random }}"
-                          - "{{ range(85, 111) | random }}"
-                          - "{{ range(5, 21) | random }}"
+                        rgb_color: [255, 100, 15]
                         brightness_pct: "{{ range(65, 96) | random }}"
-                        transition: 0.2
+                        transition: 0
                     - delay:
                         milliseconds: "{{ range(120, 350) | random }}"
 


### PR DESCRIPTION
## Summary

Follow-up to #207. After watching the tightened-but-still-randomized version live, two things are wrong: (1) the RGB still varies enough to read as color-noise rather than candlelight — real candles don't shift hue, only intensity — and (2) the 0.2 s transition smooths each tick into a pulse rather than a flicker.

Changes:

- **Lock the hue.** All six lamps hold a fixed `rgb_color: [255, 100, 15]` (warm amber). The per-tick RGB randomization is removed entirely.
- **Instant transitions.** `transition: 0` so each brightness change is a hard step. This is what reads as flicker — smooth fades read as breathing.
- Brightness still flickers in the 65–95% band per lamp.
- Per-lamp independent loops, the random 0–300 ms startup phase, and the 120–350 ms per-tick delay are unchanged.

## Test plan

- [ ] Cycle to scene 6 (Candle). All six lamps the same warm-amber hue, no color variation between lamps or over time.
- [ ] Brightness clearly flickers — each tick a visible step, not a smooth pulse.
- [ ] Lamps remain visibly de-synchronized from each other.
- [ ] Cycle off scene 6 → flicker stops; cycle back → restarts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017mzYeJZ2zawiWAkAcw7QUp)_