### PR TITLE
perception: capture scripts, scenes, helpers, storage-mode dashboards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,9 +403,10 @@ durable, `git log`-greppable one. Both should agree.
 ## HA Runtime State Context (`context/`)
 
 The `context/` directory is an auto-generated, read-only snapshot of HA runtime
-state — entity registry, area registry, device registry, and the UI-editable
-`automations.yaml`. It is populated by `scripts/ha-context-dump.sh` and refreshed
-every 6 hours (or on manual button press) via the autonomous context-sync pipeline.
+state — entity registry, area registry, device registry, the UI-editable
+`automations.yaml`, plus storage-mode scripts, scenes, helpers, and dashboards.
+It is populated by `scripts/ha-context-dump.sh` and refreshed every 6 hours
+(or on manual button press) via the autonomous context-sync pipeline.
 
 **Before writing any automation, script, dashboard, or other config that references
 entity IDs, area IDs, or device IDs, consult the relevant `context/` files:**
@@ -418,6 +419,23 @@ entity IDs, area IDs, or device IDs, consult the relevant `context/` files:**
   Useful when an automation needs to scope to a particular hardware type.
 - `context/automations-ui.yaml` — UI-managed automations. Reference this to avoid
   proposing automations that duplicate existing UI-authored ones.
+- `context/scripts.json` — storage-mode scripts (e.g. anything prototyped via the
+  ha-mcp server into `.storage/script`). Consult before codifying a prototyped
+  script into a `packages/` file so the live definition is copied, not guessed.
+  Empty (`[]`) when the script integration is YAML-mode and nothing has been
+  prototyped; the canonical UI-mode source is then `/config/scripts.yaml`.
+- `context/scenes.json` — storage-mode scenes. Same conventions as
+  `context/scripts.json`. YAML-mode fallback is `/config/scenes.yaml`.
+- `context/helpers.json` — object keyed by helper domain (`input_boolean`,
+  `input_number`, `input_text`, `input_select`, `input_datetime`, `timer`,
+  `counter`, `schedule`). Consult before referencing a helper entity in
+  automation YAML, and before proposing a new helper that might already exist.
+- `context/dashboards-storage.json` — storage-mode Lovelace dashboards
+  (`dashboards` registry + per-dashboard `configs`). The three YAML dashboards
+  this repo ships (`dashboards/home.yaml`, `dashboards/kiosk.yaml`,
+  `dashboards/homelab-status.yaml`) are NOT captured here — git is already
+  their source of truth. This artifact captures dashboards created or modified
+  via the HA UI that may need codifying into `dashboards/*.yaml`.
 
 **Never modify files in `context/`.** They are overwritten on the next snapshot.
 If a stale entity_id appears there, the fix is to correct the source of truth
@@ -459,8 +477,29 @@ that might duplicate or conflict):
 
     grep -A 20 "light.meeting_light" context/automations-ui.yaml
 
-`context/areas.json` and `context/automations-ui.yaml` are small enough (<150KB
-combined) that reading them in full is fine when needed.
+**List all helpers of a given domain** (before proposing a new one):
+
+    jq '.input_boolean[] | .id' context/helpers.json
+    jq '.timer[]' context/helpers.json
+
+**Check whether a helper id is already taken:**
+
+    jq '[.[][] | .id] | index("guest_mode")' context/helpers.json
+
+**Look up a storage-mode script or scene by alias:**
+
+    jq '.[] | select(.alias == "Morning routine")' context/scripts.json
+    jq '.[] | select(.name == "Movie night")' context/scenes.json
+
+**List storage-mode dashboards** (anything that may need codifying into
+`dashboards/*.yaml`):
+
+    jq '.dashboards[] | {url_path, title}' context/dashboards-storage.json
+
+`context/areas.json`, `context/automations-ui.yaml`, `context/scripts.json`,
+`context/scenes.json`, `context/helpers.json`, and (typically)
+`context/dashboards-storage.json` are small enough that reading them in full is
+fine when needed.
 
 ### Handling stale or missing context
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,17 @@ Seven sections:
 ├── packages/
 │   └── ha_version_sync.yaml  HA version dispatch to GitHub on startup
 ├── scripts/
-│   └── gitops-sync.sh        GitOps deploy: fetch → validate → smart reload or rollback
+│   ├── gitops-sync.sh        GitOps deploy: fetch → validate → smart reload or rollback
+│   └── ha-context-dump.sh    Perception loop: snapshot .storage/ registries to context/
+├── context/                  Auto-generated HA runtime state (read-only, never edit)
+│   ├── entities.json         Entity registry (entity_id → area/device/platform)
+│   ├── areas.json            Area registry
+│   ├── devices.json          Device registry joined with config_entries
+│   ├── automations-ui.yaml   UI-authored automations snapshot
+│   ├── scripts.json          Storage-mode scripts (populated by ha-mcp prototyping)
+│   ├── scenes.json           Storage-mode scenes
+│   ├── helpers.json          Helpers by domain (input_*, timer, counter, schedule)
+│   └── dashboards-storage.json  Storage-mode Lovelace dashboards
 ├── dashboards/
 │   ├── home.yaml             Mobile/tablet Home dashboard
 │   ├── kiosk.yaml            Kiosk wall-display dashboard (custom:grid-layout)

--- a/context/README.md
+++ b/context/README.md
@@ -15,6 +15,10 @@ pipeline (see `.github/workflows/ha-context-sync.yml`).
 | `areas.json` | `.storage/core.area_registry` | Sorted JSON array of areas with `area_id`, `name`. |
 | `devices.json` | `.storage/core.device_registry` joined with `.storage/core.config_entries` | Sorted JSON array of devices with `device_id`, `name`, `manufacturer`, `model`, `area_id`, `integrations` (array of integration domains). |
 | `automations-ui.yaml` | `/config/automations.yaml` | Byte-for-byte snapshot of the UI-editable automations file. |
+| `scripts.json` | `.storage/script` | Sorted JSON array of storage-mode script definitions. Empty (`[]`) when the script integration is YAML-mode (UI editor writes to `/config/scripts.yaml`). Populated when ha-mcp prototypes scripts into `.storage/`. |
+| `scenes.json` | `.storage/scenes` | Sorted JSON array of storage-mode scene definitions. Empty (`[]`) when the scene integration is YAML-mode (`/config/scenes.yaml`). |
+| `helpers.json` | `.storage/{input_boolean,input_number,input_text,input_select,input_datetime,timer,counter,schedule}` | Object keyed by helper domain, each value a sorted JSON array of helper items. Missing-domain values are `[]` so the shape is presence-stable across instances. |
+| `dashboards-storage.json` | `.storage/lovelace_dashboards`, `.storage/lovelace`, `.storage/lovelace.*` | Object with `dashboards` (registry of storage-mode dashboards) and `configs` (per-dashboard config keyed by storage filename). YAML-mode dashboards under `dashboards/*.yaml` are NOT captured here — they're already source-of-truth in git. |
 
 ## Refresh cadence
 

--- a/scripts/ha-context-dump.sh
+++ b/scripts/ha-context-dump.sh
@@ -30,6 +30,18 @@ rotate_log() {
   fi
 }
 
+# Read the items array from a storage-collection-style .storage file
+# (shape: {data: {items: [...]}}). Emit [] if the file is absent so
+# downstream artifacts are always well-formed and presence-stable.
+storage_items() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    jq '.data.items // [] | sort_by(.id // "")' "$path"
+  else
+    printf '[]\n'
+  fi
+}
+
 main() {
   rotate_log
   log INFO "Starting HA context dump"
@@ -106,6 +118,65 @@ main() {
 
   log INFO "Copying automations-ui.yaml"
   cp /config/automations.yaml "${CONTEXT_DIR}/automations-ui.yaml"
+
+  # Storage-mode scripts. The script integration is YAML-mode on this instance
+  # (UI editor writes to /config/scripts.yaml), so .storage/script typically
+  # does not exist and the artifact will be []. When the ha-mcp server begins
+  # prototyping scripts into .storage/, this captures them automatically.
+  log INFO "Building scripts.json"
+  storage_items "${STORAGE}/script" > "${CONTEXT_DIR}/scripts.json"
+
+  # Storage-mode scenes. Same caveat as scripts — scene integration is YAML-mode
+  # by default (/config/scenes.yaml), so the artifact is typically [].
+  log INFO "Building scenes.json"
+  storage_items "${STORAGE}/scenes" > "${CONTEXT_DIR}/scenes.json"
+
+  # Helpers — single combined artifact for reviewability. Each helper integration
+  # uses its domain name as the storage key (e.g. .storage/input_boolean). The
+  # output is an object keyed by helper type so a single jq query can list all
+  # helpers of a given kind.
+  log INFO "Building helpers.json"
+  local helpers='{}'
+  local helper_types=(
+    input_boolean
+    input_number
+    input_text
+    input_select
+    input_datetime
+    timer
+    counter
+    schedule
+  )
+  for t in "${helper_types[@]}"; do
+    local items
+    items=$(storage_items "${STORAGE}/${t}")
+    helpers=$(jq --argjson items "$items" --arg key "$t" '. + {($key): $items}' <<<"$helpers")
+  done
+  printf '%s\n' "$helpers" > "${CONTEXT_DIR}/helpers.json"
+
+  # Storage-mode Lovelace dashboards. The dashboard registry lives at
+  # .storage/lovelace_dashboards; the default dashboard config is .storage/lovelace
+  # and additional storage-mode dashboards are .storage/lovelace.<url_path>.
+  # YAML-mode dashboards (this repo's home/kiosk/homelab-status) are not stored
+  # in .storage/ — they remain in dashboards/*.yaml and are absent here.
+  log INFO "Building dashboards-storage.json"
+  local dashboards_registry
+  dashboards_registry=$(storage_items "${STORAGE}/lovelace_dashboards")
+  local configs='{}'
+  if [[ -f "${STORAGE}/lovelace" ]]; then
+    configs=$(jq --slurpfile lv "${STORAGE}/lovelace" \
+      '. + {lovelace: ($lv[0].data.config // {})}' <<<"$configs")
+  fi
+  shopt -s nullglob
+  for f in "${STORAGE}"/lovelace.*; do
+    local key
+    key=$(basename "$f")
+    configs=$(jq --slurpfile lv "$f" --arg key "$key" \
+      '. + {($key): ($lv[0].data.config // {})}' <<<"$configs")
+  done
+  shopt -u nullglob
+  jq -n --argjson dashboards "$dashboards_registry" --argjson configs "$configs" \
+    '{dashboards: $dashboards, configs: $configs}' > "${CONTEXT_DIR}/dashboards-storage.json"
 
   # Check for diff — most common case is no change
   if [[ -z "$(git -C "$WORKTREE" status --porcelain context/)" ]]; then


### PR DESCRIPTION
Extends `scripts/ha-context-dump.sh` with four new `context/` artifacts so Claude Code has a current source of truth when codifying features prototyped via the upcoming ha-mcp server. Match the existing patterns (worktree, force-reset, dispatch flow, idempotent silent-no-op).

## Origin

Card 0 from the MCP server rollout plan. The perception loop currently snapshots four artifacts (`entities.json`, `areas.json`, `devices.json`, `automations-ui.yaml`). Once ha-mcp lands and starts prototyping config into `.storage/`, CC needs to see those prototypes in `context/` to translate them into `packages/` files. The card asks for four new artifacts (`scripts.json`, `scenes.json`, combined `helpers.json`, combined `dashboards-storage.json`), each read from the standard HA `.storage/` paths, all emitted as empty-but-well-formed JSON when the source file is absent so the set of files in `context/` is presence-stable across instances. No new dependencies (bash/jq/git/curl only), no cadence change, no workflow changes. Update `README.md` and `CLAUDE.md` to document the new artifacts and lookup recipes.

## What changed

- **`scripts/ha-context-dump.sh`** — adds a `storage_items()` helper and four new emission blocks after the existing `automations-ui.yaml` copy:
  - `context/scripts.json` ← `.storage/script` (or `[]`)
  - `context/scenes.json` ← `.storage/scenes` (or `[]`)
  - `context/helpers.json` ← combined object of `.storage/{input_boolean,input_number,input_text,input_select,input_datetime,timer,counter,schedule}` keyed by domain
  - `context/dashboards-storage.json` ← `.storage/lovelace_dashboards` (registry) + `.storage/lovelace` and `.storage/lovelace.*` (configs)
- **`context/README.md`** — table extended with the four new artifacts.
- **`CLAUDE.md`** — `HA Runtime State Context` section now describes all eight artifacts; adds jq recipes for helpers / scripts / scenes / dashboards-storage lookups.
- **`README.md`** — file-structure tree gains a `context/` block listing all artifacts.

## Storage-path notes

The guide flagged that paths might diverge from what HA actually writes; here's what I held to and why:

- **Scripts (`.storage/script`) and scenes (`.storage/scenes`):** in HA these integrations are typically YAML-mode (`scripts.yaml`/`scenes.yaml`) and the `.storage/` files don't exist until something writes them. The script emits `[]` in that case. When ha-mcp starts prototyping scripts into `.storage/script`, this captures them automatically with no code change. Documented in both `context/README.md` and `CLAUDE.md` so future CC sessions know the YAML-mode fallback paths (`/config/scripts.yaml`, `/config/scenes.yaml`).
- **Helpers (`.storage/{input_boolean,...}`):** these use the helper domain name directly as the storage key — no `core.` prefix. Combined into a single object for reviewability per the card spec.
- **Dashboards (`.storage/lovelace_dashboards`, `.storage/lovelace`, `.storage/lovelace.*`):** registry plus per-dashboard configs. This repo's three YAML-mode dashboards are NOT captured here — git is already their source of truth.

I could not `ls /config/.storage/` from this dev environment (the script runs on the HAOS VM, not here), so the paths follow HA's documented storage-key conventions. If anything diverges on the running instance, the empty-array fallback keeps the artifact well-formed and we can adjust the path in a follow-up.

## Validation

- `bash -n scripts/ha-context-dump.sh` — syntax OK
- `shellcheck --severity=warning` — clean (also clean at default severity)
- Synthesized fixture `.storage/` files under `/tmp` and ran the new emission logic end-to-end:
  - `scripts.json` and `scenes.json` → `[]` when source absent
  - `helpers.json` → object with `input_boolean` and `timer` populated, the other six keys = `[]`, items sorted by `id`
  - `dashboards-storage.json` → registry array + `configs.lovelace.prototyping`
- Back-to-back invocation produced byte-identical output (idempotent — would not trigger a PR on the second run).
- A real first-run on the HAOS VM should add the four new files to `context/` (sizes ~10–200B depending on what's in `.storage/`), open one snapshot PR, then go quiet on subsequent runs until `.storage/` changes.

## Test plan

- [ ] `ha-config-check` CI gate passes (the script isn't validated by `check_config`, so this should be unaffected)
- [ ] After merge, press `input_button.ha_context_dump_now` and confirm `/config/ha-context-dump.log` shows the four new "Building X.json" log lines
- [ ] Confirm the four new files appear in the resulting context-snapshot PR (or, if `.storage/` already matches expectations, that nothing diffs)
- [ ] Manually press the dump button a second time and confirm no new PR opens

## Out of scope (per Card 0)

- No webhook-driven triggers from ha-mcp writes
- No cadence change (6h periodic + manual button stay)
- No changes to `.github/workflows/ha-context-sync.yml`
- No `.gitignore` changes


---
_Generated by [Claude Code](https://claude.ai/code/session_018scxyoQb7dcrbHjLokck27)_