### PR TITLE
Read HA access token from secrets.yaml; explain LLAT requirement

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -42,16 +42,44 @@ runs, the next `ha-context-dump.sh` snapshot picks the dashboard up in
 `context/dashboards-storage.json`, which makes it visible to assistants
 working against `context/`.
 
-Must run inside the HA Core container (so `SUPERVISOR_TOKEN`, `aiohttp`, and
-`PyYAML` are available):
+Must run inside the HA Core container (Python 3, `aiohttp`, and `PyYAML` are
+part of Core's runtime; the SSH add-on's Alpine shell has none of them):
 
 ```bash
 docker exec homeassistant /config/scripts/import-home-to-storage.sh
 ```
 
-Overridable via env vars: `SOURCE_YAML`, `URL_PATH`, `TITLE`, `ICON`,
-`HA_WS_URL`. Idempotent — re-running overwrites the saved config but does not
-duplicate the registry entry. The git-managed `dashboards/home.yaml` and its
-`lovelace.dashboards` registration in `configuration.yaml` are left in place;
-both dashboards coexist (`/dashboard-home/home` from YAML, `/home-ui` from
-storage) until cutover is decided.
+### Authentication
+
+Core's websocket auth does NOT accept `SUPERVISOR_TOKEN` in current HA
+versions (that token is for outbound Core-to-Supervisor calls, not inbound
+Core API). A long-lived access token is required:
+
+1. In the HA UI: profile avatar (bottom-left) → **Security** tab →
+   **Long-Lived Access Tokens** → **Create Token** → copy the value (shown
+   only once).
+2. Add it to `/config/secrets.yaml` so future runs need no env flag:
+   ```yaml
+   ha_token: "Bearer <paste-the-token-here>"
+   ```
+   The `Bearer ` prefix matches the project convention for stored
+   Authorization header values (see CLAUDE.md > "Script auth conventions").
+   The script strips the prefix before sending to the websocket.
+
+The script resolves the token in this order: `HA_TOKEN` env var → `ha_token`
+in `secrets.yaml` → `SUPERVISOR_TOKEN` (last-resort fallback that will
+almost certainly fail). For a one-shot run without modifying `secrets.yaml`:
+
+```bash
+docker exec -e HA_TOKEN='<paste-token-here>' homeassistant /config/scripts/import-home-to-storage.sh
+```
+
+### Overrides and behavior
+
+Env vars: `SOURCE_YAML`, `URL_PATH`, `TITLE`, `ICON`, `HA_WS_URL`,
+`SECRETS_YAML`, `HA_TOKEN`. Idempotent — re-running overwrites the saved
+config but does not duplicate the registry entry. The git-managed
+`dashboards/home.yaml` and its `lovelace.dashboards` registration in
+`configuration.yaml` are left in place; both dashboards coexist
+(`/dashboard-home/home` from YAML, `/home-ui` from storage) until cutover
+is decided.

--- a/scripts/import-home-to-storage.sh
+++ b/scripts/import-home-to-storage.sh
@@ -3,11 +3,21 @@
 # Lovelace dashboard at url_path /home-ui, so that ha-context-dump.sh
 # captures it under context/dashboards-storage.json.
 #
-# Run inside the HA Core container (SUPERVISOR_TOKEN is injected, and
-# both aiohttp and PyYAML are part of Core's runtime). Examples:
+# Run inside the HA Core container (Python 3, aiohttp, and PyYAML are
+# part of Core's runtime):
 #
 #   docker exec homeassistant /config/scripts/import-home-to-storage.sh
-#   ha core exec /config/scripts/import-home-to-storage.sh   # if exposed
+#
+# Token resolution order (first non-empty wins):
+#   1. HA_TOKEN env var (one-shot override)
+#   2. ha_token from /config/secrets.yaml (preferred, follows the project
+#      convention of storing complete Authorization header values; see
+#      CLAUDE.md > "Script auth conventions")
+#   3. SUPERVISOR_TOKEN env var (last resort — current HA versions reject
+#      it on the Core websocket auth path; the script will still try)
+#
+# A leading "Bearer " prefix is stripped automatically so the value can
+# be stored in the same form rest_command consumers expect.
 #
 # Idempotent: re-running overwrites the saved config but does not
 # duplicate the dashboard registry entry.
@@ -19,16 +29,45 @@ readonly URL_PATH="${URL_PATH:-home-ui}"
 readonly TITLE="${TITLE:-Home (UI)}"
 readonly ICON="${ICON:-mdi:home-variant}"
 readonly HA_WS_URL="${HA_WS_URL:-ws://127.0.0.1:8123/api/websocket}"
+readonly SECRETS_YAML="${SECRETS_YAML:-/config/secrets.yaml}"
 
 if [[ ! -f "$SOURCE_YAML" ]]; then
     echo "error: source dashboard not found: $SOURCE_YAML" >&2
     exit 1
 fi
 
-if [[ -z "${SUPERVISOR_TOKEN:-}" && -z "${HA_TOKEN:-}" ]]; then
-    echo "error: SUPERVISOR_TOKEN (preferred) or HA_TOKEN must be set" >&2
-    echo "       run this from inside the homeassistant Core container, e.g." >&2
-    echo "       docker exec homeassistant $0" >&2
+token=""
+token_source=""
+if [[ -n "${HA_TOKEN:-}" ]]; then
+    token=$HA_TOKEN
+    token_source="HA_TOKEN env var"
+elif [[ -f "$SECRETS_YAML" ]]; then
+    secret=$(awk -F'"' '/^ha_token:/ {print $2; exit}' "$SECRETS_YAML")
+    if [[ -n "$secret" && "$secret" != "CHANGE_ME" && "$secret" != "Bearer CHANGE_ME" ]]; then
+        token=$secret
+        token_source="ha_token from $SECRETS_YAML"
+    fi
+fi
+if [[ -z "$token" && -n "${SUPERVISOR_TOKEN:-}" ]]; then
+    token=$SUPERVISOR_TOKEN
+    token_source="SUPERVISOR_TOKEN env var (fallback)"
+fi
+token="${token#Bearer }"
+
+if [[ -z "$token" ]]; then
+    cat >&2 <<MSG
+error: no Home Assistant access token found.
+
+Create a long-lived access token in the HA UI:
+    profile (bottom-left avatar) -> Security tab
+    -> Long-Lived Access Tokens -> Create Token
+
+Then either (preferred) add it to ${SECRETS_YAML}:
+    ha_token: "Bearer <paste-the-token-here>"
+
+...or pass it once via env:
+    docker exec -e HA_TOKEN='<paste-here>' homeassistant $0
+MSG
     exit 1
 fi
 
@@ -37,7 +76,9 @@ export _IMPORT_URL_PATH="$URL_PATH"
 export _IMPORT_TITLE="$TITLE"
 export _IMPORT_ICON="$ICON"
 export _IMPORT_WS_URL="$HA_WS_URL"
-export _IMPORT_TOKEN="${SUPERVISOR_TOKEN:-$HA_TOKEN}"
+export _IMPORT_TOKEN="$token"
+export _IMPORT_TOKEN_SOURCE="$token_source"
+export _IMPORT_SECRETS_YAML="$SECRETS_YAML"
 
 python3 <<'PY'
 import asyncio
@@ -53,10 +94,28 @@ TITLE = os.environ["_IMPORT_TITLE"]
 ICON = os.environ["_IMPORT_ICON"]
 WS_URL = os.environ["_IMPORT_WS_URL"]
 TOKEN = os.environ["_IMPORT_TOKEN"]
+TOKEN_SOURCE = os.environ["_IMPORT_TOKEN_SOURCE"]
+SECRETS_YAML = os.environ["_IMPORT_SECRETS_YAML"]
 
 
 with open(SOURCE_YAML) as fh:
     dashboard_config = yaml.safe_load(fh)
+
+
+def fail_auth(resp):
+    lines = [f"auth failed (token from {TOKEN_SOURCE}): {resp}"]
+    if "SUPERVISOR_TOKEN" in TOKEN_SOURCE:
+        lines += [
+            "",
+            "SUPERVISOR_TOKEN is the token Core uses to call OUT to Supervisor;",
+            "current HA versions do not accept it for the Core websocket auth path.",
+            "",
+            "Fix: create a long-lived access token in the HA UI",
+            "(profile avatar -> Security -> Long-Lived Access Tokens -> Create), then add:",
+            f'    ha_token: "Bearer <paste-the-token-here>"',
+            f"to {SECRETS_YAML} and re-run.",
+        ]
+    sys.exit("\n".join(lines))
 
 
 async def call(ws, msg_id, payload):
@@ -79,8 +138,9 @@ async def main():
             await ws.send_json({"type": "auth", "access_token": TOKEN})
             auth_resp = await ws.receive_json()
             if auth_resp.get("type") != "auth_ok":
-                sys.exit(f"auth failed: {auth_resp}")
+                fail_auth(auth_resp)
 
+            print(f"authenticated via {TOKEN_SOURCE}")
             msg_id = 1
 
             list_resp = await call(ws, msg_id, {"type": "lovelace/dashboards/list"})

--- a/secrets.yaml.example
+++ b/secrets.yaml.example
@@ -5,4 +5,8 @@ api_key_secondary_panel: "CHANGE_ME"
 wifi_ssid: "CHANGE_ME"
 wifi_password: "CHANGE_ME"
 github_pat: "CHANGE_ME"
+# Home Assistant long-lived access token (Profile -> Security -> Long-Lived Access Tokens).
+# Used by scripts/import-home-to-storage.sh to authenticate against Core's websocket API.
+# Stored as the full Authorization header value, matching the github_pat convention.
+ha_token: "Bearer CHANGE_ME"
 trusted_network: "CHANGE_ME"  # Local subnet in CIDR notation, e.g. 10.0.0.0/24


### PR DESCRIPTION
## Origin

After PR #217 merged and Chris ran the import script in-container via
`docker exec homeassistant /config/scripts/import-home-to-storage.sh`,
Core returned `auth_invalid` — `SUPERVISOR_TOKEN` is the token Core
uses to call OUT to Supervisor, and current HA versions do not accept
it on the inbound Core websocket auth path. Chris asked me to (a)
have the script read the HA token from `secrets.yaml` so future runs
don't need an env flag, and (b) improve the error message and README
so the LLAT requirement is discoverable instead of a surprise — both,
unless the latter makes the former redundant. It doesn't: the
`secrets.yaml` path covers the configured case, the better errors
cover the unconfigured/misconfigured case.

## Summary

- **Token resolution order** (first non-empty wins):
  1. `HA_TOKEN` env var — one-shot override
  2. `ha_token` from `/config/secrets.yaml` — preferred; matches the
     project convention of storing complete Authorization header
     values (see CLAUDE.md > "Script auth conventions")
  3. `SUPERVISOR_TOKEN` env var — last-resort fallback, with a
     follow-up error explaining why it usually fails
- A leading `Bearer ` prefix on the resolved token is stripped before
  the websocket auth message so the secret can be stored in the same
  form `rest_command` consumers expect.
- **"No token found" error** now spells out the LLAT creation flow
  (Profile → Security → Long-Lived Access Tokens → Create) and shows
  both ways to feed the token to the script.
- **`auth_invalid` follow-up** when `SUPERVISOR_TOKEN` was the source
  prints a clear explanation of why that token isn't accepted and how
  to set up the `ha_token` secret instead.
- **`secrets.yaml.example`** adds the new `ha_token: "Bearer CHANGE_ME"`
  key with a comment.
- **`scripts/README.md`** adds an **Authentication** section with the
  LLAT steps, the `secrets.yaml` format, and the env-var one-shot.

## Verification

Pipe-tested the bash preamble against 9 token-resolution paths in an
isolated `env -i` shell:

| Scenario                                | rc | Resolved source                |
| --------------------------------------- | -- | ------------------------------ |
| `HA_TOKEN=foo` (bare)                   | 0  | HA_TOKEN env var               |
| `HA_TOKEN="Bearer foo"`                 | 0  | HA_TOKEN env var (prefix strip)|
| only secrets.yaml has `ha_token`        | 0  | ha_token from secrets.yaml     |
| no secrets, only `SUPERVISOR_TOKEN`     | 0  | SUPERVISOR_TOKEN (fallback)    |
| no token anywhere                       | 1  | "no token found" error         |
| secrets has `CHANGE_ME`, no env         | 1  | rejected, "no token" error     |
| secrets `CHANGE_ME` + `SUPERVISOR_TOKEN`| 0  | SUPERVISOR_TOKEN (fallback)    |
| both env + secrets set                  | 0  | HA_TOKEN env var (precedence)  |

Bash and embedded Python both pass syntax checks.

## Test plan

- [ ] CI: `YAML Lint` passes
- [ ] CI: `claude-review` passes
- [ ] Create an LLAT in HA UI, add `ha_token: "Bearer <token>"` to `/config/secrets.yaml`
- [ ] Run `docker exec homeassistant /config/scripts/import-home-to-storage.sh`; expect `authenticated via ha_token from /config/secrets.yaml` followed by the registration + save lines
- [ ] Press `input_button.ha_context_dump_now`, confirm `home-ui` shows up in `context/dashboards-storage.json`
- [ ] Without `ha_token` in `secrets.yaml` and no env vars, verify the script exits 1 with the LLAT setup instructions

---
_Generated by [Claude Code](https://claude.ai/code/session_016fztF5Pu2JnMApE8GNRwdW)_