### PR TITLE
Mirror Zooz ZEN77 office switch to all office bulbs

### DIFF
--- a/automations/office_switch.yaml
+++ b/automations/office_switch.yaml
@@ -1,0 +1,55 @@
+- id: office_switch_mirror
+  alias: 'Office Switch: mirror to office lights'
+  description: >
+    Mirrors the Zooz ZEN77 office switch (light.office_switch) onto every smart
+    bulb in the office. Single tap on/off and paddle hold-to-dim are handled by
+    the ZEN77 itself; this automation propagates the resulting state and
+    brightness to the individual bulbs so one paddle controls the whole room.
+  triggers:
+    - entity_id: light.office_switch
+      trigger: state
+  conditions:
+    - condition: template
+      value_template: >-
+        {{ trigger.to_state.state in ['on', 'off']
+           and (trigger.from_state is none
+                or trigger.to_state.state != trigger.from_state.state
+                or trigger.to_state.attributes.get('brightness')
+                   != trigger.from_state.attributes.get('brightness')) }}
+  actions:
+    - choose:
+        - conditions:
+            - condition: state
+              entity_id: light.office_switch
+              state: 'on'
+          sequence:
+            - action: light.turn_on
+              target:
+                entity_id:
+                  - light.bookcase_lamp
+                  - light.corner_lamp
+                  - light.desk_lamp_2
+                  - light.desk_lamp_2_2
+                  - light.door_lamp
+                  - light.table_lamp
+              data:
+                brightness: >-
+                  {{ state_attr('light.office_switch', 'brightness') | int(255) }}
+                transition: 1
+        - conditions:
+            - condition: state
+              entity_id: light.office_switch
+              state: 'off'
+          sequence:
+            - action: light.turn_off
+              target:
+                entity_id:
+                  - light.bookcase_lamp
+                  - light.corner_lamp
+                  - light.desk_lamp_2
+                  - light.desk_lamp_2_2
+                  - light.door_lamp
+                  - light.table_lamp
+              data:
+                transition: 1
+  mode: restart


### PR DESCRIPTION
Makes the new Zooz ZEN77 (`light.office_switch`) drive every smart bulb in the office.

## Origin

> I have a new zwave office switch in place. Have it fully control my office lights please.

## What changed

New file `automations/office_switch.yaml` with one automation, `office_switch_mirror`:

- Triggers on any state change of `light.office_switch`
- Fires only when the new state is `on` or `off` (skips `unavailable` / `unknown`) and the on/off state or the brightness attribute actually changed
- When the ZEN77 is on, calls `light.turn_on` against the six office bulbs (`light.bookcase_lamp`, `light.corner_lamp`, `light.desk_lamp_2`, `light.desk_lamp_2_2`, `light.door_lamp`, `light.table_lamp`) with the ZEN77's current brightness and a 1s transition
- When the ZEN77 is off, calls `light.turn_off` on the same six bulbs with a 1s transition
- `mode: restart` so a paddle hold that streams brightness updates always lands on the latest target

The ZEN77 itself handles single-tap on/off and paddle hold-to-dim natively; this automation just propagates the result to the bulbs so one paddle controls the whole room.

## Why

The new ZEN77 was adopted into HA but had no behavior tied to it. The user wants it to "fully control" the office lights — the simplest, most predictable mapping is to treat the dimmer as the source of truth for room on/off + brightness and mirror it to the individual bulbs.

## Notes

- Scene events (`event.office_switch_scene_001`/`_002`) are left untouched — multi-tap and hold-released gestures are available for future scene-style features but aren't bound yet.
- The bulb list is explicit rather than `area_id: office` to avoid feedback when the ZEN77 itself is in the office area.
- The pre-existing storage-mode `script.office_switch_set_mode_*` scripts are unrelated (Zigbee mode-flip experiments on the older ZHA office switch) and are not touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AGFx418yjvVWgb4zy6rk9p)_