### PR TITLE
Fix meeting light automations after Hue→ZHA migration

### DIFF
--- a/automations/meeting.yaml
+++ b/automations/meeting.yaml
@@ -15,7 +15,7 @@
       brightness: 255
       transition: 1
     target:
-      device_id: caa9c445375f8b67c1a29b11c8ae61c3
+      entity_id: light.meeting_light
   mode: single
 - id: meeting_status_off
   alias: 'Meeting: Status OFF — hallway green'
@@ -29,7 +29,7 @@
     data:
       transition: 1
     target:
-      device_id: caa9c445375f8b67c1a29b11c8ae61c3
+      entity_id: light.meeting_light
   mode: single
 - id: meeting_button_offline
   alias: 'Meeting: Button offline — hallway off'
@@ -43,7 +43,7 @@
   actions:
   - action: light.turn_off
     target:
-      device_id: caa9c445375f8b67c1a29b11c8ae61c3
+      entity_id: light.meeting_light
     data:
       transition: 2
   mode: single
@@ -70,7 +70,7 @@
           brightness: 255
           transition: 1
         target:
-          device_id: caa9c445375f8b67c1a29b11c8ae61c3
+          entity_id: light.meeting_light
     - conditions:
       - condition: state
         entity_id: switch.meeting_button_in_meeting
@@ -80,5 +80,5 @@
         data:
           transition: 1
         target:
-          device_id: caa9c445375f8b67c1a29b11c8ae61c3
+          entity_id: light.meeting_light
   mode: single


### PR DESCRIPTION
Retarget the four meeting-light automations from the stale Hue device_id to `entity_id: light.meeting_light` so the slap button drives the bulb again.

## Origin

> Please diagnose and fix my meeting light automation - it's not working. I can see in the UI it was triggered by the slap button but the light remains inactive. It's powered on, though, and can be operated by hand. I recently dropped my hue hub in favor or zha, so it's probably fallout from that. Do whatcha can!

## What was wrong

All four automations in `automations/meeting.yaml` targeted device_id `caa9c445375f8b67c1a29b11c8ae61c3` — the old Hue device. When the bulb was re-paired through ZHA, HA assigned it a new device_id (`03ebc1371a65dd35fbc10846dd9811ce`, per `context/devices.json`). Triggers were firing on the slap button, but `light.turn_on`/`light.turn_off` had no valid target, so the bulb never reacted.

## Fix

Swap every `target.device_id: caa9c44...` for `target.entity_id: light.meeting_light`. The entity name survived the integration swap (confirmed via `context/entities.json`) and entity-targeting is more resilient if the bulb is ever migrated again.

Touches: `meeting_status_on`, `meeting_status_off`, `meeting_button_offline`, `meeting_button_reconnect`.

## Test plan

- [ ] After merge + GitOps sync, slap button ON → hallway light goes red
- [ ] Slap button OFF → hallway light turns off
- [ ] Unplug button >10s → hallway light turns off
- [ ] Re-plug button → hallway re-syncs to current button state

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7z8HfXLoLZaaVMBc21Wod)_