### PR TITLE
Fix kiosk dashboard: replace stale entities, tighten typography

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -552,10 +552,10 @@ views:
                   - color: 'var(--kiosk-text-secondary)'
                   - padding-top: '8px'
                 state:
-                  - font-size: '24px'
+                  - font-size: '22px'
                   - text-transform: 'uppercase'
                   - font-weight: '600'
-                  - letter-spacing: '1px'
+                  - letter-spacing: '0.5px'
                   - padding-top: '4px'
 
             - type: custom:button-card
@@ -596,10 +596,10 @@ views:
                   - color: 'var(--kiosk-text-secondary)'
                   - padding-top: '8px'
                 state:
-                  - font-size: '24px'
+                  - font-size: '22px'
                   - text-transform: 'uppercase'
                   - font-weight: '600'
-                  - letter-spacing: '1px'
+                  - letter-spacing: '0.5px'
                   - padding-top: '4px'
 
             - type: custom:button-card
@@ -640,10 +640,10 @@ views:
                   - color: 'var(--kiosk-text-secondary)'
                   - padding-top: '8px'
                 state:
-                  - font-size: '24px'
+                  - font-size: '22px'
                   - text-transform: 'uppercase'
                   - font-weight: '600'
-                  - letter-spacing: '1px'
+                  - letter-spacing: '0.5px'
                   - padding-top: '4px'
 
             - type: custom:button-card
@@ -684,10 +684,10 @@ views:
                   - color: 'var(--kiosk-text-secondary)'
                   - padding-top: '8px'
                 state:
-                  - font-size: '24px'
+                  - font-size: '22px'
                   - text-transform: 'uppercase'
                   - font-weight: '600'
-                  - letter-spacing: '1px'
+                  - letter-spacing: '0.5px'
                   - padding-top: '4px'
 
             # === Garage door covers (state: closed/open) ===
@@ -733,10 +733,10 @@ views:
                   - color: 'var(--kiosk-text-secondary)'
                   - padding-top: '8px'
                 state:
-                  - font-size: '24px'
+                  - font-size: '22px'
                   - text-transform: 'uppercase'
                   - font-weight: '600'
-                  - letter-spacing: '1px'
+                  - letter-spacing: '0.5px'
                   - padding-top: '4px'
 
             - type: custom:button-card
@@ -781,10 +781,10 @@ views:
                   - color: 'var(--kiosk-text-secondary)'
                   - padding-top: '8px'
                 state:
-                  - font-size: '24px'
+                  - font-size: '22px'
                   - text-transform: 'uppercase'
                   - font-weight: '600'
-                  - letter-spacing: '1px'
+                  - letter-spacing: '0.5px'
                   - padding-top: '4px'
 
             # === Motion sensors (binary_sensor; on=detected=red pulse, off=clear=gray) ===
@@ -821,10 +821,10 @@ views:
                   - color: 'var(--kiosk-text-secondary)'
                   - padding-top: '8px'
                 state:
-                  - font-size: '24px'
+                  - font-size: '22px'
                   - text-transform: 'uppercase'
                   - font-weight: '600'
-                  - letter-spacing: '1px'
+                  - letter-spacing: '0.5px'
                   - padding-top: '4px'
 
             - type: custom:button-card
@@ -860,18 +860,18 @@ views:
                   - color: 'var(--kiosk-text-secondary)'
                   - padding-top: '8px'
                 state:
-                  - font-size: '24px'
+                  - font-size: '22px'
                   - text-transform: 'uppercase'
                   - font-weight: '600'
-                  - letter-spacing: '1px'
+                  - letter-spacing: '0.5px'
                   - padding-top: '4px'
 
       # ============================================================
-      # LIGHTS COLUMN — 20 lights, grouped into 5 room sections.
+      # LIGHTS COLUMN — 18 lights, grouped into 5 room sections.
       # (light.meeting_light is hoisted to the top-right meeting cell.)
-      # Sections render as a vertical-stack of (section header + 4-col grid).
-      # 4 cols keeps the column from outgrowing its cell and triggering
-      # a page-level scrollbar.
+      # Sections render as a vertical-stack of (section header + grid).
+      # Default 4 cols keeps the column from outgrowing its cell and
+      # triggering a page-level scrollbar; Outdoor uses 5 cols.
       # ============================================================
       - type: custom:mod-card
         view_layout: { grid-area: lights }
@@ -904,10 +904,10 @@ views:
                     border-radius: 0 !important;
                   }
                   ha-card .card-content {
-                    padding: 2px 4px 1px 4px !important;
-                    font-size: 9px !important;
+                    padding: 4px 6px 2px 6px !important;
+                    font-size: 13px !important;
                     font-weight: 700 !important;
-                    letter-spacing: 1.5px !important;
+                    letter-spacing: 2px !important;
                     color: var(--kiosk-accent-lights) !important;
                     border-bottom: 1px solid rgba(227, 179, 65, 0.25) !important;
                   }
@@ -916,9 +916,8 @@ views:
               columns: 4
               square: false
               cards:
-                - { type: 'custom:mushroom-light-card', entity: light.family_room, name: Family, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.family_room_2, name: Family 2, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.floor_lamp_composite, name: Floor Lamp, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.family_room_2, name: Family, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.floor_lamp_composite, name: Floor, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
 
             # --- Kitchen ---
             - <<: *light_section_header
@@ -938,11 +937,10 @@ views:
               columns: 4
               square: false
               cards:
-                - { type: 'custom:mushroom-light-card', entity: light.office, name: Office, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
                 - { type: 'custom:mushroom-light-card', entity: light.bookcase_lamp, name: Bookcase, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
                 - { type: 'custom:mushroom-light-card', entity: light.corner_lamp, name: Corner, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
                 - { type: 'custom:mushroom-light-card', entity: light.door_lamp, name: Door, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.office_lamp, name: Lamp, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.table_lamp, name: Table, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
                 - { type: 'custom:mushroom-light-card', entity: light.desk_lamp_2, name: Desk, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
                 - { type: 'custom:mushroom-light-card', entity: light.desk_lamp_2_2, name: Desk 2, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
 
@@ -1295,10 +1293,10 @@ views:
                       styles:
                         card: [{ background-color: 'rgba(88, 166, 255, 0.12)' }]
                   styles:
-                    card: [{ height: '70px' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px 10px' }]
-                    name: [{ font-size: '11px' }, { color: 'var(--kiosk-text-secondary)' }, { justify-self: 'start' }]
-                    state: [{ font-size: '12px' }, { text-transform: 'capitalize' }, { justify-self: 'start' }]
-                    grid: [{ grid-template-areas: '"i n" "i s"' }, { grid-template-columns: 'min-content 1fr' }, { column-gap: '8px' }]
+                    card: [{ height: '70px' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '8px 14px' }]
+                    name: [{ font-size: '15px' }, { font-weight: '500' }, { color: 'var(--kiosk-text-secondary)' }, { justify-self: 'start' }]
+                    state: [{ font-size: '17px' }, { font-weight: '600' }, { text-transform: 'uppercase' }, { letter-spacing: '0.5px' }, { justify-self: 'start' }]
+                    grid: [{ grid-template-areas: '"i n" "i s"' }, { grid-template-columns: 'min-content 1fr' }, { column-gap: '12px' }]
 
                 - type: custom:button-card
                   entity: media_player.basement_tv
@@ -1322,10 +1320,10 @@ views:
                       styles:
                         card: [{ background-color: 'rgba(88, 166, 255, 0.12)' }]
                   styles:
-                    card: [{ height: '70px' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px 10px' }]
-                    name: [{ font-size: '11px' }, { color: 'var(--kiosk-text-secondary)' }, { justify-self: 'start' }]
-                    state: [{ font-size: '12px' }, { text-transform: 'capitalize' }, { justify-self: 'start' }]
-                    grid: [{ grid-template-areas: '"i n" "i s"' }, { grid-template-columns: 'min-content 1fr' }, { column-gap: '8px' }]
+                    card: [{ height: '70px' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '8px 14px' }]
+                    name: [{ font-size: '15px' }, { font-weight: '500' }, { color: 'var(--kiosk-text-secondary)' }, { justify-self: 'start' }]
+                    state: [{ font-size: '17px' }, { font-weight: '600' }, { text-transform: 'uppercase' }, { letter-spacing: '0.5px' }, { justify-self: 'start' }]
+                    grid: [{ grid-template-areas: '"i n" "i s"' }, { grid-template-columns: 'min-content 1fr' }, { column-gap: '12px' }]
 
                 - type: custom:button-card
                   entity: media_player.play_room_tv
@@ -1349,7 +1347,7 @@ views:
                       styles:
                         card: [{ background-color: 'rgba(88, 166, 255, 0.12)' }]
                   styles:
-                    card: [{ height: '70px' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '6px 10px' }]
-                    name: [{ font-size: '11px' }, { color: 'var(--kiosk-text-secondary)' }, { justify-self: 'start' }]
-                    state: [{ font-size: '12px' }, { text-transform: 'capitalize' }, { justify-self: 'start' }]
-                    grid: [{ grid-template-areas: '"i n" "i s"' }, { grid-template-columns: 'min-content 1fr' }, { column-gap: '8px' }]
+                    card: [{ height: '70px' }, { background: 'var(--kiosk-bg-tile)' }, { border-radius: '8px' }, { border: 'none' }, { padding: '8px 14px' }]
+                    name: [{ font-size: '15px' }, { font-weight: '500' }, { color: 'var(--kiosk-text-secondary)' }, { justify-self: 'start' }]
+                    state: [{ font-size: '17px' }, { font-weight: '600' }, { text-transform: 'uppercase' }, { letter-spacing: '0.5px' }, { justify-self: 'start' }]
+                    grid: [{ grid-template-areas: '"i n" "i s"' }, { grid-template-columns: 'min-content 1fr' }, { column-gap: '12px' }]


### PR DESCRIPTION
Repair the long-neglected kiosk dashboard: three light tiles were
referencing entities that no longer exist (silent gray cells on the
TV), and the typography had drifted out of alignment with the rest
of the layout.

## Origin

> Using context and git status, correct the long neglected kiosk
> dashboard. Fix missing entities, align font sizes, prettify.
> Reference the dashboard directly if needed.

## Entity drift fixes

Verified every entity in `dashboards/kiosk.yaml` against
`context/entities.json`. Three were missing:

| Old (broken) | New | Why |
|---|---|---|
| `light.family_room` | (removed) | Entity no longer registered; only `light.family_room_2` survives. The Family Room section now shows 2 tiles (Family + Floor) instead of a phantom 3rd. |
| `light.office` | (removed) | The wall switch is `light.office_switch` and is redundant with the 6 lamp tiles immediately below it. Cleaner to drop. |
| `light.office_lamp` | `light.table_lamp` | The actual ZHA bulb in the office. Renamed tile to "Table". |

Result: Office grid drops from 7 → 6 tiles (4 + 2 layout in the 4-col
grid). Family Room from 3 → 2.

`alarm_control_panel.home_alarm` looked missing in the entity registry
but is fine — it's defined via the `manual` platform in
`configuration.yaml`, and YAML-platform entities don't appear in the
registry snapshot. Left untouched.

## Typography polish

The wall display is a 65" 1080p TV viewed from across the room. Three
inconsistencies were making it look unfinished:

- **Light section headers** were 9px — illegible at viewing distance.
  Bumped to 13px with 2px letter-spacing.
- **TV row buttons** were 11/12px while the parallel sensor buttons in
  the same column were 18/24px. Bumped to 15/17px with uppercase state
  to match the sensor row's visual weight.
- **Sensor state text** was 24px with 1px letter-spacing — "BASEMENT"
  and "GARAGE ENTRY" were crowding their cells. Tightened to 22px /
  0.5px letter-spacing.

Comment header in the lights column updated: 20 lights → 18 lights.

## Test plan

- [ ] Load `/dashboard-kiosk/home` on the wall display
- [ ] Verify Family Room section shows 2 tiles (Family, Floor) without
      a "entity not found" gap
- [ ] Verify Office section shows 6 tiles (Bookcase, Corner, Door,
      Table, Desk, Desk 2) without a phantom "Office" tile
- [ ] Verify section headers (FAMILY ROOM, KITCHEN, OFFICE, HALLWAYS,
      OUTDOOR) are readable from across the room
- [ ] Verify TV row text is now sized comparably to the sensor buttons
      above it
- [ ] Confirm no page-level scrollbar appears (the lights column still
      fits in its cell)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UWnDhDKUVa7A8xWPYfqhjc)_