### PR TITLE
docs: refresh PitziLabs portfolio cross-references

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,9 +277,9 @@ Seven sections:
 
 This repository is one piece of a broader infrastructure portfolio at [github.com/PitziLabs](https://github.com/PitziLabs):
 
-- **[aws-lab-infra](https://github.com/PitziLabs/aws-lab-infra)** — Terraform-managed three-tier AWS environment (VPC, ECS Fargate, RDS, ElastiCache, CI/CD)
+- **[foundry-platform-demo](https://github.com/PitziLabs/foundry-platform-demo)** — Terraform-managed three-tier AWS environment (VPC, ECS Fargate, RDS, ElastiCache, CI/CD)
 - **[firewalla-axiom-pipeline](https://github.com/PitziLabs/firewalla-axiom-pipeline)** — Fluent Bit log pipeline shipping Firewalla network telemetry to Axiom
-- **[firewalla-grafana-stack](https://github.com/PitziLabs/firewalla-grafana-stack)** — Self-hosted Grafana + Loki observability for home network monitoring
+- **[homelab-observability](https://github.com/PitziLabs/homelab-observability)** — Grafana Cloud + Alloy observability for the Firewalla home network
 - **[workstation-bootstrap](https://github.com/PitziLabs/workstation-bootstrap)** — Idempotent workstation provisioning for ChromeOS, Xubuntu, and Fedora
 
 ## License


### PR DESCRIPTION
## Summary

Two "Part of the PitziLabs Portfolio" links pointed at renamed siblings (both 404 on click):

- `aws-lab-infra` → `foundry-platform-demo`
- `firewalla-grafana-stack` → `homelab-observability`

This PR updates link text and URLs, plus refreshes the homelab-observability description to reflect its current stack (Grafana Cloud + Alloy) rather than the old self-hosted Grafana + Loki blurb.

## Test plan

- [x] Confirmed both renamed repos exist at their new URLs
- [x] Description text for homelab-observability matches the current README's first paragraph
- [ ] After merge, click both links from the rendered README to verify they resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)