### PR TITLE
Fix orphaned Play Room device→area assignments via mobile-tappable button

### DIFF
--- a/packages/playroom_area_fix.yaml
+++ b/packages/playroom_area_fix.yaml
@@ -1,0 +1,38 @@
+# One-shot button to fix the orphaned Play Room device→area assignments.
+#
+# Playroom 3, Playroom 4, and the Play Room outlet landed in the device
+# registry with area_id=null. The fix lives in
+# scripts/assign-playroom-areas.sh (websocket → config/device_registry/update).
+# This package exposes a button so it can be triggered from the HA mobile
+# app once GitOps deploys the change.
+#
+# After pressing the button and confirming via context-sync that the
+# devices now show area_id=play_room, this package, the shell_command
+# entry, and the script can all be removed in a follow-up PR.
+
+input_button:
+  assign_playroom_areas:
+    name: "Fix Play Room device areas"
+    icon: mdi:map-marker-plus
+
+automation:
+  - id: assign_playroom_areas_trigger
+    alias: "Playroom Area Fix: trigger on button press"
+    mode: single
+    triggers:
+      - trigger: state
+        entity_id: input_button.assign_playroom_areas
+    actions:
+      - action: shell_command.assign_playroom_areas
+        response_variable: result
+      - action: persistent_notification.create
+        data:
+          title: "Play Room area fix"
+          notification_id: assign_playroom_areas_done
+          message: >-
+            shell_command returned code {{ result.returncode }}.
+            {% if result.returncode == 0 %}
+            Press input_button.ha_context_dump_now to refresh context/devices.json.
+            {% else %}
+            stderr: {{ result.stderr }}
+            {% endif %}

--- a/scripts/assign-playroom-areas.sh
+++ b/scripts/assign-playroom-areas.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# One-shot: assign the orphaned Play Room devices to the play_room area.
+#
+# Device→area mapping in HA lives in .storage/core.device_registry (runtime
+# state, not git-tracked) and can only be edited via the websocket
+# `config/device_registry/update` command. This script does that for the
+# three Play Room devices that landed without an area_id:
+#
+#   8a93d92e1ef5b0f7e39d20a7d9cfa603 → play_room  (Playroom 3, ZHA Hue bulb)
+#   2cf841bd422c4e20593540bf7eeb2f1b → play_room  (Playroom 4, ZHA Hue bulb)
+#   c13d103ea0a1177f174dba7bd38fbeaa → play_room  (Play Room outlet, Kasa HS200)
+#
+# Run inside the HA Core container (Python 3 + aiohttp are part of Core):
+#
+#   docker exec homeassistant /config/scripts/assign-playroom-areas.sh
+#
+# More commonly: triggered via shell_command.assign_playroom_areas from the
+# `input_button.assign_playroom_areas` helper in
+# packages/playroom_area_fix.yaml.
+#
+# Token resolution mirrors scripts/import-home-to-storage.sh:
+#   1. HA_TOKEN env var (one-shot override)
+#   2. ha_token from /config/secrets.yaml (preferred; see CLAUDE.md >
+#      "Script auth conventions" for why values are stored as full
+#      Authorization header strings)
+#   3. SUPERVISOR_TOKEN env var (last resort; rejected by current HA on
+#      the Core websocket auth path, but tried for completeness)
+#
+# Idempotent — HA accepts the same update payload repeatedly and the script
+# logs the resulting area_id from each response so re-runs are observable.
+
+set -euo pipefail
+
+readonly HA_WS_URL="${HA_WS_URL:-ws://127.0.0.1:8123/api/websocket}"
+readonly SECRETS_YAML="${SECRETS_YAML:-/config/secrets.yaml}"
+
+token=""
+token_source=""
+if [[ -n "${HA_TOKEN:-}" ]]; then
+    token=$HA_TOKEN
+    token_source="HA_TOKEN env var"
+elif [[ -f "$SECRETS_YAML" ]]; then
+    secret=$(awk -F'"' '/^ha_token:/ {print $2; exit}' "$SECRETS_YAML")
+    if [[ -n "$secret" && "$secret" != "CHANGE_ME" && "$secret" != "Bearer CHANGE_ME" ]]; then
+        token=$secret
+        token_source="ha_token from $SECRETS_YAML"
+    fi
+fi
+if [[ -z "$token" && -n "${SUPERVISOR_TOKEN:-}" ]]; then
+    token=$SUPERVISOR_TOKEN
+    token_source="SUPERVISOR_TOKEN env var (fallback)"
+fi
+token="${token#Bearer }"
+
+if [[ -z "$token" ]]; then
+    cat >&2 <<MSG
+error: no Home Assistant access token found.
+
+Create a long-lived access token in the HA UI:
+    profile (bottom-left avatar) -> Security tab
+    -> Long-Lived Access Tokens -> Create Token
+
+Then add it to ${SECRETS_YAML}:
+    ha_token: "Bearer <paste-the-token-here>"
+MSG
+    exit 1
+fi
+
+export _ASSIGN_WS_URL="$HA_WS_URL"
+export _ASSIGN_TOKEN="$token"
+export _ASSIGN_TOKEN_SOURCE="$token_source"
+
+python3 <<'PY'
+import asyncio
+import os
+import sys
+
+import aiohttp
+
+WS_URL = os.environ["_ASSIGN_WS_URL"]
+TOKEN = os.environ["_ASSIGN_TOKEN"]
+TOKEN_SOURCE = os.environ["_ASSIGN_TOKEN_SOURCE"]
+
+ASSIGNMENTS = [
+    ("8a93d92e1ef5b0f7e39d20a7d9cfa603", "play_room", "Playroom 3"),
+    ("2cf841bd422c4e20593540bf7eeb2f1b", "play_room", "Playroom 4"),
+    ("c13d103ea0a1177f174dba7bd38fbeaa", "play_room", "Play Room outlet"),
+]
+
+
+async def call(ws, msg_id, payload):
+    payload = {**payload, "id": msg_id}
+    await ws.send_json(payload)
+    while True:
+        resp = await ws.receive_json()
+        if resp.get("id") == msg_id:
+            return resp
+
+
+async def main():
+    timeout = aiohttp.ClientTimeout(total=30)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.ws_connect(WS_URL) as ws:
+            hello = await ws.receive_json()
+            if hello.get("type") != "auth_required":
+                sys.exit(f"unexpected handshake: {hello}")
+
+            await ws.send_json({"type": "auth", "access_token": TOKEN})
+            auth_resp = await ws.receive_json()
+            if auth_resp.get("type") != "auth_ok":
+                sys.exit(f"auth failed (token from {TOKEN_SOURCE}): {auth_resp}")
+
+            print(f"authenticated via {TOKEN_SOURCE}")
+            msg_id = 1
+            failures = 0
+
+            for device_id, area_id, label in ASSIGNMENTS:
+                resp = await call(ws, msg_id, {
+                    "type": "config/device_registry/update",
+                    "device_id": device_id,
+                    "area_id": area_id,
+                })
+                msg_id += 1
+                if not resp.get("success", False):
+                    failures += 1
+                    print(f"FAIL {label} ({device_id}): {resp.get('error')}")
+                    continue
+                resulting_area = (resp.get("result") or {}).get("area_id")
+                print(f"OK   {label} ({device_id}) -> area_id={resulting_area}")
+
+            if failures:
+                sys.exit(f"{failures} assignment(s) failed")
+            print("trigger context-sync (input_button.ha_context_dump_now) to refresh context/devices.json")
+
+
+asyncio.run(main())
+PY

--- a/shell_commands.yaml
+++ b/shell_commands.yaml
@@ -1,1 +1,2 @@
 gitops_sync: "bash /config/scripts/gitops-sync.sh"
+assign_playroom_areas: "bash /config/scripts/assign-playroom-areas.sh"


### PR DESCRIPTION
Adds a one-shot button to assign Playroom 3, Playroom 4, and the Play Room outlet to the `play_room` area.

## Origin

Validation of `packages/hue_tap_dial_playroom.yaml` against `context/devices.json` confirmed the dial automation is correct, but surfaced three Play Room devices with `area_id: null`:

| Device | `device_id` | Integration |
|--------|-------------|-------------|
| Playroom 3 | `8a93d92e1ef5b0f7e39d20a7d9cfa603` | zha (Signify LCT011) |
| Playroom 4 | `2cf841bd422c4e20593540bf7eeb2f1b` | zha (Signify LCT011) |
| Play Room outlet | `c13d103ea0a1177f174dba7bd38fbeaa` | tplink (Kasa HS200) |

Playroom 1, Playroom 2, and the Hue Tap Dial itself sit in `play_room` — these three are stragglers. They don't break the dial automation (it targets by entity_id, not area), but they hide from area-scoped dashboards and any future area-aware automations.

The user asked for a behavior summary and a fix, then specified delivery via Dispatch rather than UI steps:

> Actually write it up for Dispatch. I can't get to a local browser right now

## What changed

Device→area mapping lives in `.storage/core.device_registry` (runtime state, gitignored) and is only editable via the websocket `config/device_registry/update` command. Mirroring the pattern from `scripts/import-home-to-storage.sh`:

- **`scripts/assign-playroom-areas.sh`** — bash wrapper with Python heredoc that resolves the LLAT (`HA_TOKEN` env → `ha_token` from `secrets.yaml` → `SUPERVISOR_TOKEN` fallback), opens a websocket to `ws://127.0.0.1:8123/api/websocket`, authenticates, and sends three `config/device_registry/update` calls. Idempotent — HA accepts repeat assignments and the script logs the resulting `area_id` from each response.
- **`shell_commands.yaml`** — adds `shell_command.assign_playroom_areas` invoking the script.
- **`packages/playroom_area_fix.yaml`** — exposes `input_button.assign_playroom_areas` ("Fix Play Room device areas") plus an automation that calls the shell_command on press, capturing `returncode`/`stderr` into a persistent notification.

## How to trigger

After GitOps sync deploys this PR:

1. Open the HA mobile app → Settings → Devices & services → Helpers (or pin the button to a dashboard).
2. Tap **Fix Play Room device areas**.
3. A persistent notification confirms `returncode 0` (or shows stderr on failure).
4. Tap `input_button.ha_context_dump_now` to refresh `context/devices.json` and verify the three devices now show `area_id: "play_room"`.

## Follow-up

Once the area assignments are confirmed in the next context snapshot, the package, shell_command entry, and script can be removed in a follow-up PR (the runtime change persists in `.storage/`, not in git).

## Test plan

- [ ] YAML lint passes (`packages/playroom_area_fix.yaml`)
- [ ] HA config check passes against pinned version
- [ ] After deploy: tap the button on mobile → notification reports `returncode 0`
- [ ] Next context snapshot shows `area_id: "play_room"` for all three devices in `context/devices.json`

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfMvDPtfGg1pLZozpKrygt)_