### PR TITLE
Fix Hue Tap Dial wired-power guard: real wall switch is Wemo, not TP-Link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Automations are split across two locations with different governance models:
 | `switch.family_room_outlets` | Powers floor lamp (dependency) |
 | `switch.back_porch` | Outdoor |
 | `switch.play_room_outlet` | Indoor |
-| `switch.bonus_room` | Indoor (often unavailable) |
+| `switch.bonus_room` | Wemo wall switch powering the play room Hue bulbs (device adopted under stale name) |
 | `switch.basement_1` | Indoor (often unavailable) |
 
 ### Sonos Media Players

--- a/packages/hue_tap_dial_playroom.yaml
+++ b/packages/hue_tap_dial_playroom.yaml
@@ -5,13 +5,15 @@
 #   area:      play_room
 #
 # Wired-power note: the four Hue bulbs (light.playroom_1..4) are downstream of
-# a TP-Link Kasa HS200 in-wall switch (switch.play_room_outlet). If the wall
-# switch is off the bulbs lose mains and drop off the Zigbee mesh. Every
+# a Belkin Wemo in-wall LightSwitch exposed as `switch.bonus_room` (the device
+# was adopted under that label before its actual location was known). If the
+# wall switch is off the bulbs lose mains and drop off the Zigbee mesh. Every
 # scene-on action below calls `script.playroom_lights_power_on` first, which
-# flips the outlet on (if needed) and waits for the bulbs to rejoin before
-# applying the scene. `light.turn_off` does NOT cut the outlet — the bulbs
-# stay powered-but-off so the dial can wake them again later without a
-# rejoin delay.
+# flips the switch on (if needed) and waits for the bulbs to rejoin before
+# applying the scene. `light.turn_off` does NOT cut mains — the bulbs stay
+# powered-but-off so the dial can wake them again later without a rejoin
+# delay. (`switch.play_room_outlet` is a separate TP-Link Kasa HS200 outlet
+# in the same room that does NOT power the bulbs.)
 #
 # Button layout (top → bottom):
 #   1 (top)    → Bright       100% / 4000K  (general illumination)
@@ -37,17 +39,17 @@
 
 script:
   playroom_lights_power_on:
-    alias: 'Playroom: ensure outlet on and bulbs reachable'
+    alias: 'Playroom: ensure wall switch on and bulbs reachable'
     mode: single
     sequence:
       - if:
           - condition: state
-            entity_id: switch.play_room_outlet
+            entity_id: switch.bonus_room
             state: 'off'
         then:
           - action: switch.turn_on
             target:
-              entity_id: switch.play_room_outlet
+              entity_id: switch.bonus_room
           # Hue bulbs need a moment to rejoin the Zigbee mesh after mains
           # is restored. Wait until all 4 report a usable state, capped at
           # 8s so a single missing bulb can't block the scene apply forever.
@@ -74,7 +76,7 @@ script:
       # Bulbs are unreachable when the wall switch is off; bail rather than
       # racing a power-on. User can press a button to wake the room.
       - condition: state
-        entity_id: switch.play_room_outlet
+        entity_id: switch.bonus_room
         state: 'on'
       - variables:
           # Pick the highest current brightness across the on bulbs as the

--- a/scripts/assign-playroom-areas.sh
+++ b/scripts/assign-playroom-areas.sh
@@ -9,6 +9,9 @@
 #   8a93d92e1ef5b0f7e39d20a7d9cfa603 → play_room  (Playroom 3, ZHA Hue bulb)
 #   2cf841bd422c4e20593540bf7eeb2f1b → play_room  (Playroom 4, ZHA Hue bulb)
 #   c13d103ea0a1177f174dba7bd38fbeaa → play_room  (Play Room outlet, Kasa HS200)
+#   f090c7c3434162e57c3d8a9cee321fae → play_room  (Wemo wall switch — labeled
+#                                                  "Bonus room" at adoption,
+#                                                  actually powers the Hue bulbs)
 #
 # Run inside the HA Core container (Python 3 + aiohttp are part of Core):
 #
@@ -85,6 +88,7 @@ ASSIGNMENTS = [
     ("8a93d92e1ef5b0f7e39d20a7d9cfa603", "play_room", "Playroom 3"),
     ("2cf841bd422c4e20593540bf7eeb2f1b", "play_room", "Playroom 4"),
     ("c13d103ea0a1177f174dba7bd38fbeaa", "play_room", "Play Room outlet"),
+    ("f090c7c3434162e57c3d8a9cee321fae", "play_room", "Bonus room (Wemo wall switch)"),
 ]
 
 


### PR DESCRIPTION
Points the Hue Tap Dial wired-power guard at the actual wall switch (Wemo `switch.bonus_room`) instead of the unrelated TP-Link `switch.play_room_outlet`, and adds the same Wemo to the area-assignment one-shot.

## Origin

> oh, we have a bug - the switch that controls the hue lights isn't the tplink, it's the wemo

Follow-up to #229. While auditing `packages/hue_tap_dial_playroom.yaml` against `context/devices.json`, the wired-power guard was assumed to be the TP-Link Kasa HS200 named `switch.play_room_outlet` because the entity name matched the room. The user clarified that the bulbs are actually downstream of a Belkin Wemo wall switch — confirmed via AskUserQuestion to be `switch.bonus_room` (`f090c7c3434162e57c3d8a9cee321fae`), which was adopted under a stale name before its real location was known. The TP-Link outlet is a separate device in the same room that does NOT power the bulbs.

Without this fix, `script.playroom_lights_power_on` would check / toggle the wrong switch and never wake the bulbs when the real wall switch was off — the dial buttons would appear dead until someone physically flipped the Wemo.

## What changed

- **`packages/hue_tap_dial_playroom.yaml`**
  - `script.playroom_lights_power_on`: condition + `switch.turn_on` target → `switch.bonus_room`
  - `script.playroom_brightness_step`: pre-step `condition: state` → `switch.bonus_room`
  - Header comment block updated to document the Wemo, and explicitly disambiguates from `switch.play_room_outlet`
- **`scripts/assign-playroom-areas.sh`**
  - Adds `f090c7c3434162e57c3d8a9cee321fae` (the Wemo) to the `ASSIGNMENTS` list so the next press of `input_button.assign_playroom_areas` also moves it into `play_room`
- **`CLAUDE.md`**
  - Switches reference table for `switch.bonus_room` updated to reflect its actual role

## Test plan

- [ ] YAML lint passes
- [ ] HA config check passes
- [ ] After deploy: turn the Wemo wall switch off, press a dial button → bulbs come back on (the previous code would have left them off)
- [ ] Press `input_button.assign_playroom_areas` → `switch.bonus_room` now reports `area_id: "play_room"` in the next context snapshot

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfMvDPtfGg1pLZozpKrygt)_