### PR TITLE
Playroom: add color variety to Hue Tap Dial (8 scenes + colorloop)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Automations are split across two locations with different governance models:
 | `switch.family_room_outlets` | Powers floor lamp (dependency) |
 | `switch.back_porch` | Outdoor |
 | `switch.play_room_outlet` | Indoor |
-| `switch.bonus_room` | Wemo wall switch powering the play room Hue bulbs (device adopted under stale name) |
+| `switch.bonus_room` | Wemo wall switch powering the play room Hue bulbs. Device renamed to "Playroom Lights Power" in HA UI; `entity_id` retained to match adoption-history convention (see `switch.alarm_panel_56ac70_siren`). |
 | `switch.basement_1` | Indoor (often unavailable) |
 
 ### Sonos Media Players

--- a/packages/hue_tap_dial_playroom.yaml
+++ b/packages/hue_tap_dial_playroom.yaml
@@ -1,38 +1,47 @@
 # Hue Tap Dial (RDM002) → Play Room lights
 #
 # Device: "Hue Tap Dial" (Signify RDM002) via ZHA
-#   device_id: 2d6cd400df2e3424cb883cc78bce43d7
-#   area:      play_room
+#   device_ieee: 00:17:88:01:0d:35:c4:85
+#   area:        play_room
 #
-# Wired-power note: the four Hue bulbs (light.playroom_1..4) are downstream of
-# a Belkin Wemo in-wall LightSwitch exposed as `switch.bonus_room` (the device
-# was adopted under that label before its actual location was known). If the
-# wall switch is off the bulbs lose mains and drop off the Zigbee mesh. Every
-# scene-on action below calls `script.playroom_lights_power_on` first, which
-# flips the switch on (if needed) and waits for the bulbs to rejoin before
-# applying the scene. `light.turn_off` does NOT cut mains — the bulbs stay
-# powered-but-off so the dial can wake them again later without a rejoin
-# delay. (`switch.play_room_outlet` is a separate TP-Link Kasa HS200 outlet
-# in the same room that does NOT power the bulbs.)
+# Wired-power note: the four Hue White-and-Color bulbs (light.playroom_1..4,
+# model LCT011) are downstream of a Belkin Wemo in-wall LightSwitch exposed
+# as `switch.bonus_room` (device renamed "Playroom Lights Power" in HA UI but
+# entity_id retained to match adoption-history convention used elsewhere in
+# this repo, e.g. switch.alarm_panel_56ac70_siren). If the wall switch is off
+# the bulbs lose mains and drop off the Zigbee mesh. Every scene-on action
+# below calls `script.playroom_lights_power_on` first, which flips the switch
+# on (if needed) and waits for the bulbs to rejoin before applying the scene.
+# `light.turn_off` does NOT cut mains — the bulbs stay powered-but-off so the
+# dial can wake them again later without a rejoin delay.
+# (`switch.play_room_outlet` is a separate TP-Link Kasa HS200 outlet in the
+# same room that does NOT power the bulbs.)
 #
-# Button layout (top → bottom):
-#   1 (top)    → Bright       100% / 4000K  (general illumination)
-#   2          → Relax         40% / 2200K  (warm, low)
-#   3          → Concentrate  100% / 5000K  (cool, bright)
-#   4 (bottom) → Off           — bulbs off, outlet stays on
+# Button layout — short press (immediate) / long press (hold):
+#   1 (top)    short → Bright Daylight   100% / 4000K — workhorse white
+#   1          long  → Concentrate       100% / 5000K — cool bright work
+#   2          short → Sunset            per-bulb warms (coral/pink/orange/magenta)
+#   2          long  → Relax              40% / 2200K — warm dim
+#   3          short → Ocean             per-bulb cools (cyan/blue/teal/purple)
+#   3          long  → Rainbow           per-bulb vivid (red/green/blue/yellow)
+#   4 (bottom) short → Off               — bulbs off, outlet stays on
+#   4          long  → Colorloop          Hue native effect, slow color cycle
 #
 # Dial rotation:
-#   Clockwise (step up)        → brightness +25 (~10%) on all 4 lights
+#   Clockwise (step up)         → brightness +25 (~10%) on all 4 lights
 #   Counter-clockwise (step dn) → brightness -25 on all 4 lights
 #   Rotating with all lights off is a no-op — press a button first.
 #
 # ZHA event signatures (PhilipsRDM002 quirk, zha-device-handlers):
 #   Buttons fire on cluster 0xFC00 (64512) with commands of the form
-#   `button_N_short_release` where N is 1-4. Older or alternate quirk
-#   builds emit `N_short_release` (no `button_` prefix). Both shapes are
-#   matched defensively so the automation survives quirk updates.
+#   `button_N_short_release` / `button_N_long_release` where N is 1-4.
+#   Older or alternate quirk builds emit `N_short_release` / `N_long_release`
+#   (no `button_` prefix). Both shapes are matched defensively so the
+#   automation survives quirk updates.
 #   The dial fires `step` / `step_with_on_off` on cluster 8 (Level Control),
 #   args[0] = direction (0 = up, 1 = down) per Zigbee spec.
+#   Triggers use `device_ieee` (persistent across device re-add) instead of
+#   `device_id` (changes if device is removed/re-paired).
 #
 # If you ever need to see exactly what this dial emits, watch
 # Developer Tools → Events → listen for `zha_event` and rotate / press.
@@ -117,18 +126,19 @@ script:
               transition: 0.3
 
 automation:
-  - id: hue_tap_dial_button_1_bright
-    alias: 'Hue Tap Dial: Button 1 → Bright (100% / 4000K)'
+  # ───────────────────────── BUTTON 1 ─────────────────────────
+  - id: hue_tap_dial_button_1_short_bright
+    alias: 'Hue Tap Dial: Button 1 short → Bright Daylight (100% / 4000K)'
     triggers:
       - trigger: event
         event_type: zha_event
         event_data:
-          device_id: 2d6cd400df2e3424cb883cc78bce43d7
+          device_ieee: '00:17:88:01:0d:35:c4:85'
           command: button_1_short_release
       - trigger: event
         event_type: zha_event
         event_data:
-          device_id: 2d6cd400df2e3424cb883cc78bce43d7
+          device_ieee: '00:17:88:01:0d:35:c4:85'
           command: '1_short_release'
     actions:
       - action: script.playroom_lights_power_on
@@ -145,47 +155,19 @@ automation:
           transition: 1
     mode: single
 
-  - id: hue_tap_dial_button_2_relax
-    alias: 'Hue Tap Dial: Button 2 → Relax (40% / 2200K)'
+  - id: hue_tap_dial_button_1_long_concentrate
+    alias: 'Hue Tap Dial: Button 1 long → Concentrate (100% / 5000K)'
     triggers:
       - trigger: event
         event_type: zha_event
         event_data:
-          device_id: 2d6cd400df2e3424cb883cc78bce43d7
-          command: button_2_short_release
+          device_ieee: '00:17:88:01:0d:35:c4:85'
+          command: button_1_long_release
       - trigger: event
         event_type: zha_event
         event_data:
-          device_id: 2d6cd400df2e3424cb883cc78bce43d7
-          command: '2_short_release'
-    actions:
-      - action: script.playroom_lights_power_on
-      - action: light.turn_on
-        target:
-          entity_id:
-            - light.playroom_1
-            - light.playroom_2
-            - light.playroom_3
-            - light.playroom_4
-        data:
-          brightness_pct: 40
-          color_temp_kelvin: 2200
-          transition: 1
-    mode: single
-
-  - id: hue_tap_dial_button_3_concentrate
-    alias: 'Hue Tap Dial: Button 3 → Concentrate (100% / 5000K)'
-    triggers:
-      - trigger: event
-        event_type: zha_event
-        event_data:
-          device_id: 2d6cd400df2e3424cb883cc78bce43d7
-          command: button_3_short_release
-      - trigger: event
-        event_type: zha_event
-        event_data:
-          device_id: 2d6cd400df2e3424cb883cc78bce43d7
-          command: '3_short_release'
+          device_ieee: '00:17:88:01:0d:35:c4:85'
+          command: '1_long_release'
     actions:
       - action: script.playroom_lights_power_on
       - action: light.turn_on
@@ -201,18 +183,190 @@ automation:
           transition: 1
     mode: single
 
-  - id: hue_tap_dial_button_4_off
-    alias: 'Hue Tap Dial: Button 4 → all playroom lights off'
+  # ───────────────────────── BUTTON 2 ─────────────────────────
+  - id: hue_tap_dial_button_2_short_sunset
+    alias: 'Hue Tap Dial: Button 2 short → Sunset (per-bulb warm colors)'
     triggers:
       - trigger: event
         event_type: zha_event
         event_data:
-          device_id: 2d6cd400df2e3424cb883cc78bce43d7
+          device_ieee: '00:17:88:01:0d:35:c4:85'
+          command: button_2_short_release
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: '00:17:88:01:0d:35:c4:85'
+          command: '2_short_release'
+    actions:
+      - action: script.playroom_lights_power_on
+      # Four warm-palette colors, one per bulb, for a vibrant sunset feel.
+      - parallel:
+          - action: light.turn_on
+            target:
+              entity_id: light.playroom_1
+            data:
+              brightness_pct: 90
+              rgb_color: [255, 100, 80]    # coral
+              transition: 1
+          - action: light.turn_on
+            target:
+              entity_id: light.playroom_2
+            data:
+              brightness_pct: 90
+              rgb_color: [255, 60, 130]    # pink-magenta
+              transition: 1
+          - action: light.turn_on
+            target:
+              entity_id: light.playroom_3
+            data:
+              brightness_pct: 90
+              rgb_color: [255, 120, 30]    # burnt orange
+              transition: 1
+          - action: light.turn_on
+            target:
+              entity_id: light.playroom_4
+            data:
+              brightness_pct: 90
+              rgb_color: [255, 80, 180]    # hot pink
+              transition: 1
+    mode: single
+
+  - id: hue_tap_dial_button_2_long_relax
+    alias: 'Hue Tap Dial: Button 2 long → Relax (40% / 2200K)'
+    triggers:
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: '00:17:88:01:0d:35:c4:85'
+          command: button_2_long_release
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: '00:17:88:01:0d:35:c4:85'
+          command: '2_long_release'
+    actions:
+      - action: script.playroom_lights_power_on
+      - action: light.turn_on
+        target:
+          entity_id:
+            - light.playroom_1
+            - light.playroom_2
+            - light.playroom_3
+            - light.playroom_4
+        data:
+          brightness_pct: 40
+          color_temp_kelvin: 2200
+          transition: 1
+    mode: single
+
+  # ───────────────────────── BUTTON 3 ─────────────────────────
+  - id: hue_tap_dial_button_3_short_ocean
+    alias: 'Hue Tap Dial: Button 3 short → Ocean (per-bulb cool colors)'
+    triggers:
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: '00:17:88:01:0d:35:c4:85'
+          command: button_3_short_release
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: '00:17:88:01:0d:35:c4:85'
+          command: '3_short_release'
+    actions:
+      - action: script.playroom_lights_power_on
+      # Four cool-palette colors, one per bulb, for an aquatic feel.
+      - parallel:
+          - action: light.turn_on
+            target:
+              entity_id: light.playroom_1
+            data:
+              brightness_pct: 90
+              rgb_color: [0, 200, 230]     # cyan
+              transition: 1
+          - action: light.turn_on
+            target:
+              entity_id: light.playroom_2
+            data:
+              brightness_pct: 90
+              rgb_color: [50, 80, 255]     # royal blue
+              transition: 1
+          - action: light.turn_on
+            target:
+              entity_id: light.playroom_3
+            data:
+              brightness_pct: 90
+              rgb_color: [0, 180, 160]     # teal
+              transition: 1
+          - action: light.turn_on
+            target:
+              entity_id: light.playroom_4
+            data:
+              brightness_pct: 90
+              rgb_color: [150, 80, 255]    # purple
+              transition: 1
+    mode: single
+
+  - id: hue_tap_dial_button_3_long_rainbow
+    alias: 'Hue Tap Dial: Button 3 long → Rainbow (per-bulb vivid primaries)'
+    triggers:
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: '00:17:88:01:0d:35:c4:85'
+          command: button_3_long_release
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: '00:17:88:01:0d:35:c4:85'
+          command: '3_long_release'
+    actions:
+      - action: script.playroom_lights_power_on
+      # Four vivid primaries, one per bulb. Big-energy "play time" mode.
+      - parallel:
+          - action: light.turn_on
+            target:
+              entity_id: light.playroom_1
+            data:
+              brightness_pct: 95
+              rgb_color: [255, 30, 30]     # red
+              transition: 1
+          - action: light.turn_on
+            target:
+              entity_id: light.playroom_2
+            data:
+              brightness_pct: 95
+              rgb_color: [40, 220, 60]     # green
+              transition: 1
+          - action: light.turn_on
+            target:
+              entity_id: light.playroom_3
+            data:
+              brightness_pct: 95
+              rgb_color: [40, 80, 255]     # blue
+              transition: 1
+          - action: light.turn_on
+            target:
+              entity_id: light.playroom_4
+            data:
+              brightness_pct: 95
+              rgb_color: [255, 220, 40]    # yellow
+              transition: 1
+    mode: single
+
+  # ───────────────────────── BUTTON 4 ─────────────────────────
+  - id: hue_tap_dial_button_4_short_off
+    alias: 'Hue Tap Dial: Button 4 short → all playroom lights off'
+    triggers:
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: '00:17:88:01:0d:35:c4:85'
           command: button_4_short_release
       - trigger: event
         event_type: zha_event
         event_data:
-          device_id: 2d6cd400df2e3424cb883cc78bce43d7
+          device_ieee: '00:17:88:01:0d:35:c4:85'
           command: '4_short_release'
     actions:
       - action: light.turn_off
@@ -226,13 +380,44 @@ automation:
           transition: 1
     mode: single
 
+  - id: hue_tap_dial_button_4_long_colorloop
+    alias: 'Hue Tap Dial: Button 4 long → Colorloop effect'
+    triggers:
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: '00:17:88:01:0d:35:c4:85'
+          command: button_4_long_release
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: '00:17:88:01:0d:35:c4:85'
+          command: '4_long_release'
+    actions:
+      - action: script.playroom_lights_power_on
+      # Hue native colorloop effect — bulbs slowly cycle through the full
+      # color space. Stops automatically when any of the static-color
+      # scenes (1-3 short/long) are applied next.
+      - action: light.turn_on
+        target:
+          entity_id:
+            - light.playroom_1
+            - light.playroom_2
+            - light.playroom_3
+            - light.playroom_4
+        data:
+          brightness_pct: 85
+          effect: colorloop
+    mode: single
+
+  # ───────────────────────── DIAL ROTATION ─────────────────────────
   - id: hue_tap_dial_rotation_brightness
     alias: 'Hue Tap Dial: dial rotation → playroom brightness'
     triggers:
       - trigger: event
         event_type: zha_event
         event_data:
-          device_id: 2d6cd400df2e3424cb883cc78bce43d7
+          device_ieee: '00:17:88:01:0d:35:c4:85'
           cluster_id: 8
     conditions:
       - condition: template


### PR DESCRIPTION
## Origin

> check my system status through all sources. then fix my playroom lights - the hue tap dial up there needs better setup. Add lots of interest, colors, and variety to the lighting capability. It's a play room. Also, the WEMO switch that is prereq for the bulbs to power on can be renamed/regrouped. If you can affect a change using the MCP server that will be fed back to git via the context/ loop, OR affect that same change via git/ops loop, default to git.

## Summary

Expand `packages/hue_tap_dial_playroom.yaml` from 4 white-only utility scenes to **8 scenes + colorloop** by adding long-press handlers on all four buttons and using `rgb_color` per-bulb on the new color scenes. The Hue LCT011 bulbs have always supported full color (`xy` mode) — the previous config was just leaving that capability on the table.

| Button | Short press | Long press |
|--------|-------------|------------|
| 1 (top) | Bright Daylight (100% / 4000K) | Concentrate (100% / 5000K) |
| 2 | **Sunset** — coral / pink / orange / hot-pink | Relax (40% / 2200K) |
| 3 | **Ocean** — cyan / royal blue / teal / purple | **Rainbow** — red / green / blue / yellow |
| 4 (bottom) | Off | **Colorloop** (Hue native effect) |

Dial rotation still maps to ±10% brightness step on the four bulbs.

Two side-quality improvements rolled in:
- ZHA event triggers now key on `device_ieee` (`00:17:88:01:0d:35:c4:85`) instead of `device_id`. Per the home-assistant-best-practices skill the IEEE survives a device re-add; the internal `device_id` does not.
- The Belkin Wemo wall switch that gates mains to these bulbs was renamed in the device + entity registry from "Bonus room" to **"Playroom Lights Power"** via MCP. The `entity_id` `switch.bonus_room` is intentionally retained — same adoption-history convention as `switch.alarm_panel_56ac70_siren`, and changing it would break `dashboards/home.yaml`, `dashboards/command-deck.yaml`, and `scripts/assign-playroom-areas.sh` references during the window between MCP rename and gitops deploy. `CLAUDE.md` updated to note the new label.

## System status check (requested in prompt)

- **HA Core 2026.5.2 / HAOS 17.3 / Supervisor 2026.05.0** — `ha_check_config` clean, 0 repairs.
- **1 persistent notification**: localhost (`127.0.0.1`) failed-auth — likely benign internal probe but worth a glance.
- **Two error patterns in the last 24h** unrelated to this PR:
  - `proxmoxve` coordinator throwing `KeyError: 'cpu' / 'mem' / 'disk' / 'uptime'` on the `pve4` node (74× each) — looks like `pve4` is in the inventory but the Proxmox API isn't returning standard node fields for it. Surfaces on the Homelab Status dashboard.
  - `custom_components.ugreen` — `Cannot connect to host 192.168.139.106:9443` (UGREEN NAS API unreachable). NAS panel on the Homelab Status dashboard is the consumer.
- **Hue Tap Dial battery 100%, LQI 136 / RSSI -66 dBm** — healthy radio.
- **Playroom bulbs all `unavailable`** at time of writing (expected — `switch.bonus_room` is currently off).

## "Are we racing with git?" (answering the in-prompt question)

Not quite — git and MCP write to disjoint backing stores, so there's no concurrent-write race. But there *is* a referential coupling worth being explicit about:

| Lives in git (`/config/*.yaml`) | Lives in `.storage/` (MCP-writable) |
|--------|----------|
| automations / scripts / scenes / dashboards declared as YAML | entity registry (entity_id, friendly_name, area_id, aliases, expose flags) |
| `configuration.yaml` core/packages | device registry (device name, area_id, labels) |
| `secrets.yaml` (gitignored real values) | UI-authored automations, scenes, scripts, helpers |
| `themes/`, ESPHome configs | UI-mode dashboards |

The Local-HA MCP server gives runtime read+write access to **both** stores. `ha_set_entity` / `ha_update_device` / `ha_config_set_helper` write to `.storage/` directly; they have no effect on git and won't show up in a `git diff`. The `context/` sync loop (every 6h) snapshots `.storage/` *into* git as read-only JSON (`entities.json`, `devices.json`, etc.) — that's the feedback path, but the snapshot is documentation, not source of truth.

Where the two surfaces *interact* is at YAML reference time: a YAML automation that says `entity_id: light.foo` will silently break if MCP renames `light.foo` to `light.bar`. So the rule of thumb encoded in `CLAUDE.md` — *"if a feature should survive a rebuild, it goes in git"* — really translates to:

- **YAML for declared behavior** (automations, scripts, dashboards). Git is authoritative; the gitops-sync loop is the only writer to the live `/config/`.
- **MCP for registry mutations** (device/entity names, areas, labels, voice exposure). These can't be expressed in YAML at all, so git can't drive them.
- **Avoid renaming an entity_id without simultaneously updating every YAML reference** in the same PR — that *is* a race window. This PR sidesteps the issue entirely by changing only the *display* name and keeping `entity_id: switch.bonus_room` stable, so no YAML reference churns.

## Test plan

- [ ] After auto-merge + gitops-sync deploys, press Button 2 short → confirm Sunset palette renders across the four bulbs (each a different warm color)
- [ ] Press Button 3 short → confirm Ocean palette
- [ ] Hold Button 3 (long) → confirm Rainbow palette
- [ ] Hold Button 4 (long) → confirm colorloop starts cycling
- [ ] Press Button 1 short → confirm static white returns (stops colorloop)
- [ ] Press Button 4 short → confirm all four bulbs off, `switch.bonus_room` stays on
- [ ] Rotate dial CW/CCW with a scene active → confirm brightness still steps ~10% per detent
- [ ] In HA UI under Settings → Devices, confirm Wemo device now reads "Playroom Lights Power" and the entity tile is labeled the same. `switch.bonus_room` entity_id remains unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)