### PR TITLE
Codify ZEN77 Z-Wave parameters so the paddle isn't inert after a re-pair

### DIFF
--- a/packages/office_zen77.yaml
+++ b/packages/office_zen77.yaml
@@ -34,10 +34,14 @@
 # Both controllers read from and write to the same counter, so tapping
 # either one continues from the same scene index. Single source of truth.
 #
-# Hardware note: ZEN77 Parameter "Smart Bulb Mode" (disable internal relay)
-# must be enabled so the paddle fires Central Scene events without cutting
-# power to the load. Configured manually via Settings > Devices > Office
-# Switch > Configure (out of scope for this PR).
+# Hardware setup (codified): The ZEN77 ships with both Scene Control and
+# Smart Bulb Mode disabled. The `zen77_office_parameter_apply` automation
+# at the bottom of this file enables them via zwave_js.set_config_parameter
+# on every HA start and whenever the node returns to "alive", so a re-pair
+# or backup-restore cannot leave the paddle inert.
+#   * Scene Control = 1     → paddle emits Central Scene Notification reports
+#   * Smart Switch Mode = 1 → internal relay decoupled from paddle (scene-only,
+#                              load stays on so wired Hue bulbs keep power)
 
 automation:
   - id: zen77_office_up_cycle
@@ -125,4 +129,40 @@ automation:
         data:
           value: 1
       - action: script.office_sonoff_apply_scene
+    mode: single
+
+  - id: zen77_office_parameter_apply
+    alias: 'Office ZEN77: apply Z-Wave parameters (Scene Control + Smart Switch Mode)'
+    description: >
+      Idempotently sets the two Zooz ZEN77 configuration parameters that the
+      device ships with disabled:
+        * Scene Control = 1     — enable Central Scene reports on paddle taps
+        * Smart Switch Mode = 1 — decouple the internal relay so the paddle is
+                                  scene-only (load stays on, paddle drives
+                                  scenes via the other three automations).
+      Without these, the up/down/hold automations above are inert: paddle taps
+      either fight us by cutting power, or never generate Central Scene events
+      in the first place. Re-runs on every HA start and whenever the Z-Wave
+      node returns to "alive" (covers radio dropouts and device re-pairs).
+      Note: zwave_js.set_config_parameter is keyed by device_id by design —
+      the service finds the underlying Z-Wave node, not an entity. This is the
+      one place a device_id reference is the correct shape.
+    triggers:
+      - trigger: homeassistant
+        event: start
+      - trigger: state
+        entity_id: sensor.office_switch_node_status
+        to: alive
+    conditions: []
+    actions:
+      - action: zwave_js.set_config_parameter
+        data:
+          device_id: 51a69e120926a13bba9cfaac7a2937e7
+          parameter: Scene Control
+          value: 1
+      - action: zwave_js.set_config_parameter
+        data:
+          device_id: 51a69e120926a13bba9cfaac7a2937e7
+          parameter: Smart Switch Mode
+          value: 1
     mode: single


### PR DESCRIPTION
Adds an idempotent startup automation that applies the two configuration
parameters the ZEN77 ships disabled:

  * Scene Control = 1     — paddle emits Central Scene Notification reports
  * Smart Switch Mode = 1 — internal relay decoupled from paddle (scene-only)

Without these, the three paddle automations in packages/office_zen77.yaml
(up tap, down tap, up hold) never fire. PR #241 noted both parameters had
to be set manually via the device's config page and explicitly punted the
work ("out of scope for this PR"). That manual step was never done, so the
switch sat with the blue LED lit and no observable effect on the office
Hue lamps for days until troubleshooting today.

The new automation triggers on both `homeassistant.start` and on the
ZEN77's node_status entity transitioning to "alive", so a backup restore,
HA restart, radio dropout, or device re-include will self-heal. Updates the
header comment block to describe the codified setup instead of pointing at
a manual workflow.

Live behavior was already verified end-to-end during troubleshooting: with
the parameters set via zwave_js.set_config_parameter, an up-paddle tap
fired event.office_switch_scene_001 = KeyPressed, advanced
counter.office_sonoff_scene 2 → 3, and applied scene 3 to all six office
Hue bulbs.

Note on device_id: zwave_js.set_config_parameter is keyed by device_id by
design — it has to identify a Z-Wave node, not an entity. This is the one
place in the repo where a device_id reference is the correct shape, and
the automation's description block calls that out.

Prompt-Origin: |
  Test your access to my HA instance over MCP, then troubleshoot and fix
  my office wall switch (the new zen77.) It's not doing anything, but the
  blue led is lit. Remember and use all your data sources: MCP, context/,
  and repo yaml, project instructions, memory, etc.
Authored-By: Claude Code
Co-Authored-By: Chris Pitzi <cpitzi@gmail.com>
