### PR TITLE
Document Master Bathroom Hubspace light

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ Automations are split across two locations with different governance models:
 | Family Room | `light.family_room`, `light.family_room_2`, `light.floor_lamp` |
 | Entry/Upstairs | `light.entry_1`, `light.entry_2`, `light.downstairs_hallway`, `light.upstairs_hallway_light`, `light.meeting_light` |
 | Outdoor | `light.front_door`, `light.front_lantern`, `light.garage_front`, `light.garage_side`, `light.shed` |
+| Master Bathroom | `light.master_bathroom` (Ecosmart 12A19060WRGBWH2 RGBWW A19, Hubspace cloud) |
 
 ### Switches
 | Entity ID | Description |


### PR DESCRIPTION
Set up the master bathroom Hubspace WiFi bulb end-to-end and document it.

## Origin

> find and configure my master bathroom light. It's a home depot hubspace bulb, wifi

## What changed

- `CLAUDE.md` — added a `Master Bathroom` row to the Lights table with the new `light.master_bathroom` entity, hardware model, and a note that it's cloud-backed via Hubspace.

## Runtime work (not git-tracked — `.storage/` and `custom_components/`)

- Added `jdeath/Hubspace-Homeassistant` as a HACS custom repository and installed it. HA restarted to load the new integration.
- Configured the Hubspace integration via the HA UI (cloud account `cpitzi@gmail.com`, config entry `01KRYY8CBXVY191GVE7BQ8ZXVT`, state `loaded`).
- Created area **Master Bathroom** (`area_id: master_bathroom`, icon `mdi:shower`).
- Discovered device — Ecosmart `12A19060WRGBWH2` RGBWW A19, MAC `34:5f:45:d8:05:1c`, sw `2.6.1.26955-light` — assigned to the new area.
- Renamed `light.master_bathroom_light` → `light.master_bathroom` and set friendly name to `Master Bathroom`. The companion `sensor.master_bathroom_wifi_rssi` followed the device into the new area.

## Notes

- Hubspace is cloud-only: requires internet + Hubspace's servers to be reachable. No local API.
- No automations or dashboard surfaces added (per the request). The bulb is controllable from Settings → Devices & Services and via voice; routing it into `dashboards/home.yaml` or `dashboards/kiosk.yaml` is a follow-up.
- Integration source code lives in `custom_components/hubspace/` (HACS-managed, gitignored); the bulb's config entry lives in `.storage/core.config_entries` (gitignored). The next `context/` snapshot will pick up the new entity and area.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DRZh426fS8Lg625TBboD9u)_