### PR TITLE
Add Sonoff Button 1 long-press → Downstairs + Hallways at 25%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ Automations are split across two locations with different governance models:
 | File | Automations |
 |------|-------------|
 | `meeting.yaml` | 4 automations: meeting button ON/OFF → hallway light red/off; button unavailable → light off; reconnect → re-sync state |
-| `sonoff_button_kitchen_family.yaml` | 2 automations: Sonoff Button 1 single press → Downstairs + Hallways ON; double press → OFF |
+| `sonoff_button_kitchen_family.yaml` | 3 automations: Sonoff Button 1 single press → Downstairs + Hallways ON; double press → OFF; long press → all to 25% |
 
 Additional device-scoped controllers live in `packages/` rather than
 `automations/` when they bundle helpers, scripts, or rest_commands alongside

--- a/automations/sonoff_button_kitchen_family.yaml
+++ b/automations/sonoff_button_kitchen_family.yaml
@@ -41,3 +41,25 @@
     target:
       entity_id: switch.family_room_outlets
   mode: single
+- id: sonoff_button_1_kitchen_family_dim
+  alias: 'Sonoff Button 1: Long press → Downstairs + Hallways 25%'
+  triggers:
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      device_ieee: f0:44:d3:ff:fe:f6:94:01
+      command: "off"
+  conditions: []
+  actions:
+  - action: light.turn_on
+    data:
+      brightness_pct: 25
+    target:
+      entity_id:
+        - group.downstairs_lights
+        - light.downstairs_hallway
+        - light.upstairs_hallway_light
+  - action: switch.turn_on
+    target:
+      entity_id: switch.family_room_outlets
+  mode: single


### PR DESCRIPTION
Adds a long-press binding to Sonoff Button 1 that dims the downstairs and hallway lights to 25%.

## Origin

> adjust button one so a long press sets the, uh, sets all the lights to twenty five percent brightness

## What changed

Sonoff Button 1 previously had only two bindings (single press → ON at full brightness, double press → OFF). This adds a third automation, `sonoff_button_1_kitchen_family_dim`, triggered by the SNZB-01 long-press event (`zha_event` `command: 'off'` — the same hold command used by Button 2).

The long-press handler:
- Turns on `group.downstairs_lights`, `light.downstairs_hallway`, and `light.upstairs_hallway_light` at `brightness_pct: 25` — the same light targets as the single-press handler.
- Powers on `switch.family_room_outlets` so the dependent floor lamp is included, mirroring the single-press behavior.

`CLAUDE.md` automations table updated from "2 automations" to "3 automations" for this file.

## Test plan

- [ ] CI `check-config` passes against the pinned HA version
- [ ] Long-press Button 1 → downstairs + hallway lights come on at 25%
- [ ] Single press / double press behavior unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQhWbRYNuSTvHtQtqxSmbM)_