### PR TITLE
Drive office door_lamp red with the meeting indicator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Automations are split across two locations with different governance models:
 
 | File | Automations |
 |------|-------------|
-| `meeting.yaml` | 4 automations: meeting button ON/OFF → hallway light red/off; button unavailable → light off; reconnect → re-sync state |
+| `meeting.yaml` | 4 automations: meeting button ON/OFF → hallway light + office `door_lamp` red/restored (`door_lamp` snapshot-and-restored via runtime scene); button unavailable → lights cleared; reconnect → re-sync state |
 | `sonoff_button_kitchen_family.yaml` | 3 automations: Sonoff Button 1 single press → Downstairs + Hallways ON; double press → OFF; long press → all to 25% |
 
 Additional device-scoped controllers live in `packages/` rather than
@@ -280,7 +280,7 @@ The "Kiosk" person/user (Settings → People) is a non-admin local account used 
 ├── .ha-version                 # Pinned HA version for CI (matches running instance)
 ├── .yamllint.yml               # YAML lint rules (line length 250, indentation 2, etc.)
 ├── automations/                # Git-managed automations (see automations/README.md)
-│   ├── meeting.yaml            # Meeting indicator (Rachel's office) → hallway light
+│   ├── meeting.yaml            # Meeting indicator (Rachel's office) → hallway light + office door_lamp
 │   └── sonoff_button_kitchen_family.yaml  # Sonoff Button 1 → Downstairs + Hallways
 ├── packages/                   # HA packages (see packages/README.md)
 │   ├── ha_context_dump.yaml    # Snapshot pipeline: button, periodic trigger, dump action

--- a/automations/README.md
+++ b/automations/README.md
@@ -17,16 +17,20 @@ This partition prevents the GitOps pipeline from silently clobbering UI edits. T
 
 ### `meeting.yaml` — Meeting Indicator
 
-Four automations managing a physical meeting-in-progress indicator for Rachel's office. An ESP32 button device drives a hallway light as a visual signal.
+Four automations managing a physical meeting-in-progress indicator for Rachel's office. An ESP32 button device drives two lights as a visual signal: `light.meeting_light` (a dedicated hallway indicator) and `light.door_lamp` (an office lamp).
 
 | Automation ID | Trigger | Action |
 |---------------|---------|--------|
-| `meeting_status_on` | Button entity turns `on` | Hallway light → red (RGB 255,0,0, brightness 150) |
-| `meeting_status_off` | Button entity turns `off` | Hallway light → off |
-| `meeting_button_offline` | Button unavailable for 10 s | Hallway light → off (fail-safe) |
-| `meeting_button_reconnect` | Button becomes available | Re-sync hallway light to current button state |
+| `meeting_status_on` | Button `off` → `on` | Snapshot `door_lamp`, then hallway + office lamp → red (RGB 255,0,0, brightness 255) |
+| `meeting_status_off` | Button `on` → `off` | Hallway light → off; office lamp → restored to its pre-meeting state |
+| `meeting_button_offline` | Button unavailable for 10 s | Hallway light → off; office lamp → restored (fail-safe) |
+| `meeting_button_reconnect` | Button becomes available | Re-sync hallway + office lamp to current button state |
 
-The offline/reconnect pair handles an important edge case: if the ESP32 drops off WiFi while the button is on, the hallway light would remain red indefinitely. The 10-second unavailability trigger clears it; the reconnect trigger restores the correct state without manual intervention.
+**Hallway vs. office lamp.** The hallway light is a dedicated indicator — it is simply turned red or off. The office lamp is a general-purpose light that may already be in use, so instead of being turned off when the meeting ends it is **restored to its pre-meeting state**. `meeting_status_on` captures that state into a runtime scene (`scene.meeting_office_door_lamp_snapshot`) via `scene.create` immediately before going red; the OFF/offline/reconnect handlers reapply it with `scene.turn_on`.
+
+The restore steps gate on `light.meeting_light` being on — it is the proxy for "the indicator is currently showing." This prevents a button blip while no meeting is active from clobbering `door_lamp` with a stale snapshot.
+
+The offline/reconnect pair handles an important edge case: if the ESP32 drops off WiFi while the button is on, the lights would remain red indefinitely. The 10-second unavailability trigger clears them (hallway off, office lamp restored); the reconnect trigger restores the correct state without manual intervention.
 
 ## Adding automations
 

--- a/automations/meeting.yaml
+++ b/automations/meeting.yaml
@@ -1,11 +1,32 @@
+# Meeting indicator — physical "in a meeting" signal for Rachel's office.
+#
+# An ESP32 button (switch.meeting_button_in_meeting) drives two lights red:
+#   - light.meeting_light : dedicated hallway indicator (red on / off)
+#   - light.door_lamp     : an office lamp, snapshot-and-restored so a lamp
+#                           that was already in use is returned to its prior
+#                           state when the meeting ends, instead of just off.
+#
+# door_lamp's pre-meeting state is captured into the runtime scene
+# scene.meeting_office_door_lamp_snapshot via scene.create, and reapplied with
+# scene.turn_on when the meeting clears.
+#
+# "Is the indicator currently showing?" is read off light.meeting_light — it is
+# on iff a meeting is being displayed. The restore steps gate on it so a button
+# blip while no meeting is active never clobbers door_lamp with a stale snapshot.
 - id: meeting_status_on
-  alias: 'Meeting: Status ON — hallway red'
+  alias: 'Meeting: Status ON — hallway + office red'
   triggers:
   - entity_id: switch.meeting_button_in_meeting
+    from: 'off'
     to: 'on'
     trigger: state
   conditions: []
   actions:
+  - action: scene.create
+    data:
+      scene_id: meeting_office_door_lamp_snapshot
+      snapshot_entities:
+      - light.door_lamp
   - action: light.turn_on
     data:
       rgb_color:
@@ -15,16 +36,31 @@
       brightness: 255
       transition: 1
     target:
-      entity_id: light.meeting_light
+      entity_id:
+      - light.meeting_light
+      - light.door_lamp
   mode: single
 - id: meeting_status_off
-  alias: 'Meeting: Status OFF — hallway green'
+  alias: 'Meeting: Status OFF — hallway off, office restored'
   triggers:
   - entity_id: switch.meeting_button_in_meeting
+    from: 'on'
     to: 'off'
     trigger: state
   conditions: []
   actions:
+  - if:
+    - condition: state
+      entity_id: light.meeting_light
+      state: 'on'
+    - condition: template
+      value_template: '{{ states.scene.meeting_office_door_lamp_snapshot is not none }}'
+    then:
+    - action: scene.turn_on
+      target:
+        entity_id: scene.meeting_office_door_lamp_snapshot
+      data:
+        transition: 1
   - action: light.turn_off
     data:
       transition: 1
@@ -32,7 +68,7 @@
       entity_id: light.meeting_light
   mode: single
 - id: meeting_button_offline
-  alias: 'Meeting: Button offline — hallway off'
+  alias: 'Meeting: Button offline — hallway off, office restored'
   triggers:
   - entity_id: switch.meeting_button_in_meeting
     to: unavailable
@@ -41,6 +77,18 @@
     trigger: state
   conditions: []
   actions:
+  - if:
+    - condition: state
+      entity_id: light.meeting_light
+      state: 'on'
+    - condition: template
+      value_template: '{{ states.scene.meeting_office_door_lamp_snapshot is not none }}'
+    then:
+    - action: scene.turn_on
+      target:
+        entity_id: scene.meeting_office_door_lamp_snapshot
+      data:
+        transition: 2
   - action: light.turn_off
     target:
       entity_id: light.meeting_light
@@ -48,7 +96,7 @@
       transition: 2
   mode: single
 - id: meeting_button_reconnect
-  alias: 'Meeting: Button reconnected — re-sync hallway'
+  alias: 'Meeting: Button reconnected — re-sync hallway + office'
   triggers:
   - entity_id: switch.meeting_button_in_meeting
     from: unavailable
@@ -61,6 +109,19 @@
         entity_id: switch.meeting_button_in_meeting
         state: 'on'
       sequence:
+      # Re-snapshot only when the indicator is not already showing — if it is
+      # (a sub-10s blip that never tripped the offline automation) door_lamp is
+      # still red and the existing snapshot holds the real pre-meeting state.
+      - if:
+        - condition: state
+          entity_id: light.meeting_light
+          state: 'off'
+        then:
+        - action: scene.create
+          data:
+            scene_id: meeting_office_door_lamp_snapshot
+            snapshot_entities:
+            - light.door_lamp
       - action: light.turn_on
         data:
           rgb_color:
@@ -70,12 +131,26 @@
           brightness: 255
           transition: 1
         target:
-          entity_id: light.meeting_light
+          entity_id:
+          - light.meeting_light
+          - light.door_lamp
     - conditions:
       - condition: state
         entity_id: switch.meeting_button_in_meeting
         state: 'off'
       sequence:
+      - if:
+        - condition: state
+          entity_id: light.meeting_light
+          state: 'on'
+        - condition: template
+          value_template: '{{ states.scene.meeting_office_door_lamp_snapshot is not none }}'
+        then:
+        - action: scene.turn_on
+          target:
+            entity_id: scene.meeting_office_door_lamp_snapshot
+          data:
+            transition: 1
       - action: light.turn_off
         data:
           transition: 1


### PR DESCRIPTION
Extends the meeting indicator so the meeting button also turns an office light red, mirroring the existing hallway light.

## Origin

> Adjust my automations so the meeting button/light thing ALSO turns one of the office lights red in the same way as the meeting light

Two clarifying questions were asked and answered before implementing:

- **Which office light?** → `light.door_lamp` (the lamp by the office door — a natural at-a-glance meeting indicator).
- **What happens when the meeting ends?** → Restore its previous state, rather than just turning it off — so a lamp that was already in use isn't killed by the meeting ending.

## What changed

`automations/meeting.yaml` — all four meeting automations now drive `light.door_lamp` alongside `light.meeting_light`:

- **`meeting_status_on`** (button `off` → `on`) — snapshots `door_lamp`'s current state into a runtime scene (`scene.meeting_office_door_lamp_snapshot`) via `scene.create`, then turns both the hallway light and `door_lamp` red.
- **`meeting_status_off`** (button `on` → `off`) — turns the hallway light off and **restores** `door_lamp` to its pre-meeting state via `scene.turn_on`.
- **`meeting_button_offline`** (unavailable 10 s) — same fail-safe restore for `door_lamp`.
- **`meeting_button_reconnect`** — re-syncs both lights to the button's current state.

### Design notes

- **Hallway light is unchanged in spirit** — it's a dedicated indicator, so it's still just turned red/off. `door_lamp` is a general-purpose lamp, so it gets snapshot-and-restore treatment instead.
- **Restore is gated on `light.meeting_light` being on**, which serves as the "indicator is currently showing" proxy. This prevents a button blip while no meeting is active from clobbering `door_lamp` with a stale snapshot.
- **Triggers tightened** — `meeting_status_on`/`off` now pin `from:` (`off`→`on` / `on`→`off`) so reconnect-from-`unavailable` transitions are handled solely by `meeting_button_reconnect`, giving exactly one handler per state transition (no double-fire, no concurrency races).
- The runtime snapshot scene is intentionally ephemeral (not committed YAML); all restore steps also guard on its existence so a mid-meeting HA restart can't throw an error.

`light.door_lamp` is RGB-capable — it's already driven with `rgb_color` by the office candle scenes in `packages/sonoff_button_office.yaml`.

Docs updated: `automations/README.md` and the `meeting.yaml` rows in `CLAUDE.md`.

## Test plan

- [ ] `YAML Lint` and `check-config` CI pass
- [ ] Press meeting button on → hallway light and `door_lamp` both go red
- [ ] Press meeting button off → hallway light off, `door_lamp` returns to its pre-meeting state (off if it was off, prior color/brightness if it was on)
- [ ] Pull the ESP32 offline mid-meeting → after 10 s both lights clear (`door_lamp` restored)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELX4379tY1cx995bnvWaNP)_