### PR TITLE
Warm office scene 1 to 2700K

### DIFF
--- a/packages/sonoff_button_office.yaml
+++ b/packages/sonoff_button_office.yaml
@@ -37,7 +37,7 @@
 # lamps don't all brighten or dim on the same beat.
 #
 # Scene catalog:
-#   1  Bright            — all 6, 100% / 4000K  (general illumination)
+#   1  Bright            — all 6, 100% / 2700K  (warm general illumination)
 #   2  Relax             — all 6, 40%  / 2200K  (warm, low)
 #   3  Focus             — all 6, 100% / 5000K  (bright, cool)
 #   4  Amber Candle      — flicker rgb(255, 100, 15)
@@ -92,7 +92,7 @@ script:
                   entity_id: '{{ office_lamps }}'
                 data:
                   brightness_pct: 100
-                  color_temp_kelvin: 4000
+                  color_temp_kelvin: 2700
           - conditions: "{{ states('counter.office_sonoff_scene') == '2' }}"
             sequence:
               - action: light.turn_on


### PR DESCRIPTION
Drops scene 1 from 4000K to 2700K — keeps full brightness but a much warmer general-illumination feel.

## Origin

> change the office light scenes so scene 1 is full brightness but much warmer

## Changes

- `packages/sonoff_button_office.yaml`: scene 1 `color_temp_kelvin` 4000 → 2700; updated catalog comment.

Scene 1 remains the "first tap" / "long hold bail-out" target, still 100% brightness. Stays distinct from neighbors:

| Scene | Brightness | Color |
|-------|------------|-------|
| 1 Bright | 100% | **2700K** (was 4000K) |
| 2 Relax | 40% | 2200K |
| 3 Focus | 100% | 5000K |


---
_Generated by [Claude Code](https://claude.ai/code/session_01MxReKbdGbCK1wh88esmsaS)_