### PR TITLE
ZEN77 hold to dim/brighten current office scene

### DIFF
--- a/packages/office_zen77.yaml
+++ b/packages/office_zen77.yaml
@@ -19,13 +19,17 @@
 #   value: KeyPressed2x..5x     = multi-tap (intentionally unhandled, reserved)
 #
 # Bindings:
-#   up tap   → if lights off, reset counter to 1 and apply scene 1;
-#              otherwise advance counter (wraps 11 → 1) and apply.
-#              i.e. first tap turns on, subsequent taps cycle scenes.
-#   down tap → all 6 office lamps off (counter persists, candle loop killed).
-#   up hold  → jump straight to scene 1 (Bright), reset counter to 1.
-#              Useful for bailing out of a colored/flicker scene without
-#              click-cycling through the rest of the catalog.
+#   up tap    → if lights off, reset counter to 1 and apply scene 1;
+#               otherwise advance counter (wraps 11 → 1) and apply.
+#               i.e. first tap turns on, subsequent taps cycle scenes.
+#   down tap  → all 6 office lamps off (counter persists, candle loop killed).
+#   up hold   → brighten the current scene by 10%. KeyHeldDown fires
+#               repeatedly while the paddle is held, so each fire steps
+#               input_number.office_brightness up (capped at 100). apply_scene
+#               is called with reset_brightness:false so the helper drives.
+#   down hold → dim the current scene by 10% (floored at 10).
+#   To bail out of a colored/flicker scene back to scene 1, use the
+#   Sonoff button's long-press, or tap down (off) then up (on → scene 1).
 #
 # Shared state with the Sonoff Button 2:
 #   counter:  counter.office_sonoff_scene
@@ -113,8 +117,8 @@ automation:
           entity_id: '{{ office_lamps }}'
     mode: single
 
-  - id: zen77_office_up_hold_bright
-    alias: 'Office ZEN77: Up hold → jump to scene 1 (Bright)'
+  - id: zen77_office_up_hold_brighten
+    alias: 'Office ZEN77: Up hold → brighten current scene'
     triggers:
       - trigger: event
         event_type: zwave_js_value_notification
@@ -123,15 +127,49 @@ automation:
           command_class_name: Central Scene
           property_key_name: '001'
           value: KeyHeldDown
-    conditions: []
+    conditions:
+      - condition: state
+        entity_id: binary_sensor.office_lights_on
+        state: 'on'
     actions:
-      - action: counter.set_value
+      - action: input_number.set_value
         target:
-          entity_id: counter.office_sonoff_scene
+          entity_id: input_number.office_brightness
         data:
-          value: 1
+          value: "{{ [(states('input_number.office_brightness') | float(100)) + 10, 100] | min }}"
       - action: script.office_sonoff_apply_scene
-    mode: single
+        data:
+          reset_brightness: false
+    # KeyHeldDown fires repeatedly (~every 500 ms) while held. queued lets
+    # each fire step the helper in order; max:20 caps a runaway hold.
+    mode: queued
+    max: 20
+
+  - id: zen77_office_down_hold_dim
+    alias: 'Office ZEN77: Down hold → dim current scene'
+    triggers:
+      - trigger: event
+        event_type: zwave_js_value_notification
+        event_data:
+          device_id: 51a69e120926a13bba9cfaac7a2937e7
+          command_class_name: Central Scene
+          property_key_name: '002'
+          value: KeyHeldDown
+    conditions:
+      - condition: state
+        entity_id: binary_sensor.office_lights_on
+        state: 'on'
+    actions:
+      - action: input_number.set_value
+        target:
+          entity_id: input_number.office_brightness
+        data:
+          value: "{{ [(states('input_number.office_brightness') | float(100)) - 10, 10] | max }}"
+      - action: script.office_sonoff_apply_scene
+        data:
+          reset_brightness: false
+    mode: queued
+    max: 20
 
   - id: zen77_office_parameter_apply
     alias: 'Office ZEN77: apply Z-Wave parameters (Scene Control + Smart Switch Mode)'

--- a/packages/sonoff_button_office.yaml
+++ b/packages/sonoff_button_office.yaml
@@ -57,6 +57,13 @@
 # drops to 3 or below. Every static scene calls script.turn_off on it before
 # applying. Transitioning into any flicker scene calls script.turn_on so the
 # apply script fires-and-forgets — it never waits on the infinite loop.
+#
+# Live brightness: input_number.office_brightness (10-100, step 10) is the
+# brightness applied by every scene. Static scenes read it directly;
+# flicker tick scales its 75-92% random band by `helper / 100`. apply_scene
+# resets the helper to the new scene's default brightness on every tap/cycle
+# (1=100, 2=40, 3=100, 4-11=100) — pass `reset_brightness: false` to render
+# without touching the helper (used by ZEN77 hold-to-dim/brighten).
 
 counter:
   office_sonoff_scene:
@@ -67,10 +74,26 @@ counter:
     step: 1
     restore: true
 
+input_number:
+  office_brightness:
+    name: Office Brightness
+    min: 10
+    max: 100
+    step: 10
+    unit_of_measurement: '%'
+    icon: mdi:brightness-6
+
 script:
   office_sonoff_apply_scene:
     alias: 'Office Sonoff: Apply current scene'
     mode: restart
+    fields:
+      reset_brightness:
+        description: >-
+          When true (default), resets input_number.office_brightness to the
+          new scene's default before rendering. Pass false from hold-to-dim
+          handlers so the helper drives the render instead.
+        default: true
     variables:
       # Office lamps to drive. While a meeting is active (light.meeting_light
       # on) light.door_lamp is owned by the meeting indicator and is dropped
@@ -81,9 +104,24 @@ script:
         {{ lamps if is_state('light.meeting_light', 'on')
            else lamps + ['light.door_lamp'] }}
     sequence:
-      - action: script.turn_off
-        target:
-          entity_id: script.office_sonoff_candle_loop
+      # Scene-change path: reset helper to scene default and kill any running
+      # candle loop so the choose: block below starts fresh. On hold-to-dim
+      # (reset_brightness:false) we skip both — the helper is already at the
+      # caller's stepped value, and a running flicker loop must keep ticking
+      # so the next ~400 ms tick picks up the new helper value without a
+      # visible kill/restart glitch.
+      - if:
+          - condition: template
+            value_template: "{{ reset_brightness }}"
+        then:
+          - action: input_number.set_value
+            target:
+              entity_id: input_number.office_brightness
+            data:
+              value: "{{ 40 if states('counter.office_sonoff_scene') == '2' else 100 }}"
+          - action: script.turn_off
+            target:
+              entity_id: script.office_sonoff_candle_loop
       - choose:
           - conditions: "{{ states('counter.office_sonoff_scene') == '1' }}"
             sequence:
@@ -91,7 +129,7 @@ script:
                 target:
                   entity_id: '{{ office_lamps }}'
                 data:
-                  brightness_pct: 100
+                  brightness_pct: "{{ states('input_number.office_brightness') | int(100) }}"
                   color_temp_kelvin: 2700
           - conditions: "{{ states('counter.office_sonoff_scene') == '2' }}"
             sequence:
@@ -99,7 +137,7 @@ script:
                 target:
                   entity_id: '{{ office_lamps }}'
                 data:
-                  brightness_pct: 40
+                  brightness_pct: "{{ states('input_number.office_brightness') | int(40) }}"
                   color_temp_kelvin: 2200
           - conditions: "{{ states('counter.office_sonoff_scene') == '3' }}"
             sequence:
@@ -107,13 +145,17 @@ script:
                 target:
                   entity_id: '{{ office_lamps }}'
                 data:
-                  brightness_pct: 100
+                  brightness_pct: "{{ states('input_number.office_brightness') | int(100) }}"
                   color_temp_kelvin: 5000
           # Scenes 4-11 are all flicker variants; the loop reads its target
           # color from a palette dict keyed on the counter, so we just turn
           # it on for any scene >= 4 and cycling between hues changes
-          # color seamlessly on the next tick.
-          - conditions: "{{ states('counter.office_sonoff_scene') | int(0) >= 4 }}"
+          # color seamlessly on the next tick. Gated on reset_brightness so
+          # hold-to-dim on a running flicker scene is a no-op (the loop is
+          # already ticking, the helper update reaches it on next iteration).
+          - conditions:
+              - "{{ states('counter.office_sonoff_scene') | int(0) >= 4 }}"
+              - "{{ reset_brightness }}"
             sequence:
               - action: script.turn_on
                 target:
@@ -135,7 +177,9 @@ script:
         default: 0
     variables:
       scene: "{{ states('counter.office_sonoff_scene') | int(0) }}"
-      brightness: "{{ range(75, 93) | random }}"
+      # 75-92% random flicker band scaled by input_number.office_brightness.
+      # At helper=100 (default) the band is unchanged; at helper=50 it's 37-46%.
+      brightness: "{{ ((range(75, 93) | random) * (states('input_number.office_brightness') | int(100)) / 100) | int }}"
     sequence:
       - choose:
           # Scene 10 — Rainbow Sync: all lamps share the same hue, driven by


### PR DESCRIPTION
Adds hold-to-dim/brighten on the ZEN77 wall switch via a new `input_number.office_brightness` helper that every office scene reads from.

## Origin

> change the office wall switch so holding down or up dims or brightens whatever scene is current

Follow-up clarifications:
- Scope: all scenes (static and flicker) via brightness helper.
- Fallback on dim-doesn't-apply: moot since dim applies everywhere — the prior up-hold-to-bail-to-scene-1 escape is removed from the ZEN77 and is still available on the Sonoff button's long-press.

## Changes

**`packages/sonoff_button_office.yaml`**
- New helper `input_number.office_brightness` (10-100, step 10, default 100).
- `script.office_sonoff_apply_scene` gets a `reset_brightness` field (default true). Scene-change path resets the helper to scene default (1=100, 2=40, 3=100, 4-11=100) and tears down the candle loop. Hold-to-dim passes `false` and skips both — the loop keeps ticking and reads the helper on the next ~400ms tick.
- Static scenes 1-3 read `brightness_pct` from the helper.
- `office_lamp_tick` scales its 75-92% random band by `helper / 100`.

**`packages/office_zen77.yaml`**
- Replaces `zen77_office_up_hold_bright` with `zen77_office_up_hold_brighten`: each `KeyHeldDown` event clamps helper +10 (capped 100) and re-renders.
- New `zen77_office_down_hold_dim`: each event clamps helper -10 (floored 10) and re-renders.
- Both gated on `binary_sensor.office_lights_on == on` so holding when off doesn't quietly drift the helper. `mode: queued`, `max: 20` so rapid repeat events step in order without dropping.

## Behavior

| Action | Effect |
|--------|--------|
| Up tap | Cycle to next scene (resets brightness to scene default) |
| Down tap | All office lamps off |
| Up hold | +10% brightness per fire (~every 500 ms) |
| Down hold | -10% brightness per fire |

Flicker scenes dim smoothly because the helper feeds the per-lamp tick — no kill/restart of the candle loop.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MxReKbdGbCK1wh88esmsaS)_