### PR TITLE
Fix office cycle taps not resetting brightness helper

### DIFF
--- a/packages/sonoff_button_office.yaml
+++ b/packages/sonoff_button_office.yaml
@@ -104,6 +104,13 @@ script:
         {{ lamps if is_state('light.meeting_light', 'on')
            else lamps + ['light.door_lamp'] }}
     sequence:
+      # Coerce reset_brightness to its passed value or true. The fields.default
+      # above only seeds the dev-tools service form; at runtime, callers that
+      # invoke this script without `data: { reset_brightness: ... }` leave the
+      # variable undefined, and `{{ reset_brightness }}` renders as "" (falsy).
+      # That made the reset path below silently skip on every tap-to-cycle.
+      - variables:
+          reset_brightness: "{{ reset_brightness | default(true) }}"
       # Scene-change path: reset helper to scene default and kill any running
       # candle loop so the choose: block below starts fresh. On hold-to-dim
       # (reset_brightness:false) we skip both — the helper is already at the


### PR DESCRIPTION
## Origin

> my office lights won't brighten via the wall switch and the cycles all seem very dim

Reported after PR #259 ("ZEN77 hold to dim/brighten") merged. Diagnosed
live: `counter.office_sonoff_scene = 1` (Bright), but lamps were at
`brightness=51` (20%) and the brightness helper was stuck at 20%
regardless of how many times the up paddle was tapped. Holding up did
step the helper +10% but only once per hold-down-and-release.

## Root cause

`script.office_sonoff_apply_scene` gates its reset-helper-to-scene-default
block on `{{ reset_brightness }}` with `fields.reset_brightness.default:
true`. **HA script `fields.<name>.default` only seeds the dev-tools
service form** — at runtime, callers that invoke the script without
`data: { reset_brightness: ... }` leave the variable undefined, and the
template renders as `""` (falsy). The reset block silently skipped on
every cycle tap, and so did the scene-4-11 candle-loop gate (same
template reference).

The three tap automations all call apply_scene with no data:

- `zen77_office_up_cycle`
- `sonoff_button_2_office_cycle`
- `sonoff_button_2_office_jump_to_bright`

So once the helper landed below 100% (a single down-hold was enough),
every subsequent scene rendered at that brightness.

**Verification (live):**

| step | observation |
|------|-------------|
| set helper to 30, call `apply_scene` with no data | helper stayed at 30 ✗ |
| same call with `data: { reset_brightness: true }` | helper jumped to 100 ✓ |

## Fix

One `variables:` block at the top of the script's `sequence:` coerces
the field to its passed value or `true` at every invocation. Both
downstream `{{ reset_brightness }}` references then see the intended
default without touching any caller.

```yaml
sequence:
  - variables:
      reset_brightness: "{{ reset_brightness | default(true) }}"
  - if:
      - condition: template
        value_template: "{{ reset_brightness }}"
    ...
```

`fields:` declaration is kept so the dev-tools form still surfaces the
parameter.

## Test plan

- [x] Live MCP repro on main: helper does not reset on tap-with-no-data
- [x] Live MCP confirmation: helper resets when `data: { reset_brightness: true }` is passed explicitly
- [ ] After deploy: tap up paddle from any dimmed scene → scene 1 renders at 100% / 2700K, helper reads 100
- [ ] After deploy: tap-cycle through scenes → each scene renders at its default brightness
- [ ] After deploy: up-hold from scene 1 brightens (no-op at 100), down-hold dims by 10% per fire
- [ ] After deploy: tap to a different scene resets helper to that scene's default (40 for scene 2, 100 otherwise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)