### PR TITLE
chore: gitignore session strays and allow read-only HA MCP tools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,14 @@
     "allow": [
       "Bash(git fetch *)",
       "Bash(yamllint *)",
-      "Bash(shellcheck *)"
+      "Bash(shellcheck *)",
+      "mcp__Local-HA__ha_get_state",
+      "mcp__Local-HA__ha_get_logs",
+      "mcp__Local-HA__ha_search_entities",
+      "mcp__Local-HA__ha_get_history",
+      "mcp__Local-HA__ha_read_resource",
+      "mcp__Local-HA__ha_get_skill_home_assistant_best_practices",
+      "mcp__Local-HA__ha_get_device"
     ]
   },
   "hooks": {

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ esphome/archive/
 .context-mirror/
 ha-context-dump.log
 ha-context-dump.log.*
+
+# Claude Code session state — ephemeral cowork worktrees
+.claude/worktrees/
+
+# GitHub PAT — credential, never commit
+.gh-token


### PR DESCRIPTION
## Origin

> gitignore the strays and open the PR

Triggered by a `git status` check that surfaced two untracked items the repo shouldn't track: `.claude/worktrees/` (Claude cowork session state) and `.gh-token` (a GitHub PAT, confirmed `github_pat_...`). The same working tree had a modified `.claude/settings.json` adding read-only HA MCP tools to the permission allowlist; bundling both into one PR since they're both cleanup of the same `.claude/` surface.

## Summary

- Ignore `.claude/worktrees/` (ephemeral cowork session worktrees) and `.gh-token` (GitHub PAT credential).
- Add seven read-only `mcp__Local-HA__` tools to the Claude permission allowlist so routine HA exploration doesn't prompt: `ha_get_state`, `ha_get_logs`, `ha_search_entities`, `ha_get_history`, `ha_read_resource`, `ha_get_skill_home_assistant_best_practices`, `ha_get_device`.

## Notes

- The `.gh-token` file at the repo root is now ignored, but per `~/repos/CLAUDE.md` the canonical PAT location is `~/repos/.gh-token`. The stray copy at the repo root may want to be moved or removed in follow-up — out of scope here.
- Untracked items left in place by design: `docs/workflows/cowork-cc-dashboard-workflow.md` (deferred to author), `issue-body.md` (scratchpad from prior PR — author can clean up).