### PR TITLE
Alert when exterior doors are left open after sunset

### DIFF
--- a/automations/exterior_doors_night.yaml
+++ b/automations/exterior_doors_night.yaml
@@ -1,0 +1,40 @@
+# Alerts when any exterior door has been open for 5 minutes after sunset.
+# Konnected alarm panel zones cover the four entry doors; the ratgdo
+# dry-contact-open sensors cover both garage rolling doors.
+- id: exterior_door_left_open_at_night
+  alias: 'Exterior door left open after sunset'
+  description: >-
+    Notifies the phone (and posts a persistent notification) when an exterior
+    door has been open for 5 minutes between sunset and sunrise. Parallel mode
+    so each door alerts independently.
+  mode: parallel
+  max: 10
+  triggers:
+    - trigger: state
+      entity_id:
+        - binary_sensor.main_panel_front_door
+        - binary_sensor.main_panel_basement_door
+        - binary_sensor.main_panel_sliding_door
+        - binary_sensor.main_panel_garage_door
+        - binary_sensor.garage_door_1_dry_contact_open
+        - binary_sensor.garage_door_2_dry_contact_open
+      to: 'on'
+      for:
+        minutes: 5
+  conditions:
+    - condition: sun
+      after: sunset
+      before: sunrise
+  actions:
+    - action: notify.mobile_app_sm_s926u1
+      data:
+        title: 'Door left open'
+        message: '{{ trigger.to_state.name }} has been open for 5 minutes (after dark).'
+        data:
+          tag: 'exterior-door-open-{{ trigger.entity_id }}'
+          channel: Security
+          importance: high
+    - action: notify.persistent_notification
+      data:
+        title: 'Door left open'
+        message: '{{ trigger.to_state.name }} has been open for 5 minutes after dark.'


### PR DESCRIPTION
Adds `automations/exterior_doors_night.yaml` — phone push + persistent notification when an exterior door has been open for 5 minutes after dark.

## Origin

> set up an automation in HA that alerts me if an exterior door is left open anywhere at night

Followed by:

> read repos/homeassistant-config/*.md and get the automation codified properly

(The first prompt produced a prototype via `ha_config_set_automation` into `.storage/`; the second asked to codify it as git YAML per the repo's three-layer state model. Storage-mode automation was deleted before this commit.)

## What it does

- **Watches 6 sensors:**
  - `binary_sensor.main_panel_front_door`
  - `binary_sensor.main_panel_basement_door`
  - `binary_sensor.main_panel_sliding_door`
  - `binary_sensor.main_panel_garage_door`
  - `binary_sensor.garage_door_1_dry_contact_open`
  - `binary_sensor.garage_door_2_dry_contact_open`
- **Triggers** when any of them has been `on` for 5 minutes
- **Gated by** `condition: sun` (after sunset / before sunrise) — handles seasonal drift, no fixed time window
- **Parallel mode** (`max: 10`) so each door alerts independently with its own `tag`
- **Actions:** `notify.mobile_app_sm_s926u1` (high-importance Security channel) + `notify.persistent_notification`

## Best-practices checklist

- [x] Native `state` trigger with `for:` — no template polling
- [x] Native `sun` condition — no `{{ now().hour }}` template
- [x] `entity_id` references, no `device_id`
- [x] `mode: parallel` for per-entity independent fires (per `automation-patterns.md#automation-modes`)
- [x] Templates restricted to `data.message` / `data.tag` (allowed positions per the skill)

## Test plan

- [ ] Wait for gitops-sync to deploy (≤5 min after merge)
- [ ] Run `ha_check_config` on live system
- [ ] Confirm `automation.exterior_door_left_open_after_sunset` exists and is enabled
- [ ] Manually leave a door open after sunset, confirm push arrives at 5 min mark