### PR TITLE
Swap meeting indicator office lamp: door_lamp → corner_lamp

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -43,18 +43,18 @@ The same PAT lives in two places: `secrets.yaml` on the HA instance as `github_p
 A physical "in a meeting" signal for Rachel's office. An ESP32 button (`switch.meeting_button_in_meeting`) drives two lights red while a meeting is on:
 
 - **`light.meeting_light`** — a dedicated hallway indicator. Simply red (on) or off.
-- **`light.door_lamp`** — one of the six office lamps. Turned red as an in-room indicator while a meeting is active, then handed back to the office scene controller when the meeting ends.
+- **`light.corner_lamp`** — one of the six office lamps. Turned red as an in-room indicator while a meeting is active, then handed back to the office scene controller when the meeting ends.
 
-### door_lamp ownership
+### corner_lamp ownership
 
-`door_lamp` is normally driven by the office scene controller (`office_zen77.yaml` + `sonoff_button_office.yaml`). While a meeting is active the meeting indicator owns it exclusively — the office controller drops `door_lamp` from every scene-apply and office-off action, so cycling the office scene mid-meeting cannot disturb the red.
+`corner_lamp` is normally driven by the office scene controller (`office_zen77.yaml` + `sonoff_button_office.yaml`). While a meeting is active the meeting indicator owns it exclusively — the office controller drops `corner_lamp` from every scene-apply and office-off action, so cycling the office scene mid-meeting cannot disturb the red.
 
 `light.meeting_light` being on is the shared "a meeting is active" signal: nothing else ever turns it on, and both this package and the office controller read it via `is_state('light.meeting_light', ...)`.
 
 ### Components
 
-**`script.meeting_indicator_show`** — turns the hallway light and `door_lamp` red. If the office is mid-flicker it waits ~1 s for the candle loop's `door_lamp` branch to bow out before claiming the lamp, and skips `door_lamp` if the meeting ended during that wait.
+**`script.meeting_indicator_show`** — turns the hallway light and `corner_lamp` red. If the office is mid-flicker it waits ~1 s for the candle loop's `corner_lamp` branch to bow out before claiming the lamp, and skips `corner_lamp` if the meeting ended during that wait.
 
-**`script.meeting_indicator_clear`** — turns the hallway light off, then hands `door_lamp` back: off if the rest of the office is off, otherwise re-renders the current office scene via `script.office_sonoff_apply_scene` so `door_lamp` rejoins it.
+**`script.meeting_indicator_clear`** — turns the hallway light off, then hands `corner_lamp` back: off if the rest of the office is off, otherwise re-renders the current office scene via `script.office_sonoff_apply_scene` so `corner_lamp` rejoins it.
 
 **Four automations** — `meeting_status_on` / `meeting_status_off` (button on/off), `meeting_button_offline` (unavailable 10 s — fail-safe clear), `meeting_button_reconnect` (re-sync after a WiFi blip). Each just calls one of the two scripts.

--- a/packages/meeting_indicator.yaml
+++ b/packages/meeting_indicator.yaml
@@ -2,18 +2,18 @@
 #
 # An ESP32 button (switch.meeting_button_in_meeting) drives two lights:
 #   - light.meeting_light : a dedicated hallway indicator (red on / off).
-#   - light.door_lamp     : one of the six office lamps. While a meeting is
+#   - light.corner_lamp   : one of the six office lamps. While a meeting is
 #                           active it is turned red as an in-room indicator;
 #                           when the meeting ends it rejoins the office scene.
 #
-# door_lamp ownership
-# -------------------
-# door_lamp is normally one of the lamps driven by the office scene controller
+# corner_lamp ownership
+# ---------------------
+# corner_lamp is normally one of the lamps driven by the office scene controller
 # (packages/office_zen77.yaml + packages/sonoff_button_office.yaml). While a
 # meeting is active the meeting indicator owns it exclusively: the office
-# controller drops door_lamp from every scene/off action for the duration, so
+# controller drops corner_lamp from every scene/off action for the duration, so
 # cycling the office scene mid-meeting cannot disturb the red. When the meeting
-# ends door_lamp is handed back — it rejoins the current office scene, or turns
+# ends corner_lamp is handed back — it rejoins the current office scene, or turns
 # off if the rest of the office is off.
 #
 # "Is a meeting active?" is read off light.meeting_light: it is on iff the
@@ -21,8 +21,8 @@
 # package and the office controller use that as the shared signal.
 #
 # Two scripts hold the shared logic so the four automations stay thin:
-#   meeting_indicator_show  — turn the hallway light and door_lamp red.
-#   meeting_indicator_clear — turn the hallway light off and hand door_lamp
+#   meeting_indicator_show  — turn the hallway light and corner_lamp red.
+#   meeting_indicator_clear — turn the hallway light off and hand corner_lamp
 #                             back to the office scene controller.
 
 script:
@@ -37,9 +37,9 @@ script:
           rgb_color: [255, 0, 0]
           brightness: 255
           transition: 1
-      # If the office is mid-flicker, the candle loop's door_lamp branch needs
+      # If the office is mid-flicker, the candle loop's corner_lamp branch needs
       # a beat to see the meeting and stop ticking — otherwise its last tick
-      # could overwrite the red. Wait it out before claiming door_lamp.
+      # could overwrite the red. Wait it out before claiming corner_lamp.
       - if:
           - condition: state
             entity_id: script.office_sonoff_candle_loop
@@ -47,7 +47,7 @@ script:
         then:
           - delay:
               seconds: 1
-      # Skip door_lamp if the meeting ended during that wait.
+      # Skip corner_lamp if the meeting ended during that wait.
       - if:
           - condition: state
             entity_id: switch.meeting_button_in_meeting
@@ -55,7 +55,7 @@ script:
         then:
           - action: light.turn_on
             target:
-              entity_id: light.door_lamp
+              entity_id: light.corner_lamp
             data:
               rgb_color: [255, 0, 0]
               brightness: 255
@@ -71,12 +71,12 @@ script:
         data:
           transition: 1
       - choose:
-          # Rest of the office is off → door_lamp joins them (off).
+          # Rest of the office is off → corner_lamp joins them (off).
           - conditions:
               - condition: state
                 entity_id:
                   - light.bookcase_lamp
-                  - light.corner_lamp
+                  - light.door_lamp
                   - light.desk_lamp_2
                   - light.desk_lamp_2_2
                   - light.table_lamp
@@ -84,12 +84,12 @@ script:
             sequence:
               - action: light.turn_off
                 target:
-                  entity_id: light.door_lamp
+                  entity_id: light.corner_lamp
                 data:
                   transition: 1
         # Rest of the office is on → re-render the current office scene. With
-        # the meeting cleared (meeting_light now off), door_lamp is back in the
-        # controller's lamp set, so this rejoins it to the scene.
+        # the meeting cleared (meeting_light now off), corner_lamp is back in
+        # the controller's lamp set, so this rejoins it to the scene.
         default:
           - action: script.office_sonoff_apply_scene
 

--- a/packages/office_zen77.yaml
+++ b/packages/office_zen77.yaml
@@ -101,13 +101,13 @@ automation:
           value: KeyPressed
     conditions: []
     variables:
-      # While a meeting is active, door_lamp is owned by the meeting indicator
+      # While a meeting is active, corner_lamp is owned by the meeting indicator
       # (packages/meeting_indicator.yaml) and stays out of office-off.
       office_lamps: >-
-        {% set lamps = ['light.bookcase_lamp', 'light.corner_lamp',
+        {% set lamps = ['light.bookcase_lamp', 'light.door_lamp',
           'light.desk_lamp_2', 'light.desk_lamp_2_2', 'light.table_lamp'] %}
         {{ lamps if is_state('light.meeting_light', 'on')
-           else lamps + ['light.door_lamp'] }}
+           else lamps + ['light.corner_lamp'] }}
     actions:
       - action: script.turn_off
         target:

--- a/packages/sonoff_button_office.yaml
+++ b/packages/sonoff_button_office.yaml
@@ -96,13 +96,13 @@ script:
         default: true
     variables:
       # Office lamps to drive. While a meeting is active (light.meeting_light
-      # on) light.door_lamp is owned by the meeting indicator and is dropped
+      # on) light.corner_lamp is owned by the meeting indicator and is dropped
       # from the set — see packages/meeting_indicator.yaml.
       office_lamps: >-
-        {% set lamps = ['light.bookcase_lamp', 'light.corner_lamp',
+        {% set lamps = ['light.bookcase_lamp', 'light.door_lamp',
           'light.desk_lamp_2', 'light.desk_lamp_2_2', 'light.table_lamp'] %}
         {{ lamps if is_state('light.meeting_light', 'on')
-           else lamps + ['light.door_lamp'] }}
+           else lamps + ['light.corner_lamp'] }}
     sequence:
       # Coerce reset_brightness to its passed value or true. The fields.default
       # above only seeds the dev-tools service form; at runtime, callers that
@@ -265,6 +265,12 @@ script:
                     - condition: numeric_state
                       entity_id: counter.office_sonoff_scene
                       above: 3
+                    # Stop ticking corner_lamp while a meeting owns it.
+                    - condition: not
+                      conditions:
+                        - condition: state
+                          entity_id: light.meeting_light
+                          state: 'on'
                   sequence:
                     - action: script.office_lamp_tick
                       data:
@@ -280,12 +286,6 @@ script:
                     - condition: numeric_state
                       entity_id: counter.office_sonoff_scene
                       above: 3
-                    # Stop ticking door_lamp while a meeting owns it.
-                    - condition: not
-                      conditions:
-                        - condition: state
-                          entity_id: light.meeting_light
-                          state: 'on'
                   sequence:
                     - action: script.office_lamp_tick
                       data:
@@ -389,13 +389,13 @@ automation:
           command: 'on'
     conditions: []
     variables:
-      # While a meeting is active, door_lamp is owned by the meeting indicator
+      # While a meeting is active, corner_lamp is owned by the meeting indicator
       # (packages/meeting_indicator.yaml) and stays out of office-off.
       office_lamps: >-
-        {% set lamps = ['light.bookcase_lamp', 'light.corner_lamp',
+        {% set lamps = ['light.bookcase_lamp', 'light.door_lamp',
           'light.desk_lamp_2', 'light.desk_lamp_2_2', 'light.table_lamp'] %}
         {{ lamps if is_state('light.meeting_light', 'on')
-           else lamps + ['light.door_lamp'] }}
+           else lamps + ['light.corner_lamp'] }}
     actions:
       - action: script.turn_off
         target:


### PR DESCRIPTION
Swap which office lamp the meeting indicator turns red. corner_lamp now
plays the meeting-owned role; door_lamp rejoins the normal office scene
set.

## Origin

> Change the meeting automation so it changes a different light in the
> office to be red. Um, how about the one that's called office corner?

(The only Philips bulb in the Office area whose name matches "office
corner" is **Corner Lamp** / `light.corner_lamp`, so that's the target.)

## What changes

- **`packages/meeting_indicator.yaml`** — `meeting_indicator_show` and
  `meeting_indicator_clear` now target `light.corner_lamp` for the red /
  hand-back actions. The "rest of the office is off?" check list flips:
  `corner_lamp` out, `door_lamp` in.
- **`packages/office_zen77.yaml`** — down-tap-off lamp template: base
  list now includes `door_lamp`; `corner_lamp` is the one dropped while a
  meeting is active.
- **`packages/sonoff_button_office.yaml`**
  - Both `office_lamps` templates (`office_sonoff_apply_scene` script
    and the double-press-off automation) swap roles to match.
  - The candle-loop meeting-active guard moves from the `door_lamp`
    branch to the `corner_lamp` branch — so the flicker loop stops
    ticking corner_lamp (not door_lamp) when a meeting is on.
- **`packages/README.md`** — doc updates so the package description
  matches the new owner.

`configuration.yaml` and the dashboards reference both lamps
independently for activity/visibility purposes — no logic swap needed
there.

## Verification done locally

- `python3 -c "import yaml; yaml.safe_load(open(f))"` on all three
  edited package files: clean parse.
- Cross-file grep: all three `lamps = [...]` base lists now agree
  (`bookcase, door, desk_lamp_2, desk_lamp_2_2, table`); the only
  remaining `light.door_lamp` in `meeting_indicator.yaml` is in the
  "rest of office off?" check, which is now correct.
- Diff is perfectly balanced (37 ins / 37 del) — pure role swap, no
  behavioural drift beyond the lamp identity.

The `ha-config-check` workflow will validate end-to-end against a clean
HA instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)