### PR TITLE
Add UPS section to Homelab Status dashboard

### DIFF
--- a/dashboards/homelab-status.yaml
+++ b/dashboards/homelab-status.yaml
@@ -185,7 +185,56 @@ views:
 
 
       # ═══════════════════════════════════════════════════════════
-      # 3. Smart Home Coordinators
+      # 3. UPS — CyberPower CP1500PFCLCDa
+      # ═══════════════════════════════════════════════════════════
+      - type: markdown
+        content: "### 🔌 UPS (CyberPower CP1500PFCLCDa)"
+
+      - type: entities
+        title: Power
+        entities:
+          - entity: sensor.cyberpower_status_data
+            name: Status
+          - entity: sensor.cyberpower_load
+            name: Load
+          - entity: sensor.cyberpower_input_voltage
+            name: Input Voltage
+          - entity: sensor.cyberpower_output_voltage
+            name: Output Voltage
+
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-template-card
+            primary: Battery Charge
+            secondary: "{{ states('sensor.cyberpower_battery_charge') }}%"
+            icon: >
+              {% set v = states('sensor.cyberpower_battery_charge') | int(100) %}
+              {% if v < 20 %}mdi:battery-10{% elif v < 40 %}mdi:battery-40{% elif v < 60 %}mdi:battery-60{% elif v < 80 %}mdi:battery-80{% else %}mdi:battery{% endif %}
+            icon_color: >
+              {% set v = states('sensor.cyberpower_battery_charge') | int(100) %}
+              {% if v < 20 %}red{% elif v < 40 %}amber{% else %}green{% endif %}
+            entity: sensor.cyberpower_battery_charge
+            tap_action:
+              action: more-info
+
+          - type: custom:mushroom-template-card
+            primary: Runtime Remaining
+            secondary: >
+              {% set s = states('sensor.cyberpower_battery_runtime') | int(-1) %}
+              {% if s < 0 %}—{% elif s >= 3600 %}{{ (s // 3600) }}h {{ ((s % 3600) // 60) }}m{% else %}{{ (s // 60) }}m{% endif %}
+            icon: mdi:timer-sand
+            icon_color: >
+              {% set s = states('sensor.cyberpower_battery_runtime') | int(0) %}
+              {% if s < 300 %}red{% elif s < 600 %}amber{% else %}green{% endif %}
+            entity: sensor.cyberpower_battery_runtime
+            tap_action:
+              action: more-info
+
+
+      # ═══════════════════════════════════════════════════════════
+      # 4. Smart Home Coordinators
       # ═══════════════════════════════════════════════════════════
       - type: markdown
         content: "### 📡 Coordinators"
@@ -244,7 +293,7 @@ views:
 
 
       # ═══════════════════════════════════════════════════════════
-      # 4. Battery Health
+      # 5. Battery Health
       # ═══════════════════════════════════════════════════════════
       - type: markdown
         content: "### 🔋 Battery Health"
@@ -359,7 +408,7 @@ views:
 
 
       # ═══════════════════════════════════════════════════════════
-      # 5. Consumables — Printer (HP M477fdw)
+      # 6. Consumables — Printer (HP M477fdw)
       # ═══════════════════════════════════════════════════════════
       - type: markdown
         content: "### 🖨️ Printer (HP M477fdw)"
@@ -419,7 +468,7 @@ views:
 
 
       # ═══════════════════════════════════════════════════════════
-      # 6. GitHub
+      # 7. GitHub
       # ═══════════════════════════════════════════════════════════
       - type: markdown
         content: "### 🐙 GitHub"
@@ -457,7 +506,7 @@ views:
 
 
       # ═══════════════════════════════════════════════════════════
-      # 7. Meeting Indicator (Rachel's Office)
+      # 8. Meeting Indicator (Rachel's Office)
       # ═══════════════════════════════════════════════════════════
       - type: markdown
         content: "### 🔴 Meeting Indicator (Rachel's Office)"


### PR DESCRIPTION
## Summary

Adds a new "UPS — CyberPower CP1500PFCLCDa" section to the Homelab Status dashboard, slotted between Proxmox and Smart Home Coordinators. Renders the UPS's status, load, input/output voltage in an `entities` card, plus a 2-column mushroom-template grid for battery charge % (icon scales with level) and runtime remaining (formatted from seconds, color-coded red/amber/green by remaining minutes).

References `sensor.cyberpower_*` entities, which will exist once the HA NUT integration is added against `cyberpower@192.168.139.8` (Settings > Devices & Services > Add Integration > Network UPS Tools). Naming follows the NUT UPS alias; if HA's auto-generated entity_ids land on a different prefix, that's a one-line fix-forward.

Sections 4–7 renumbered to 5–8 to keep numbering sequential.

## Origin

Originated from a homelab session where I plugged a CyberPower CP1500PFCLCDa UPS into pve via USB. NUT was configured with pve as master and pve2/3/5 as slaves (10% LB threshold, HOSTSYNC 180s on master, FINALDELAY 5s on clients, shutdown via `/sbin/shutdown -h +0`). On confirming the cluster setup, I asked Claude to "go with all follow-ups": adding the HA NUT integration and a dashboard tile, installing nut-client on Neptune, attempting to tune `battery.charge.low` to 20% (rejected by the CyberPower HID — only the LCD-front-panel can change it), and Firewalla static DHCP reservations for pve3/pve5.

This PR is the dashboard piece. The integration entry itself is config-flow-only and is added separately in the HA UI; the dashboard YAML will start rendering cleanly the moment the entities exist.

## Test plan

- [ ] CI: `YAML Lint`, `check-config`, `claude-review` all pass
- [ ] After HA NUT integration is added in UI, the new "UPS" section renders without "Entity not available" placeholders
- [ ] Battery charge tile icon color switches red <20%, amber 20-40%, green >=40%
- [ ] Runtime tile color switches red <5min, amber 5-10min, green >=10min
- [ ] Renumbered sections still scroll in order (NAS → Proxmox → UPS → Smart Home → Battery Health → Printer → GitHub → Meeting Indicator)