### PR TITLE
Add ShellCheck + bats test gates for shell logic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+
+      - name: Run shellcheck
+        run: shellcheck scripts/*.sh
+
+  bats:
+    name: Bats
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bats
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq bats
+
+      - name: Run bats suite
+        run: bats tests/

--- a/scripts/gitops-sync.sh
+++ b/scripts/gitops-sync.sh
@@ -231,10 +231,18 @@ main() {
   fi
 }
 
-# Acquire exclusive lock — exit silently if a previous run is still in progress
-exec 9>"$LOCK_FILE"
-if ! flock -n 9; then
-  exit 0
-fi
+# Acquire exclusive lock — exit silently if a previous run is still in progress,
+# then run main. Wrapped in a function so the script can be sourced (e.g. by the
+# bats suite in tests/) without acquiring the lock or deploying.
+main_locked() {
+  exec 9>"$LOCK_FILE"
+  if ! flock -n 9; then
+    exit 0
+  fi
+  main
+}
 
-main
+# Only self-execute when run directly, not when sourced for testing.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main_locked
+fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,47 @@
+# tests/
+
+Fast, dependency-light tests for the repo's shell logic. They run on a stock
+Ubuntu runner with `shellcheck` + `bats` — **no Home Assistant instance and no
+secrets required** — via the `Tests` workflow (`.github/workflows/tests.yml`).
+
+This complements, rather than replaces, the existing gates:
+
+| Gate | Scope |
+|---|---|
+| `YAML Lint` (`lint.yml`) | yamllint syntax/style across all YAML |
+| `check-config` (`ha-config-check.yml`) | Real HA validates the proposed config |
+| **`ShellCheck` (`tests.yml`)** | Static analysis of every `scripts/*.sh` |
+| **`Bats` (`tests.yml`)** | Behavioral unit tests for shell logic |
+
+## Running locally
+
+```bash
+sudo apt-get install -y shellcheck bats   # one-time
+shellcheck scripts/*.sh
+bats tests/
+```
+
+## What's covered
+
+- **`apply_reload.bats`** — the smart-reload routing tree in
+  `scripts/gitops-sync.sh` (`apply_reload`). This is the GitOps loop's decision
+  about the lightest safe reload for a change set (dashboards → themes →
+  automations → scripts → scenes → full restart, plus no-op and fallback cases).
+  A bug here means a deploy silently doesn't take effect, or HA gets needlessly
+  restarted. The function is pure path-matching with no HA dependency, so the
+  suite sources the script and stubs its side-effecting helpers
+  (`log` / `ha_call_service` / `ha_core_restart` / `ha_notify`) and `git diff`.
+
+## Making a script testable
+
+Scripts that self-execute at the bottom should guard that call so the file can
+be sourced without side effects:
+
+```bash
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main_locked
+fi
+```
+
+Sourcing then loads only the function definitions, letting a bats `setup()`
+override the side-effecting helpers before calling the function under test.

--- a/tests/apply_reload.bats
+++ b/tests/apply_reload.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+#
+# Unit tests for apply_reload() in scripts/gitops-sync.sh.
+#
+# apply_reload() is the smart-routing decision tree the GitOps loop uses to pick
+# the lightest safe reload for a given change set (dashboards -> themes ->
+# automations -> scripts -> scenes -> full restart, with no-op and fallback
+# cases). It is pure path-matching logic with no HA dependency, so it can be
+# exercised in isolation by sourcing the script and stubbing its side-effecting
+# helpers (log / ha_call_service / ha_core_restart / ha_notify) plus `git diff`.
+#
+# Each stub appends a token to $CALLS_FILE; tests assert on the recorded calls.
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../scripts/gitops-sync.sh"
+
+  # Source the script. The `BASH_SOURCE == $0` guard at the bottom prevents the
+  # lock-acquire + main() from firing when sourced, so only the functions load.
+  # shellcheck source=../scripts/gitops-sync.sh
+  source "$SCRIPT"
+
+  CALLS_FILE="${BATS_TEST_TMPDIR}/calls"
+  : > "$CALLS_FILE"
+
+  # --- stubs over the script's side-effecting helpers ---
+  log()           { :; }                                   # silence /config logging
+  ha_notify()     { :; }
+  ha_call_service() { printf 'CALL %s %s\n' "$1" "$2" >> "$CALLS_FILE"; }
+  ha_core_restart() { printf 'RESTART\n'        >> "$CALLS_FILE"; }
+
+  # Stub `git diff` so the changed-file list is injectable via $MOCK_DIFF.
+  # Everything else falls through to the real git.
+  git() {
+    if [[ "$1" == "diff" ]]; then
+      printf '%s' "$MOCK_DIFF"
+    else
+      command git "$@"
+    fi
+  }
+
+  export CALLS_FILE
+}
+
+# Convenience: run apply_reload with a non-empty old_sha and the given diff.
+run_with_diff() {
+  MOCK_DIFF="$1"
+  run apply_reload "OLDSHA" "NEWSHA"
+}
+
+@test "empty old_sha falls back to a full restart" {
+  run apply_reload "" "NEWSHA"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$CALLS_FILE")" = "RESTART" ]
+}
+
+@test "empty diff falls back to a full restart" {
+  run_with_diff ""
+  [ "$status" -eq 0 ]
+  [ "$(cat "$CALLS_FILE")" = "RESTART" ]
+}
+
+@test "dashboard-only change reloads lovelace resources and themes" {
+  run_with_diff "dashboards/kiosk.yaml"
+  [ "$status" -eq 0 ]
+  grep -qx "CALL lovelace reload_resources" "$CALLS_FILE"
+  grep -qx "CALL frontend reload_themes"    "$CALLS_FILE"
+  ! grep -q "RESTART" "$CALLS_FILE"
+}
+
+@test "theme-only change reloads themes" {
+  run_with_diff "themes/noctis-kiosk.yaml"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$CALLS_FILE")" = "CALL frontend reload_themes" ]
+}
+
+@test "top-level automations.yaml reloads automations" {
+  run_with_diff "automations.yaml"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$CALLS_FILE")" = "CALL automation reload" ]
+}
+
+@test "automations subdir yaml reloads automations" {
+  run_with_diff "automations/exterior_doors_night.yaml"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$CALLS_FILE")" = "CALL automation reload" ]
+}
+
+@test "scripts.yaml reloads scripts" {
+  run_with_diff "scripts.yaml"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$CALLS_FILE")" = "CALL script reload" ]
+}
+
+@test "scenes.yaml reloads scenes" {
+  run_with_diff "scenes.yaml"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$CALLS_FILE")" = "CALL scene reload" ]
+}
+
+@test "shell scripts under scripts/ are a no-op (not a script.reload)" {
+  # scripts/*.sh must NOT be confused with scripts/*.yaml -> script.reload.
+  run_with_diff "scripts/gitops-sync.sh"
+  [ "$status" -eq 0 ]
+  [ ! -s "$CALLS_FILE" ]
+}
+
+@test "docs, context, .github, esphome, and dotfiles are no-ops" {
+  run_with_diff "$(printf '%s\n' \
+    "README.md" \
+    "context/entities.json" \
+    ".github/workflows/lint.yml" \
+    "esphome/konnected-56ac70.yaml" \
+    ".gitignore" \
+    ".yamllint.yml")"
+  [ "$status" -eq 0 ]
+  [ ! -s "$CALLS_FILE" ]
+}
+
+@test "mixed lightweight changes trigger each matching reload, no restart" {
+  run_with_diff "$(printf '%s\n' \
+    "dashboards/home.yaml" \
+    "automations.yaml" \
+    "scenes.yaml")"
+  [ "$status" -eq 0 ]
+  grep -qx "CALL lovelace reload_resources" "$CALLS_FILE"
+  grep -qx "CALL frontend reload_themes"    "$CALLS_FILE"
+  grep -qx "CALL automation reload"         "$CALLS_FILE"
+  grep -qx "CALL scene reload"              "$CALLS_FILE"
+  ! grep -q "RESTART" "$CALLS_FILE"
+}
+
+@test "a file outside the lightweight set forces a full restart" {
+  run_with_diff "configuration.yaml"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$CALLS_FILE")" = "RESTART" ]
+}
+
+@test "restart wins even when mixed with lightweight changes" {
+  # configuration.yaml (heavy) alongside a dashboard (light): the heavy file
+  # must short-circuit to a single full restart with no partial reloads.
+  run_with_diff "$(printf '%s\n' \
+    "configuration.yaml" \
+    "dashboards/kiosk.yaml")"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$CALLS_FILE")" = "RESTART" ]
+}


### PR DESCRIPTION
Adds the first behavioral/static test coverage for the repo's shell logic, via a new `Tests` workflow.

## Origin

This came out of a request to *"Analyze the test coverage of the codebase and propose some areas in which we should improve our tests."* The analysis found that the repo's three existing gates (`YAML Lint`, `check-config`, `claude-review`) cover HA config validity well, but ~809 lines of Bash and several jq/regex flows have **zero automated coverage** — the most logic-dense code in the repo was the least tested. Notably, the `claude-review` prompt *claims* to focus on "bash correctness" but nothing deterministic backs it.

Seven gaps were proposed, ranked by value-to-effort. The user selected the top two for implementation:

1. **ShellCheck CI gate** over `scripts/*.sh`
2. **bats unit tests** for `apply_reload()` — the most complex pure-logic function in the repo

## What's here

A new `Tests` workflow (`.github/workflows/tests.yml`) with two jobs that run on a stock Ubuntu runner — **no HA instance, no secrets, fast**:

- **ShellCheck** — static analysis of every `scripts/*.sh`. All four scripts already pass clean under shellcheck 0.9.0, so this locks in the current state and backs the review prompt's bash-correctness focus with something deterministic.
- **Bats** — behavioral unit tests in `tests/`.

`tests/apply_reload.bats` (13 cases) covers the GitOps smart-reload routing tree in `scripts/gitops-sync.sh` — the decision about the lightest safe reload for a change set (dashboards → themes → automations → scripts → scenes → full restart, plus no-op and fallback cases). A bug there means a deploy silently doesn't apply, or HA is needlessly restarted. The cases pin the tricky boundaries:

- empty `old_sha` / empty diff → full restart (safe fallbacks)
- each domain → its lightest reload
- `scripts/*.sh` (no-op) vs `scripts/*.yaml` (`script.reload`)
- docs / `context/` / `.github/` / `esphome/` / dotfiles → no-op
- mixed lightweight changes → each matching reload, no restart
- a heavy file (`configuration.yaml`) → full restart, and **restart wins** when mixed with lightweight files

## Testability change to `gitops-sync.sh`

To exercise the routing function in isolation, the self-exec at the bottom of `gitops-sync.sh` is now guarded by a `BASH_SOURCE == $0` check and wrapped in `main_locked()`. Sourcing the script loads only the function definitions (no lock acquired, no deploy), letting the bats `setup()` stub the side-effecting helpers (`log` / `ha_call_service` / `ha_core_restart` / `ha_notify`) and `git diff`. **Direct-execution behavior is unchanged.**

## Verification

Run locally with `shellcheck scripts/*.sh` and `bats tests/` — all 13 tests pass, shellcheck clean, and the new workflow passes `yamllint -c .yamllint.yml`.

## Remaining proposed gaps (not in this PR)

For future PRs: tests for the version/branch regex validators in the sync workflows; an `esphome config` CI job; jq-pipeline tests for `ha-context-dump.sh`; a dashboard entity-existence cross-check; and a `!secret`-coverage assertion + secret scanning.

https://claude.ai/code/session_014UUn1yZ1E1LG6XfuBAWfQa

---
_Generated by [Claude Code](https://claude.ai/code/session_014UUn1yZ1E1LG6XfuBAWfQa)_