### PR TITLE
Add bats coverage for context-dump transforms and !secret drift

### DIFF
--- a/scripts/ha-context-dump.sh
+++ b/scripts/ha-context-dump.sh
@@ -42,6 +42,106 @@ storage_items() {
   fi
 }
 
+# --- Snapshot transforms ---------------------------------------------------
+# Each build_* function takes its input path(s) and emits the artifact JSON on
+# stdout. They are pure (no global state, no file writes) so the bats suite in
+# tests/ can exercise them against fixtures without an HA instance.
+
+# Project the entity registry down to the fields the snapshot exposes,
+# dropping disabled entities and sorting by entity_id.
+build_entities() {
+  jq '
+    .data.entities
+    | map(select(.disabled_by == null))
+    | map({
+        entity_id: .entity_id,
+        friendly_name: (.name // .original_name // null),
+        area_id: .area_id,
+        device_id: .device_id,
+        platform: .platform,
+        hidden: (.hidden_by != null)
+      })
+    | sort_by(.entity_id)
+  ' "$1"
+}
+
+# Project the area registry to {area_id, name}, sorted by name.
+build_areas() {
+  jq '
+    .data.areas
+    | map({area_id: .id, name: .name})
+    | sort_by(.name)
+  ' "$1"
+}
+
+# Join devices against config_entries to resolve each device's integration
+# domains. Args: <device_registry_path> <config_entries_path>.
+build_devices() {
+  jq -n \
+    --slurpfile dev "$1" \
+    --slurpfile cfg "$2" \
+    '
+    ($cfg[0].data.entries | map({(.entry_id): .domain}) | add // {}) as $entry_domains |
+    $dev[0].data.devices
+    | map({
+        device_id: .id,
+        name: (.name_by_user // .name // null),
+        manufacturer: .manufacturer,
+        model: .model,
+        area_id: .area_id,
+        integrations: (.config_entries | map($entry_domains[.]) | map(select(. != null)) | unique)
+      })
+    | sort_by(.name // "")
+    '
+}
+
+# Assemble the combined helpers artifact — an object keyed by helper type, each
+# value the storage_items array for that type. Arg: <storage_dir>.
+build_helpers() {
+  local storage_dir="$1"
+  local helpers='{}'
+  local helper_types=(
+    input_boolean
+    input_number
+    input_text
+    input_select
+    input_datetime
+    timer
+    counter
+    schedule
+  )
+  local t items
+  for t in "${helper_types[@]}"; do
+    items=$(storage_items "${storage_dir}/${t}")
+    helpers=$(jq --argjson items "$items" --arg key "$t" '. + {($key): $items}' <<<"$helpers")
+  done
+  printf '%s\n' "$helpers"
+}
+
+# Assemble the storage-mode dashboards artifact: the dashboard registry plus the
+# config blob for the default dashboard (.storage/lovelace) and any additional
+# storage-mode dashboards (.storage/lovelace.<url_path>). Arg: <storage_dir>.
+build_dashboards_storage() {
+  local storage_dir="$1"
+  local dashboards_registry
+  dashboards_registry=$(storage_items "${storage_dir}/lovelace_dashboards")
+  local configs='{}'
+  if [[ -f "${storage_dir}/lovelace" ]]; then
+    configs=$(jq --slurpfile lv "${storage_dir}/lovelace" \
+      '. + {lovelace: ($lv[0].data.config // {})}' <<<"$configs")
+  fi
+  local f key
+  shopt -s nullglob
+  for f in "${storage_dir}"/lovelace.*; do
+    key=$(basename "$f")
+    configs=$(jq --slurpfile lv "$f" --arg key "$key" \
+      '. + {($key): ($lv[0].data.config // {})}' <<<"$configs")
+  done
+  shopt -u nullglob
+  jq -n --argjson dashboards "$dashboards_registry" --argjson configs "$configs" \
+    '{dashboards: $dashboards, configs: $configs}'
+}
+
 main() {
   rotate_log
   log INFO "Starting HA context dump"
@@ -77,44 +177,14 @@ main() {
   mkdir -p "$CONTEXT_DIR"
 
   log INFO "Building entities.json"
-  jq '
-    .data.entities
-    | map(select(.disabled_by == null))
-    | map({
-        entity_id: .entity_id,
-        friendly_name: (.name // .original_name // null),
-        area_id: .area_id,
-        device_id: .device_id,
-        platform: .platform,
-        hidden: (.hidden_by != null)
-      })
-    | sort_by(.entity_id)
-  ' "${STORAGE}/core.entity_registry" > "${CONTEXT_DIR}/entities.json"
+  build_entities "${STORAGE}/core.entity_registry" > "${CONTEXT_DIR}/entities.json"
 
   log INFO "Building areas.json"
-  jq '
-    .data.areas
-    | map({area_id: .id, name: .name})
-    | sort_by(.name)
-  ' "${STORAGE}/core.area_registry" > "${CONTEXT_DIR}/areas.json"
+  build_areas "${STORAGE}/core.area_registry" > "${CONTEXT_DIR}/areas.json"
 
   log INFO "Building devices.json"
-  jq -n \
-    --slurpfile dev "${STORAGE}/core.device_registry" \
-    --slurpfile cfg "${STORAGE}/core.config_entries" \
-    '
-    ($cfg[0].data.entries | map({(.entry_id): .domain}) | add // {}) as $entry_domains |
-    $dev[0].data.devices
-    | map({
-        device_id: .id,
-        name: (.name_by_user // .name // null),
-        manufacturer: .manufacturer,
-        model: .model,
-        area_id: .area_id,
-        integrations: (.config_entries | map($entry_domains[.]) | map(select(. != null)) | unique)
-      })
-    | sort_by(.name // "")
-    ' > "${CONTEXT_DIR}/devices.json"
+  build_devices "${STORAGE}/core.device_registry" "${STORAGE}/core.config_entries" \
+    > "${CONTEXT_DIR}/devices.json"
 
   log INFO "Copying automations-ui.yaml"
   cp /config/automations.yaml "${CONTEXT_DIR}/automations-ui.yaml"
@@ -136,23 +206,7 @@ main() {
   # output is an object keyed by helper type so a single jq query can list all
   # helpers of a given kind.
   log INFO "Building helpers.json"
-  local helpers='{}'
-  local helper_types=(
-    input_boolean
-    input_number
-    input_text
-    input_select
-    input_datetime
-    timer
-    counter
-    schedule
-  )
-  for t in "${helper_types[@]}"; do
-    local items
-    items=$(storage_items "${STORAGE}/${t}")
-    helpers=$(jq --argjson items "$items" --arg key "$t" '. + {($key): $items}' <<<"$helpers")
-  done
-  printf '%s\n' "$helpers" > "${CONTEXT_DIR}/helpers.json"
+  build_helpers "$STORAGE" > "${CONTEXT_DIR}/helpers.json"
 
   # Storage-mode Lovelace dashboards. The dashboard registry lives at
   # .storage/lovelace_dashboards; the default dashboard config is .storage/lovelace
@@ -160,23 +214,7 @@ main() {
   # YAML-mode dashboards (this repo's home/kiosk/homelab-status) are not stored
   # in .storage/ — they remain in dashboards/*.yaml and are absent here.
   log INFO "Building dashboards-storage.json"
-  local dashboards_registry
-  dashboards_registry=$(storage_items "${STORAGE}/lovelace_dashboards")
-  local configs='{}'
-  if [[ -f "${STORAGE}/lovelace" ]]; then
-    configs=$(jq --slurpfile lv "${STORAGE}/lovelace" \
-      '. + {lovelace: ($lv[0].data.config // {})}' <<<"$configs")
-  fi
-  shopt -s nullglob
-  for f in "${STORAGE}"/lovelace.*; do
-    local key
-    key=$(basename "$f")
-    configs=$(jq --slurpfile lv "$f" --arg key "$key" \
-      '. + {($key): ($lv[0].data.config // {})}' <<<"$configs")
-  done
-  shopt -u nullglob
-  jq -n --argjson dashboards "$dashboards_registry" --argjson configs "$configs" \
-    '{dashboards: $dashboards, configs: $configs}' > "${CONTEXT_DIR}/dashboards-storage.json"
+  build_dashboards_storage "$STORAGE" > "${CONTEXT_DIR}/dashboards-storage.json"
 
   # Check for diff — most common case is no change
   if [[ -z "$(git -C "$WORKTREE" status --porcelain context/)" ]]; then
@@ -241,4 +279,8 @@ main() {
   log INFO "Snapshot pushed — context-snapshot PR will open shortly"
 }
 
-main
+# Only self-execute when run directly, not when sourced for testing (the bats
+# suite in tests/ sources this file to exercise the build_* transforms).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main
+fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,6 +32,21 @@ bats tests/
   suite sources the script and stubs its side-effecting helpers
   (`log` / `ha_call_service` / `ha_core_restart` / `ha_notify`) and `git diff`.
 
+- **`context_dump.bats`** — the snapshot transforms in
+  `scripts/ha-context-dump.sh` (`build_entities`, `build_areas`,
+  `build_devices`, `build_helpers`, `build_dashboards_storage`,
+  `storage_items`). These are pure jq projections over HA's `.storage/` registry
+  files; a bug silently produces a malformed or empty `context/` snapshot that
+  everything downstream trusts. The suite feeds each transform JSON fixtures
+  under `tests/fixtures/storage/` — covering the device↔config_entry integration
+  join, `name`/`name_by_user` precedence, disabled-entity filtering, and the
+  presence-stable empty-array behavior for absent `.storage` files.
+
+- **`secrets_coverage.bats`** — asserts every `!secret` reference in the HA
+  config resolves in `secrets.fake.yaml`, so a new reference can't pass locally
+  yet break the `check-config` gate with an opaque error. (`esphome/` is
+  excluded — it isn't part of HA's `check-config`.)
+
 ## Making a script testable
 
 Scripts that self-execute at the bottom should guard that call so the file can

--- a/tests/context_dump.bats
+++ b/tests/context_dump.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+#
+# Unit tests for the snapshot transforms in scripts/ha-context-dump.sh.
+#
+# build_entities / build_areas / build_devices / build_helpers /
+# build_dashboards_storage and storage_items are pure jq projections over
+# HA's .storage/ registry files. A bug there silently produces a malformed or
+# empty context/ snapshot, which everything downstream then trusts. These tests
+# source the script (guarded by BASH_SOURCE == $0 so main() does not run) and
+# feed each transform fixtures under tests/fixtures/storage/.
+
+setup() {
+  # shellcheck source=../scripts/ha-context-dump.sh
+  source "${BATS_TEST_DIRNAME}/../scripts/ha-context-dump.sh"
+  FIXTURES="${BATS_TEST_DIRNAME}/fixtures/storage"
+}
+
+# --- storage_items ---------------------------------------------------------
+
+@test "storage_items returns [] for a missing file" {
+  run storage_items "${BATS_TEST_TMPDIR}/does-not-exist"
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | jq -c .)" = "[]" ]
+}
+
+@test "storage_items extracts and id-sorts the items array" {
+  run storage_items "${FIXTURES}/input_boolean"
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | jq 'length')" = "2" ]
+  [ "$(printf '%s' "$output" | jq -r '.[0].id')" = "away" ]
+}
+
+# --- build_entities --------------------------------------------------------
+
+@test "build_entities drops disabled entities and sorts by entity_id" {
+  run build_entities "${FIXTURES}/core.entity_registry"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq 'length')" = "2" ]
+  [ "$(echo "$output" | jq -r '.[0].entity_id')" = "light.kitchen" ]
+  [ "$(echo "$output" | jq -r '.[1].entity_id')" = "sensor.aaa" ]
+  # the disabled entity must be absent entirely
+  [ "$(echo "$output" | jq '[.[] | select(.entity_id == "light.disabled")] | length')" = "0" ]
+}
+
+@test "build_entities prefers name over original_name and derives hidden" {
+  run build_entities "${FIXTURES}/core.entity_registry"
+  # light.kitchen: has name -> "Kitchen Light", hidden_by null -> hidden false
+  [ "$(echo "$output" | jq -r '.[0].friendly_name')" = "Kitchen Light" ]
+  [ "$(echo "$output" | jq -r '.[0].hidden')" = "false" ]
+  # sensor.aaa: name null -> falls back to original_name; hidden_by set -> true
+  [ "$(echo "$output" | jq -r '.[1].friendly_name')" = "AAA Sensor" ]
+  [ "$(echo "$output" | jq -r '.[1].hidden')" = "true" ]
+}
+
+# --- build_areas -----------------------------------------------------------
+
+@test "build_areas maps id->area_id and sorts by name" {
+  run build_areas "${FIXTURES}/core.area_registry"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.[0].area_id')" = "kitchen" ]
+  [ "$(echo "$output" | jq -r '.[0].name')" = "Kitchen" ]
+  [ "$(echo "$output" | jq -r '.[1].area_id')" = "office" ]
+}
+
+# --- build_devices ---------------------------------------------------------
+
+@test "build_devices resolves integration domains via the config_entries join" {
+  run build_devices "${FIXTURES}/core.device_registry" "${FIXTURES}/core.config_entries"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq 'length')" = "2" ]
+  # dev1 ("My Hue") -> name_by_user wins, ce_hue resolves to "hue"
+  [ "$(echo "$output" | jq -r '.[0].name')" = "My Hue" ]
+  [ "$(echo "$output" | jq -c '.[0].integrations')" = '["hue"]' ]
+}
+
+@test "build_devices falls back to name and drops unknown config entries" {
+  run build_devices "${FIXTURES}/core.device_registry" "${FIXTURES}/core.config_entries"
+  # dev2: name_by_user null -> falls back to .name "ZHA Sensor"
+  [ "$(echo "$output" | jq -r '.[1].name')" = "ZHA Sensor" ]
+  # ce_zha -> "zha"; ce_unknown has no matching entry -> filtered out
+  [ "$(echo "$output" | jq -c '.[1].integrations')" = '["zha"]' ]
+}
+
+# --- build_helpers ---------------------------------------------------------
+
+@test "build_helpers emits all eight helper types, present ones populated" {
+  run build_helpers "$FIXTURES"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq 'keys | length')" = "8" ]
+  # input_boolean is present in the fixture dir -> populated and id-sorted
+  [ "$(echo "$output" | jq '.input_boolean | length')" = "2" ]
+  [ "$(echo "$output" | jq -r '.input_boolean[0].id')" = "away" ]
+  # a type with no .storage file -> stable empty array, not missing/null
+  [ "$(echo "$output" | jq -c '.timer')" = "[]" ]
+  [ "$(echo "$output" | jq -c '.counter')" = "[]" ]
+}
+
+@test "build_helpers yields all-empty arrays for an empty storage dir" {
+  run build_helpers "$BATS_TEST_TMPDIR"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq '[.[] | length] | add')" = "0" ]
+  [ "$(echo "$output" | jq 'keys | length')" = "8" ]
+}
+
+# --- build_dashboards_storage ----------------------------------------------
+
+@test "build_dashboards_storage merges registry, default, and extra dashboards" {
+  run build_dashboards_storage "$FIXTURES"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq '.dashboards | length')" = "1" ]
+  [ "$(echo "$output" | jq -r '.dashboards[0].url_path')" = "home-ui" ]
+  # default dashboard config blob
+  [ "$(echo "$output" | jq -r '.configs.lovelace.views[0].title')" = "Main" ]
+  # extra storage-mode dashboard, keyed by its .storage filename
+  [ "$(echo "$output" | jq -r '.configs["lovelace.home-ui"].views[0].title')" = "HomeUI" ]
+}
+
+@test "build_dashboards_storage is presence-stable for an empty storage dir" {
+  run build_dashboards_storage "$BATS_TEST_TMPDIR"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -c '.dashboards')" = "[]" ]
+  [ "$(echo "$output" | jq -c '.configs')" = "{}" ]
+}

--- a/tests/fixtures/storage/core.area_registry
+++ b/tests/fixtures/storage/core.area_registry
@@ -1,0 +1,1 @@
+{"data":{"areas":[{"id":"office","name":"Office"},{"id":"kitchen","name":"Kitchen"}]}}

--- a/tests/fixtures/storage/core.config_entries
+++ b/tests/fixtures/storage/core.config_entries
@@ -1,0 +1,1 @@
+{"data":{"entries":[{"entry_id":"ce_hue","domain":"hue"},{"entry_id":"ce_zha","domain":"zha"}]}}

--- a/tests/fixtures/storage/core.device_registry
+++ b/tests/fixtures/storage/core.device_registry
@@ -1,0 +1,4 @@
+{"data":{"devices":[
+  {"id":"dev1","name_by_user":"My Hue","name":"Hue bulb","manufacturer":"Signify","model":"LCT001","area_id":"kitchen","config_entries":["ce_hue"]},
+  {"id":"dev2","name_by_user":null,"name":"ZHA Sensor","manufacturer":"Aqara","model":"X1","area_id":"office","config_entries":["ce_zha","ce_unknown"]}
+]}}

--- a/tests/fixtures/storage/core.entity_registry
+++ b/tests/fixtures/storage/core.entity_registry
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "entities": [
+      {"entity_id":"light.kitchen","name":"Kitchen Light","original_name":"light","area_id":"kitchen","device_id":"dev1","platform":"hue","disabled_by":null,"hidden_by":null},
+      {"entity_id":"light.disabled","name":null,"original_name":"Disabled","area_id":null,"device_id":null,"platform":"hue","disabled_by":"user","hidden_by":null},
+      {"entity_id":"sensor.aaa","name":null,"original_name":"AAA Sensor","area_id":"office","device_id":"dev2","platform":"zha","disabled_by":null,"hidden_by":"integration"}
+    ]
+  }
+}

--- a/tests/fixtures/storage/input_boolean
+++ b/tests/fixtures/storage/input_boolean
@@ -1,0 +1,1 @@
+{"data":{"items":[{"id":"guest_mode","name":"Guest"},{"id":"away","name":"Away"}]}}

--- a/tests/fixtures/storage/lovelace
+++ b/tests/fixtures/storage/lovelace
@@ -1,0 +1,1 @@
+{"data":{"config":{"views":[{"title":"Main"}]}}}

--- a/tests/fixtures/storage/lovelace.home-ui
+++ b/tests/fixtures/storage/lovelace.home-ui
@@ -1,0 +1,1 @@
+{"data":{"config":{"views":[{"title":"HomeUI"}]}}}

--- a/tests/fixtures/storage/lovelace_dashboards
+++ b/tests/fixtures/storage/lovelace_dashboards
@@ -1,0 +1,1 @@
+{"data":{"items":[{"id":"d1","url_path":"home-ui","title":"Home"}]}}

--- a/tests/secrets_coverage.bats
+++ b/tests/secrets_coverage.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+#
+# Guards the check-config gate against !secret drift.
+#
+# ha-config-check.yml copies secrets.fake.yaml -> secrets.yaml and validates the
+# tree. If a YAML file gains a `!secret foo` reference whose key is absent from
+# secrets.fake.yaml, check-config fails in CI with an opaque error. This test
+# turns that into a fast, local, explicit failure naming the missing key(s).
+#
+# esphome/ is excluded: ESPHome firmware is not part of HA's check-config (it has
+# its own secrets handling), so its !secret refs are out of scope here.
+
+@test "every !secret reference in HA config is defined in secrets.fake.yaml" {
+  local repo_root fake
+  repo_root="${BATS_TEST_DIRNAME}/.."
+  fake="${repo_root}/secrets.fake.yaml"
+  [ -f "$fake" ]
+
+  local refs
+  mapfile -t refs < <(grep -rhoP '!secret\s+\K[A-Za-z0-9_]+' \
+    --include='*.yaml' --exclude-dir=esphome --exclude-dir=.git \
+    "$repo_root" | sort -u)
+
+  # Guard: the scan must find at least one reference. A zero count means the
+  # grep pattern broke, which would make this test vacuously pass.
+  [ "${#refs[@]}" -gt 0 ]
+
+  local key missing=()
+  for key in "${refs[@]}"; do
+    grep -qE "^${key}:" "$fake" || missing+=("$key")
+  done
+
+  if [ "${#missing[@]}" -gt 0 ]; then
+    echo "Keys referenced via !secret but missing from secrets.fake.yaml: ${missing[*]}" >&2
+    return 1
+  fi
+}


### PR DESCRIPTION
Extends the `tests/` suite established in #274 with the next two gaps from the test-coverage analysis. Both run on the existing `Bats` gate — no HA instance, no secrets.

## Origin

Follow-on to the test-coverage analysis. After gap #1 (ShellCheck) and gap #2 (`apply_reload` bats tests) merged in #274, the user said *"continue"*, so this implements the next two self-contained gaps from the same ranked list:

- **#5 — jq-pipeline tests for `ha-context-dump.sh`**
- **#7 — the `!secret`-coverage assertion**

Both extend the same fast, HA-free bats harness rather than introducing new tooling.

## What's here

**`tests/context_dump.bats` (11 cases)** — unit tests for the snapshot transforms in `ha-context-dump.sh`. These are pure jq projections over HA's `.storage/` registry files; a bug there silently produces a malformed or empty `context/` snapshot that everything downstream trusts. To make them testable in isolation, the inline jq pipelines are extracted into pure functions — `build_entities`, `build_areas`, `build_devices`, `build_helpers`, `build_dashboards_storage` — each taking input path(s) and emitting artifact JSON on stdout. `main()` now calls these (**behavior unchanged**), and the self-exec at the bottom is guarded by `BASH_SOURCE == $0` so the file can be sourced. Fixtures under `tests/fixtures/storage/` cover the tricky bits:
- the device ↔ `config_entries` integration-domain join, including filtering out unknown entries
- `name` / `name_by_user` / `original_name` precedence
- disabled-entity filtering and `hidden` derivation
- the presence-stable `[]` / `{}` behavior for absent `.storage` files

**`tests/secrets_coverage.bats` (1 case)** — asserts every `!secret` reference in the HA config resolves in `secrets.fake.yaml`. Without it, adding a `!secret foo` whose key is missing from the fake file fails the `check-config` gate with an opaque error; this turns that into a fast, local failure that names the missing key(s). `esphome/` is excluded since it isn't part of HA's `check-config`.

## Verification

`bats tests/` → 25/25 pass (13 from #274 + 12 new). `shellcheck scripts/*.sh` clean. The `ha-context-dump.sh` refactor is behavior-preserving — only the structure changed (inline jq → named functions + a source guard).

## Remaining proposed gaps (future PRs)

From the original analysis, still open: tests for the version/branch regex validators in the sync workflows (would involve extracting the inline regexes into testable scripts — flagged as a more invasive change), an `esphome config` CI job, and a dashboard entity-existence cross-check.

https://claude.ai/code/session_014UUn1yZ1E1LG6XfuBAWfQa

---
_Generated by [Claude Code](https://claude.ai/code/session_014UUn1yZ1E1LG6XfuBAWfQa)_