### PR TITLE
Add ESPHome config validation to CI

### DIFF
--- a/.github/workflows/esphome-check.yml
+++ b/.github/workflows/esphome-check.yml
@@ -1,0 +1,47 @@
+name: ESPHome Check
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  esphome-config:
+    name: ESPHome Config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # Pinned for deterministic validation — bump deliberately alongside the
+      # ESPHome Device Builder add-on version the panels are flashed from.
+      - name: Install ESPHome
+        run: pip install esphome==2026.5.1
+
+      - name: Prepare fake secrets
+        run: cp esphome/secrets.fake.yaml esphome/secrets.yaml
+
+      - name: Validate ESPHome configs
+        run: |
+          shopt -s nullglob
+          status=0
+          for f in esphome/*.yaml; do
+            case "$(basename "$f")" in
+              secrets*.yaml) continue ;;  # not device configs
+            esac
+            echo "::group::esphome config $f"
+            if ! esphome config "$f"; then
+              echo "::error file=$f::ESPHome config validation failed"
+              status=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "$status"

--- a/esphome/secrets.fake.yaml
+++ b/esphome/secrets.fake.yaml
@@ -1,0 +1,7 @@
+# Fake ESPHome secrets for CI validation (`esphome config`). Do not use real values.
+# The API key must be a valid 32-byte base64 string or schema validation fails;
+# this is a throwaway generated key, not the real panel key.
+wifi_ssid: "fake-ssid"
+wifi_password: "fake-password-1234"
+api_key_main_panel: "W6qXIZ/IYdZsOAp8cTd0ierZBWiAtE/cocH0NQCJO4w="
+api_key_secondary_panel: "W6qXIZ/IYdZsOAp8cTd0ierZBWiAtE/cocH0NQCJO4w="

--- a/esphome/secrets.yaml.example
+++ b/esphome/secrets.yaml.example
@@ -1,0 +1,8 @@
+# Required ESPHome secrets. Copy to secrets.yaml and fill in real values
+# (esphome/secrets.yaml is gitignored). See esphome/README.md > Secrets.
+wifi_ssid: "CHANGE_ME"
+wifi_password: "CHANGE_ME"
+# ESPHome API encryption keys — generate with `openssl rand -base64 32`.
+# One per panel; both must be valid 32-byte base64 strings.
+api_key_main_panel: "CHANGE_ME"
+api_key_secondary_panel: "CHANGE_ME"


### PR DESCRIPTION
Closes gap #4 from the test-coverage analysis: the ESPHome panel firmware was validated nowhere in CI.

## Origin

Follow-on to the test-coverage analysis — *"keep going"* after #274 (ShellCheck + `apply_reload` tests) and #275 (context-dump transform tests + `!secret` coverage) merged. This implements **gap #4: an `esphome config` CI job**.

`frenck/action-home-assistant` (the `check-config` gate) validates HA config, **not** ESPHome YAML — so a broken pin, sensor, or schema in the two Konnected ESP8266 panel firmwares (`esphome/konnected-*.yaml`) would ship unnoticed until a physical OTA flash.

## What's here

- **`.github/workflows/esphome-check.yml`** — a new `ESPHome Check` workflow. It installs a pinned `esphome`, copies `esphome/secrets.fake.yaml` → `esphome/secrets.yaml`, and runs `esphome config` over every `esphome/*.yaml` device config (skipping `secrets*.yaml`). The loop fails the job if any config is invalid, with a `::error file=...::` annotation pointing at the offender. Both panels validate clean against esphome `2026.5.1`.

- **`esphome/secrets.fake.yaml`** — CI dummy secrets. The API key must be a **valid 32-byte base64 string** or schema validation rejects it, so this ships a throwaway generated key rather than the `"fake_value"` placeholder the root `secrets.fake.yaml` uses. (HA core never loads the ESPHome `api` block, which is why the root file's non-base64 placeholder was fine for `check-config` but won't work here.)

- **`esphome/secrets.yaml.example`** — `esphome/README.md` already references this file under *Secrets*, but it didn't exist. Adds it, mirroring the root `secrets.yaml.example` convention.

## Notes / decisions

- **Pinned `esphome==2026.5.1`** for deterministic validation — a floating `latest` could fail CI on unchanged configs after an upstream schema change. Comment in the workflow says to bump it deliberately alongside the ESPHome Device Builder add-on version the panels are flashed from.
- **Generic `esphome/*.yaml` loop** (skipping secrets files) so a future third panel is covered automatically without editing the workflow.

## Verification

Ran the exact CI steps locally: `pip install esphome==2026.5.1`, `cp esphome/secrets.fake.yaml esphome/secrets.yaml`, then the validation loop — both panels report `Configuration is valid!`, loop exits 0. New YAML passes `yamllint -c .yamllint.yml`. Existing 25-test bats suite still green (the `!secret`-coverage test excludes `esphome/`, so the new secret files don't affect it).

## Remaining proposed gaps (future PRs)

Still open from the analysis: #3 (regex-validator tests for the sync workflows — needs extracting inline regexes into scripts, a more invasive change I'd want sign-off on) and #6 (dashboard entity-existence cross-check against `context/entities.json`).

https://claude.ai/code/session_014UUn1yZ1E1LG6XfuBAWfQa

---
_Generated by [Claude Code](https://claude.ai/code/session_014UUn1yZ1E1LG6XfuBAWfQa)_