### PR TITLE
Migrate UPS power-event notifications to YAML

### DIFF
--- a/automations/ups_power_events.yaml
+++ b/automations/ups_power_events.yaml
@@ -1,0 +1,56 @@
+# UPS power-event notifications for the CyberPower CP1500PFCLCDa on
+# neptune. Alerts when the UPS transitions between Online / On Battery /
+# Low Battery. NUT shutdown coordination is owned by upsmon on each
+# secondary (PVE cluster); this automation is for situational awareness only.
+- id: ups_power_event_notifications
+  alias: 'UPS — Power event notifications'
+  description: >-
+    Notifies on CyberPower UPS state transitions (Online / On Battery /
+    Low Battery). NUT secondaries on the PVE cluster handle the actual
+    graceful shutdown via upsmon FSD; this automation is alerting only.
+  mode: parallel
+  max: 5
+  triggers:
+    - trigger: state
+      entity_id: sensor.cyberpower_status
+      to:
+        - 'On Battery'
+        - 'Low Battery'
+        - 'Online'
+  actions:
+    - choose:
+        - conditions:
+            - condition: state
+              entity_id: sensor.cyberpower_status
+              state: 'On Battery'
+          sequence:
+            - action: notify.mobile_app_sm_s926u1
+              data:
+                title: 'UPS On Battery'
+                message: >-
+                  Wall power lost. Battery
+                  {{ states('sensor.cyberpower_battery_charge') }}%, load
+                  {{ states('sensor.cyberpower_load') }}%.
+        - conditions:
+            - condition: state
+              entity_id: sensor.cyberpower_status
+              state: 'Low Battery'
+          sequence:
+            - action: notify.mobile_app_sm_s926u1
+              data:
+                title: 'UPS LOW BATTERY — shutdown imminent'
+                message: >-
+                  Battery {{ states('sensor.cyberpower_battery_charge') }}%,
+                  load {{ states('sensor.cyberpower_load') }}%. PVE cluster
+                  + NAS will halt when upsmon hits FSD.
+        - conditions:
+            - condition: state
+              entity_id: sensor.cyberpower_status
+              state: 'Online'
+          sequence:
+            - action: notify.mobile_app_sm_s926u1
+              data:
+                title: 'UPS Online'
+                message: >-
+                  Wall power restored. Battery
+                  {{ states('sensor.cyberpower_battery_charge') }}%.


### PR DESCRIPTION
## Origin

Wired up a CyberPower CP1500PFCLCDa UPS on neptune as the homelab NUT master (2026-05-30). HA's Network UPS Tools integration was added against neptune, and an alert automation was prototyped via `ha_config_set_automation` — which lands in `.storage/`. Per this repo's drift guardrail, automations that should survive a rebuild belong in `automations/` as YAML, not in `.storage/`. This PR migrates the prototype.

## Summary

- Adds `automations/ups_power_events.yaml` with the Online / On Battery / Low Battery notification automation.
- Mode `parallel` (max 5) so a rapid OB → LB transition doesn't drop the second alert.
- Targets `notify.mobile_app_sm_s926u1` to match the convention used in `exterior_doors_night.yaml`.
- NUT graceful-shutdown coordination is owned by upsmon on each PVE secondary; this automation is alerting only.

## Cleanup (follow-up, not in this PR)

After merge + deploy, the storage-mode prototype `automation.ups_power_event_notifications` (unique_id `1780152068248`) needs to be deleted to avoid double-firing. I'll handle that once this PR is green.

## Test plan

- [ ] check-config passes against the proposed YAML
- [ ] YAML lint clean
- [ ] After merge: `automation.ups_power_event_notifications` reloads from YAML (state `on`, id matches)
- [ ] Storage-mode duplicate removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)