### PR TITLE
Revamp kiosk dashboard for interactive 2560x1440 monitor

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -14,35 +14,36 @@ Mobile-first control interface. Design principle: show only what's active.
 
 ## `kiosk.yaml` — Kiosk view (`/dashboard-kiosk/home`)
 
-Fixed 1080p wall display on a 65-inch TCL TV running Chromium in kiosk mode.
+Primary 2560x1440 monitor display driven by mouse + keyboard.
 
 - **View IS the grid** — the view itself is `type: custom:grid-layout` with `height: 100vh`; no nested panel-mode wrapper
 - **Typed cards per cell** — every panel is a typed Lovelace card (`mushroom-light-card`, `button-card`, `mini-media-player`, `clock-weather-card`, `better-thermostat-ui-card`) wrapped in `custom:mod-card` so the ha-card host provides the height cascade
 - **State-driven styling** — colors live in per-card `state` blocks (`button-card`) and `card_mod` styles, not Jinja-templated HTML. The alarm hero pulses on triggered.
-- **Non-interactive** — every card sets `tap_action: { action: none }`; the wall display ignores touch
+- **Interactive** — light tiles toggle on tap (hold = more-info); sensors, alarm, TVs, and the climate standby tiles open more-info dialogs; BTUI thermostat dials expose +/- and menu controls; mini-media-player tiles show play/pause, prev/next, volume, progress, and power overlaid on the artwork; the meeting indicator card toggles `switch.meeting_button_in_meeting` on tap
 - **Unavailable handling** — declared inside each card's `state` list (e.g. a `value: unavailable` block on a button-card), not via wrapper conditionals
 
 **Grid structure:**
 ```
 grid-template-columns: 1fr 1fr 1.4fr 1fr
-grid-template-rows:    130px 1fr
+grid-template-rows:    300px 1fr
 grid-template-areas:
-  "weather weather alarm   alarm"
+  "weather weather alarm   meeting"
   "climate sensors lights  media"
 ```
 
 | Cell | Contents |
 |------|----------|
-| weather | `clock-weather-card` with 4-day forecast (top-left, spans 2 cols) |
-| alarm | `button-card` hero (top-right, spans 2 cols) |
-| climate | 2 `better-thermostat-ui-card` dials stacked + heater `button-card` |
-| sensors | 10 `button-card` tiles in a 2×5 internal grid (6 doors + 2 garage covers + 2 motion) |
-| lights | 21 `mushroom-light-card` tiles in a 3×7 internal grid |
-| media | 6 `mini-media-player` cards (album art via `artwork: full-cover-fit`) in a 2×3 internal grid + TVs row |
+| weather | `clock-weather-card` with 3-row forecast (top-left, spans 2 cols) |
+| alarm | `button-card` hero for `alarm_control_panel.home_alarm` (top, third col) |
+| meeting | `button-card` for the `light.meeting_light` indicator; taps `switch.meeting_button_in_meeting` (top, fourth col) |
+| climate | 2 `better-thermostat-ui-card` dials stacked, each with a `mushroom-chips-card` strip (humidity, setpoint, HVAC action); standby mode swaps the dial for a large current-temp tile |
+| sensors | 8 `button-card` tiles in a 2×4 internal grid (4 doors + 2 garage covers + 2 motion) |
+| lights | 18 `mushroom-light-card` tiles grouped into 5 room sections (Family, Kitchen, Office, Hallways, Outdoor) with per-section header markdown cards |
+| media | 6 `mini-media-player` cards (album art via `artwork: full-cover-fit`, controls overlaid) in a 2×3 internal grid + TVs row |
 
 ### Kiosk Mode
 
-`kiosk_mode` block at the top of `kiosk.yaml` hides header and sidebar for the `Kiosk` user (a non-admin local account used on the wall display).
+The `kiosk_mode` block at the top of `kiosk.yaml` hides header and sidebar **only for the `Kiosk` non-admin user** (used historically on the wall-display kiosk). The desktop session logs in as the normal admin user, so the sidebar/header remain available for navigation between dashboards.
 
 ## `homelab-status.yaml` — Homelab Status
 

--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -1,10 +1,20 @@
 # =================================================================
-# KIOSK DASHBOARD — V2 (foundation rebuild)
-# Dedicated 1920x1080 home-state display for pve2 -> TCL TV.
+# KIOSK DASHBOARD — V3 (interactive desktop layout)
+# Primary home-state display, scaled for a 2560x1440 monitor driven
+# by mouse + keyboard. Every card supports its native interactions:
+#   - Light tiles toggle on tap, more-info on hold
+#   - Sensors, alarm, TVs, climate standby tiles open more-info
+#     dialogs (history, arm/disarm panel, media controls, climate
+#     setpoint sliders)
+#   - BTUI thermostat dials expose +/- and menu controls
+#   - Mini-media-player tiles expose play/pause, prev/next, volume,
+#     progress, and power overlaid on the artwork
+#   - Meeting card toggles switch.meeting_button_in_meeting so the
+#     in-meeting indicator can be flipped from the dashboard
 #
 # URL: http://<ha-host>:8123/kiosk/home
 #
-# Architecture (research-driven rebuild):
+# Architecture:
 #   - View type: custom:grid-layout (NOT panel:true wrapper)
 #   - Cell wrappers: custom:mod-card for ha-card host + height: 100% cascade
 #   - Typed cards per panel (no html-template-card):
@@ -38,7 +48,7 @@ views:
       overflow: hidden
       grid-gap: 8px
       grid-template-columns: 1fr 1fr 1.4fr 1fr
-      grid-template-rows: 240px 1fr
+      grid-template-rows: 300px 1fr
       grid-template-areas: |
         "weather weather alarm   meeting"
         "climate sensors lights  media"
@@ -100,8 +110,7 @@ views:
           show_icon: true
           size: 55%
           layout: icon_name_state
-          tap_action: { action: none }
-          hold_action: { action: none }
+          tap_action: { action: more-info }
           state:
             - value: disarmed
               icon: mdi:shield-check
@@ -195,8 +204,18 @@ views:
           show_label: true
           show_icon: true
           size: 60%
-          tap_action: { action: none }
-          hold_action: { action: none }
+          # Tap toggles the underlying meeting button so the in-meeting
+          # state can be flipped from the dashboard; the card's visual
+          # state still reads from light.meeting_light (the indicator
+          # the meeting_indicator package drives).
+          tap_action:
+            action: call-service
+            service: switch.toggle
+            target:
+              entity_id: switch.meeting_button_in_meeting
+          hold_action:
+            action: more-info
+            entity: switch.meeting_button_in_meeting
           state:
             - value: 'on'
               icon: mdi:account-voice
@@ -301,8 +320,8 @@ views:
                       entity: climate.upstairs
                       name: Upstairs
                       humidity: sensor.upstairs_humidity
-                      disable_buttons: true
-                      disable_menu: true
+                      disable_buttons: false
+                      disable_menu: false
                       card_mod:
                         style: |
                           ha-card { background: transparent !important; border: none !important; box-shadow: none !important; }
@@ -324,7 +343,7 @@ views:
                       icon: mdi:thermometer
                       icon_color: blue-grey
                       fill_container: true
-                      tap_action: { action: none }
+                      tap_action: { action: more-info }
                       card_mod:
                         style: |
                           ha-card {
@@ -423,8 +442,8 @@ views:
                       entity: climate.downstairs
                       name: Downstairs
                       humidity: sensor.downstairs_humidity
-                      disable_buttons: true
-                      disable_menu: true
+                      disable_buttons: false
+                      disable_menu: false
                       card_mod:
                         style: |
                           ha-card { background: transparent !important; border: none !important; box-shadow: none !important; }
@@ -446,7 +465,7 @@ views:
                       icon: mdi:thermometer
                       icon_color: blue-grey
                       fill_container: true
-                      tap_action: { action: none }
+                      tap_action: { action: more-info }
                       card_mod:
                         style: |
                           ha-card {
@@ -566,7 +585,7 @@ views:
               show_state: true
               show_icon: true
               size: 70%
-              tap_action: { action: none }
+              tap_action: { action: more-info }
               state:
                 - value: 'on'
                   icon: mdi:door-open
@@ -610,7 +629,7 @@ views:
               show_state: true
               show_icon: true
               size: 70%
-              tap_action: { action: none }
+              tap_action: { action: more-info }
               state:
                 - value: 'on'
                   icon: mdi:door-sliding-open
@@ -654,7 +673,7 @@ views:
               show_state: true
               show_icon: true
               size: 70%
-              tap_action: { action: none }
+              tap_action: { action: more-info }
               state:
                 - value: 'on'
                   icon: mdi:door-open
@@ -698,7 +717,7 @@ views:
               show_state: true
               show_icon: true
               size: 70%
-              tap_action: { action: none }
+              tap_action: { action: more-info }
               state:
                 - value: 'on'
                   icon: mdi:door-open
@@ -743,7 +762,7 @@ views:
               show_state: true
               show_icon: true
               size: 70%
-              tap_action: { action: none }
+              tap_action: { action: more-info }
               state:
                 - value: 'closed'
                   icon: mdi:garage
@@ -791,7 +810,7 @@ views:
               show_state: true
               show_icon: true
               size: 70%
-              tap_action: { action: none }
+              tap_action: { action: more-info }
               state:
                 - value: 'closed'
                   icon: mdi:garage
@@ -840,7 +859,7 @@ views:
               show_state: true
               show_icon: true
               size: 70%
-              tap_action: { action: none }
+              tap_action: { action: more-info }
               state:
                 - value: 'on'
                   icon: mdi:motion-sensor
@@ -879,7 +898,7 @@ views:
               show_state: true
               show_icon: true
               size: 70%
-              tap_action: { action: none }
+              tap_action: { action: more-info }
               state:
                 - value: 'on'
                   icon: mdi:motion-sensor
@@ -969,8 +988,8 @@ views:
               columns: 2
               square: false
               cards:
-                - { type: 'custom:mushroom-light-card', entity: light.family_room_2, name: Family, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.floor_lamp_composite, name: Floor, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.family_room_2, name: Family, layout: vertical, fill_container: true, icon_type: icon }
+                - { type: 'custom:mushroom-light-card', entity: light.floor_lamp_composite, name: Floor, layout: vertical, fill_container: true, icon_type: icon }
 
             # --- Kitchen ---
             - <<: *light_section_header
@@ -979,9 +998,9 @@ views:
               columns: 3
               square: false
               cards:
-                - { type: 'custom:mushroom-light-card', entity: light.kitchen_island, name: Island, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.kitchen_main, name: Kitchen, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.kitchen_table, name: Table, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.kitchen_island, name: Island, layout: vertical, fill_container: true, icon_type: icon }
+                - { type: 'custom:mushroom-light-card', entity: light.kitchen_main, name: Kitchen, layout: vertical, fill_container: true, icon_type: icon }
+                - { type: 'custom:mushroom-light-card', entity: light.kitchen_table, name: Table, layout: vertical, fill_container: true, icon_type: icon }
 
             # --- Office ---
             - <<: *light_section_header
@@ -990,12 +1009,12 @@ views:
               columns: 3
               square: false
               cards:
-                - { type: 'custom:mushroom-light-card', entity: light.bookcase_lamp, name: Bookcase, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.corner_lamp, name: Corner, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.door_lamp, name: Door, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.table_lamp, name: Table, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.desk_lamp_2, name: Desk, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.desk_lamp_2_2, name: Desk 2, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.bookcase_lamp, name: Bookcase, layout: vertical, fill_container: true, icon_type: icon }
+                - { type: 'custom:mushroom-light-card', entity: light.corner_lamp, name: Corner, layout: vertical, fill_container: true, icon_type: icon }
+                - { type: 'custom:mushroom-light-card', entity: light.door_lamp, name: Door, layout: vertical, fill_container: true, icon_type: icon }
+                - { type: 'custom:mushroom-light-card', entity: light.table_lamp, name: Table, layout: vertical, fill_container: true, icon_type: icon }
+                - { type: 'custom:mushroom-light-card', entity: light.desk_lamp_2, name: Desk, layout: vertical, fill_container: true, icon_type: icon }
+                - { type: 'custom:mushroom-light-card', entity: light.desk_lamp_2_2, name: Desk 2, layout: vertical, fill_container: true, icon_type: icon }
 
             # --- Hallways ---
             - <<: *light_section_header
@@ -1004,8 +1023,8 @@ views:
               columns: 2
               square: false
               cards:
-                - { type: 'custom:mushroom-light-card', entity: light.downstairs_hallway, name: Down Hall, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.upstairs_hallway_light, name: Up Hall, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.downstairs_hallway, name: Down Hall, layout: vertical, fill_container: true, icon_type: icon }
+                - { type: 'custom:mushroom-light-card', entity: light.upstairs_hallway_light, name: Up Hall, layout: vertical, fill_container: true, icon_type: icon }
 
             # --- Outdoor ---
             - <<: *light_section_header
@@ -1014,11 +1033,11 @@ views:
               columns: 5
               square: false
               cards:
-                - { type: 'custom:mushroom-light-card', entity: light.front_door, name: Front, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.front_lantern, name: Lantern, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.garage_front, name: Garage Fr, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.garage_side, name: Garage Sd, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
-                - { type: 'custom:mushroom-light-card', entity: light.shed, name: Shed, layout: vertical, fill_container: true, icon_type: icon, tap_action: { action: none } }
+                - { type: 'custom:mushroom-light-card', entity: light.front_door, name: Front, layout: vertical, fill_container: true, icon_type: icon }
+                - { type: 'custom:mushroom-light-card', entity: light.front_lantern, name: Lantern, layout: vertical, fill_container: true, icon_type: icon }
+                - { type: 'custom:mushroom-light-card', entity: light.garage_front, name: Garage Fr, layout: vertical, fill_container: true, icon_type: icon }
+                - { type: 'custom:mushroom-light-card', entity: light.garage_side, name: Garage Sd, layout: vertical, fill_container: true, icon_type: icon }
+                - { type: 'custom:mushroom-light-card', entity: light.shed, name: Shed, layout: vertical, fill_container: true, icon_type: icon }
 
       # ============================================================
       # MEDIA COLUMN — 6 Sonos cells (2x3) + TV row (60px)
@@ -1074,8 +1093,8 @@ views:
                     name: Master Bedroom
                     artwork: full-cover-fit
                     info: scroll
-                    hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-                    tap_action: { action: none }
+                    hide: { source: true, sound_mode: true, shuffle: true, runtime: true, name: false }
+                    tap_action: { action: more-info }
                     card_mod:
                       style: |
                         ha-card {
@@ -1118,8 +1137,8 @@ views:
                     name: Basement
                     artwork: full-cover-fit
                     info: scroll
-                    hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-                    tap_action: { action: none }
+                    hide: { source: true, sound_mode: true, shuffle: true, runtime: true, name: false }
+                    tap_action: { action: more-info }
                     card_mod:
                       style: |
                         ha-card {
@@ -1162,8 +1181,8 @@ views:
                     name: Office
                     artwork: full-cover-fit
                     info: scroll
-                    hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-                    tap_action: { action: none }
+                    hide: { source: true, sound_mode: true, shuffle: true, runtime: true, name: false }
+                    tap_action: { action: more-info }
                     card_mod:
                       style: |
                         ha-card {
@@ -1206,8 +1225,8 @@ views:
                     name: Kitchen
                     artwork: full-cover-fit
                     info: scroll
-                    hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-                    tap_action: { action: none }
+                    hide: { source: true, sound_mode: true, shuffle: true, runtime: true, name: false }
+                    tap_action: { action: more-info }
                     card_mod:
                       style: |
                         ha-card {
@@ -1250,8 +1269,8 @@ views:
                     name: Dining Room
                     artwork: full-cover-fit
                     info: scroll
-                    hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-                    tap_action: { action: none }
+                    hide: { source: true, sound_mode: true, shuffle: true, runtime: true, name: false }
+                    tap_action: { action: more-info }
                     card_mod:
                       style: |
                         ha-card {
@@ -1294,8 +1313,8 @@ views:
                     name: Roam 2
                     artwork: full-cover-fit
                     info: scroll
-                    hide: { power: true, volume: true, source: true, progress: true, controls: true, play_pause: true, next: true, prev: true, runtime: true, shuffle: true, sound_mode: true, name: false }
-                    tap_action: { action: none }
+                    hide: { source: true, sound_mode: true, shuffle: true, runtime: true, name: false }
+                    tap_action: { action: more-info }
                     card_mod:
                       style: |
                         ha-card {
@@ -1332,7 +1351,7 @@ views:
                   show_icon: true
                   size: 30%
                   layout: icon_name_state
-                  tap_action: { action: none }
+                  tap_action: { action: more-info }
                   state:
                     - value: 'off'
                       icon: mdi:television-off
@@ -1359,7 +1378,7 @@ views:
                   show_icon: true
                   size: 30%
                   layout: icon_name_state
-                  tap_action: { action: none }
+                  tap_action: { action: more-info }
                   state:
                     - value: 'off'
                       icon: mdi:television-off
@@ -1386,7 +1405,7 @@ views:
                   show_icon: true
                   size: 30%
                   layout: icon_name_state
-                  tap_action: { action: none }
+                  tap_action: { action: more-info }
                   state:
                     - value: 'off'
                       icon: mdi:television-off

--- a/themes/kiosk_polish.yaml
+++ b/themes/kiosk_polish.yaml
@@ -24,12 +24,12 @@ Kiosk Polish:
 
   # Mushroom token overrides — sized to fit the lights column
   # (5 sections + 7 tile rows + headers) inside the kiosk cell
-  # without triggering a page-level scrollbar at 1920x1080.
-  mush-icon-size: 26px
+  # without triggering a page-level scrollbar at 2560x1440.
+  mush-icon-size: 32px
   mush-icon-symbol-size: 0.55em
-  mush-card-primary-font-size: 10px
-  mush-card-secondary-font-size: 9px
-  mush-spacing: 6px
+  mush-card-primary-font-size: 13px
+  mush-card-secondary-font-size: 12px
+  mush-spacing: 8px
 
   # State-color sugar
   state-on-color: "#56d364"


### PR DESCRIPTION
## Origin

> revamp the kiosk dash so it's interactive. I'm scaling down to a monitor, at 2560x1440, with a mouse and keyboard so we may as well go interactive!

## Summary

The kiosk dashboard was built for a touchless 1080p TCL TV — every card explicitly disabled tap/hold actions (`tap_action: { action: none }`). The kiosk surface is moving to a 2560x1440 desktop monitor with mouse + keyboard, so this PR restores native interactions across the board and scales the layout for the new viewport.

### Interactivity restored

- **Mushroom light tiles** — defaults restored: tap toggles, hold opens more-info (brightness/color picker).
- **Button-card sensors / alarm hero / TVs / standby thermostat tiles** — tap → more-info dialog (history for sensors, arm-disarm panel for the alarm, media controls for TVs, climate setpoint slider for standby HVAC).
- **Better-thermostat-ui-card dials** — `disable_buttons: false`, `disable_menu: false` so the +/- and menu controls are clickable.
- **mini-media-player tiles** — previously hid every control; now expose play/pause, prev/next, volume, progress, and power overlaid on the artwork.
- **Meeting indicator card** — wired explicitly to `switch.toggle` on `switch.meeting_button_in_meeting` so the in-meeting state can be flipped from the dashboard (without toggling `light.meeting_light` directly, which would only kill the indicator without clearing the underlying state). Visual state still reads off `light.meeting_light`.

### Layout scaled for 2560x1440

- Top row grows from `240px` → `300px` to preserve its share of vertical space at 1440p.
- Kiosk Polish theme bumps the Mushroom token overrides ~25–33% (icon 26→32px, primary text 10→13px, secondary text 9→12px, spacing 6→8px) to use the extra vertical room in the lights column.

### README cleanup

- Describes the new interactive layout
- Fixes pre-existing cell-map drift: top-row split is `alarm | meeting` (not `alarm` spanning 2 cols), sensors are 8 not 10, lights are 18 grouped into 5 sections (not 21 in a flat grid)

## Test plan

- [ ] `YAML Lint`, `check-config`, and `claude-review` all green
- [ ] After deploy, visit `/dashboard-kiosk/home` on the monitor and confirm:
  - [ ] Light tiles toggle on click; hold opens the light dialog
  - [ ] Alarm hero opens the arm/disarm dialog on click
  - [ ] Meeting card flips Rachel's in-meeting state on click (and the office corner lamp / hallway light follow per the existing meeting_indicator automations)
  - [ ] Thermostat dials let you tap +/- to nudge setpoint
  - [ ] Mini-media-player tiles show play/pause and volume; controls work without unexpected layout breakage on the full-cover-fit artwork
  - [ ] Sensor / garage / TV tiles open more-info on click
  - [ ] Top row sits roughly 20–22% of viewport height (no awkward gap below weather, no overflow above)
  - [ ] Lights column doesn't trigger a page scrollbar at 1440p

🤖 Generated with [Claude Code](https://claude.com/claude-code)