### PR TITLE
Harvest dashboard-kiosk Chromium launcher from pve2

### DIFF
--- a/kiosk-host/README.md
+++ b/kiosk-host/README.md
@@ -1,0 +1,75 @@
+# kiosk-host/
+
+Display-host configuration for the machine that renders
+`/dashboard-kiosk/home` on the household monitor. The kiosk dashboard
+itself lives in `dashboards/kiosk.yaml`; these files configure the
+*Chromium kiosk runner* that points a screen at it.
+
+## Where it runs
+
+| | |
+|---|---|
+| **Host** | `pve2` (NUC, i3-6100U, quorum-only PVE node — see top-level `~/CLAUDE.md`) |
+| **Display** | 2560x1440 monitor on `HDMI-2`, mouse + keyboard attached |
+| **Browser** | Chromium in `--kiosk` mode, root-owned, no X session manager |
+| **Display target URL** | `http://192.168.139.172:8123/dashboard-kiosk/home` (= `homeassistant.local`) |
+
+## File map (on pve2)
+
+| Repo path | Deployed to | Mode | Owner |
+|---|---|---|---|
+| `dashboard-kiosk.sh` | `/usr/local/bin/dashboard-kiosk.sh` | `0755` | `root:root` |
+| `dashboard-kiosk.service` | `/etc/systemd/system/dashboard-kiosk.service` | `0644` | `root:root` |
+
+The systemd unit launches a bare `xinit` session pinned to display `:0`
+(no display manager) and the script forks `unclutter` + `chromium` in
+front of it.
+
+## Deploy
+
+After editing files in this directory, push them and reload systemd:
+
+```bash
+# from a workstation that can ssh to pve.local (pve → pve2 hop):
+scp -o ProxyJump=root@pve.local \
+    kiosk-host/dashboard-kiosk.sh \
+    root@pve2:/usr/local/bin/dashboard-kiosk.sh
+scp -o ProxyJump=root@pve.local \
+    kiosk-host/dashboard-kiosk.service \
+    root@pve2:/etc/systemd/system/dashboard-kiosk.service
+
+ssh -J root@pve.local root@pve2 '
+  chmod 0755 /usr/local/bin/dashboard-kiosk.sh
+  systemctl daemon-reload
+  systemctl restart dashboard-kiosk.service
+  systemctl status --no-pager dashboard-kiosk.service
+'
+```
+
+A restart cycles the X session and reloads Chromium against the live
+dashboard URL.
+
+## Verify
+
+```bash
+ssh -J root@pve.local root@pve2 'systemctl status dashboard-kiosk.service --no-pager'
+ssh -J root@pve.local root@pve2 'journalctl -u dashboard-kiosk.service -n 50 --no-pager'
+```
+
+Or just walk over to the monitor.
+
+## Known cleanup (not done in this commit)
+
+- `Description=Grafana Dashboard Kiosk` in the unit is a stale label
+  from when pve2 displayed Grafana. Rename to
+  `Description=Home Assistant Dashboard Kiosk` next time the unit is
+  touched.
+- The chromium URL hard-codes `192.168.139.172` (HAOS VM IP). The HAOS
+  VM gets DHCP today — pin the IP in Firewalla (see the *Static DHCP
+  reservations* note in `~/CLAUDE.md`) or switch the URL to
+  `http://homeassistant.local:8123/dashboard-kiosk/home`. Either makes
+  the kiosk survive a lease change.
+- No GitOps-style auto-deploy. Edits to this dir are deployed manually
+  via the scp+restart recipe above; if this surface grows, consider an
+  Ansible role or a small drop-in service on pve2 that `git pull`s and
+  diffs.

--- a/kiosk-host/dashboard-kiosk.service
+++ b/kiosk-host/dashboard-kiosk.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Grafana Dashboard Kiosk
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/xinit /usr/local/bin/dashboard-kiosk.sh -- :0
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/kiosk-host/dashboard-kiosk.sh
+++ b/kiosk-host/dashboard-kiosk.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+xrandr --output HDMI-2 --mode 2560x1440 --rate 60
+xset s off
+xset -dpms
+xset s noblank
+unclutter -idle 3 -root &
+chromium \
+  --no-sandbox \
+  --kiosk \
+  --noerrdialogs \
+  --disable-infobars \
+  --no-first-run \
+  --disable-session-crashed-bubble \
+  --disable-features=TranslateUI \
+  --check-for-update-interval=31536000 \
+  --force-device-scale-factor=1 \
+  --window-size=2560,1440 \
+  --window-position=0,0 \
+  "http://192.168.139.172:8123/dashboard-kiosk/home"


### PR DESCRIPTION
## Origin

> harvest the chromium script from pve2 and get it under git control

## Summary

Brings the dashboard-kiosk launcher under version control. Both files
captured verbatim from the live host so the in-repo copy is a true
mirror of what pve2 is running right now.

- `kiosk-host/dashboard-kiosk.sh` → deploys to `/usr/local/bin/dashboard-kiosk.sh` (0755, root)
- `kiosk-host/dashboard-kiosk.service` → deploys to `/etc/systemd/system/dashboard-kiosk.service` (0644, root)
- `kiosk-host/README.md` documents the host (pve2 NUC, 2560x1440 monitor on HDMI-2), the deploy recipe (scp via `-J root@pve.local` jump host + `systemctl daemon-reload` + `restart`), and the verify steps.

## Known cleanup, left in place to keep this commit a faithful mirror

- Service `Description=Grafana Dashboard Kiosk` is stale from when pve2 displayed Grafana — rename next time the unit is touched.
- Chromium URL hard-codes `192.168.139.172` (HAOS VM's current DHCP lease). Switching to `http://homeassistant.local:8123/dashboard-kiosk/home` or pinning the lease in Firewalla (per `~/CLAUDE.md`) would make the kiosk survive a lease change.

Why now: a pve2 rebuild is plausibly on the table once a small ZFS-target SSD arrives, and having these in git means re-deploy from a checkout instead of recovering from a backup of an ephemeral OS disk.

## Test plan

- [ ] `YAML Lint`, `check-config`, and `claude-review` all green (these files don't affect HA config, but the workflows still run)
- [ ] After merge, do a no-op redeploy from the README recipe and confirm `systemctl status dashboard-kiosk.service` stays `active (running)` and the monitor shows the kiosk dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)