### PR TITLE
Add gitops pull loop for kiosk-host on pve2

### DIFF
--- a/kiosk-host/README.md
+++ b/kiosk-host/README.md
@@ -16,43 +16,103 @@ itself lives in `dashboards/kiosk.yaml`; these files configure the
 
 ## File map (on pve2)
 
-| Repo path | Deployed to | Mode | Owner |
-|---|---|---|---|
-| `dashboard-kiosk.sh` | `/usr/local/bin/dashboard-kiosk.sh` | `0755` | `root:root` |
-| `dashboard-kiosk.service` | `/etc/systemd/system/dashboard-kiosk.service` | `0644` | `root:root` |
+| Repo path | Deployed to | Mode | Owner | Managed by |
+|---|---|---|---|---|
+| `dashboard-kiosk.sh` | `/usr/local/bin/dashboard-kiosk.sh` | `0755` | `root:root` | gitops loop |
+| `dashboard-kiosk.service` | `/etc/systemd/system/dashboard-kiosk.service` | `0644` | `root:root` | gitops loop |
+| `gitops-pull.sh` | (run in place from `/opt/homeassistant-config/kiosk-host/`) | `0755` | `root:root` | bootstrap only |
+| `gitops-pull.service` | `/etc/systemd/system/dashboard-kiosk-gitops.service` | `0644` | `root:root` | bootstrap only |
+| `gitops-pull.timer` | `/etc/systemd/system/dashboard-kiosk-gitops.timer` | `0644` | `root:root` | bootstrap only |
 
-The systemd unit launches a bare `xinit` session pinned to display `:0`
-(no display manager) and the script forks `unclutter` + `chromium` in
-front of it.
+The kiosk `systemd` unit launches a bare `xinit` session pinned to
+display `:0` (no display manager) and the script forks `unclutter` +
+`chromium` in front of it. The gitops loop is a oneshot service driven
+by a 5-minute timer that pulls `origin/main` and reinstalls the two
+kiosk artifacts if they drift.
 
 ## Deploy
 
-After editing files in this directory, push them and reload systemd:
+Push a change through the standard PitziLabs PR flow. The merged
+change is picked up by the gitops loop on pve2 within ~5 minutes:
+
+1. Loop fetches `origin/main` and resets the clone if it has diverged.
+2. Loop `bash -n`'s the script and `systemd-analyze verify`'s the unit
+   before touching the deployed copies — a syntax-broken commit can't
+   put the kiosk into a crash loop.
+3. If either differs from the deployed copy, the loop reinstalls it,
+   runs `daemon-reload` if the unit changed, then
+   `systemctl restart dashboard-kiosk.service` — a single restart
+   cycles X + Chromium against the new state. No-op polls do not
+   restart anything.
+
+The loop refuses to deploy unless the clone is on the `main` branch,
+mirroring the HA-side `scripts/gitops-sync.sh` guard.
+
+To force an immediate pull instead of waiting for the timer:
 
 ```bash
-# from a workstation that can ssh to pve.local (pve → pve2 hop):
-scp -o ProxyJump=root@pve.local \
-    kiosk-host/dashboard-kiosk.sh \
-    root@pve2:/usr/local/bin/dashboard-kiosk.sh
-scp -o ProxyJump=root@pve.local \
-    kiosk-host/dashboard-kiosk.service \
-    root@pve2:/etc/systemd/system/dashboard-kiosk.service
+ssh -J root@pve.local root@pve2 'systemctl start dashboard-kiosk-gitops.service'
+```
 
+To watch the loop's log:
+
+```bash
+ssh -J root@pve.local root@pve2 'tail -f /var/log/dashboard-kiosk-gitops.log'
+# or
+ssh -J root@pve.local root@pve2 'journalctl -u dashboard-kiosk-gitops.service -f'
+```
+
+To temporarily disable the loop (e.g. while hand-iterating on pve2):
+
+```bash
+ssh -J root@pve.local root@pve2 'systemctl stop dashboard-kiosk-gitops.timer'
+# resume with:
+ssh -J root@pve.local root@pve2 'systemctl start dashboard-kiosk-gitops.timer'
+```
+
+## Bootstrap (one-time, after a fresh pve2 install)
+
+The gitops loop manages the two kiosk artifacts but cannot install
+itself, so the initial setup is manual:
+
+```bash
 ssh -J root@pve.local root@pve2 '
-  chmod 0755 /usr/local/bin/dashboard-kiosk.sh
+  set -euo pipefail
+  apt-get update
+  apt-get install -y git chromium xserver-xorg xinit unclutter
+
+  # Clone the canonical config
+  test -d /opt/homeassistant-config || \
+    git clone https://github.com/PitziLabs/homeassistant-config.git /opt/homeassistant-config
+  cd /opt/homeassistant-config && git checkout main && git pull --ff-only origin main
+
+  # Install the kiosk display artifacts (the loop manages these going forward)
+  install -m 0755 -o root -g root kiosk-host/dashboard-kiosk.sh         /usr/local/bin/dashboard-kiosk.sh
+  install -m 0644 -o root -g root kiosk-host/dashboard-kiosk.service    /etc/systemd/system/dashboard-kiosk.service
+
+  # Install the gitops loop units (the loop does NOT manage these — bootstrap only)
+  install -m 0644 -o root -g root kiosk-host/gitops-pull.service        /etc/systemd/system/dashboard-kiosk-gitops.service
+  install -m 0644 -o root -g root kiosk-host/gitops-pull.timer          /etc/systemd/system/dashboard-kiosk-gitops.timer
+
   systemctl daemon-reload
-  systemctl restart dashboard-kiosk.service
-  systemctl status --no-pager dashboard-kiosk.service
+  systemctl enable --now dashboard-kiosk.service
+  systemctl enable --now dashboard-kiosk-gitops.timer
+
+  systemctl status --no-pager dashboard-kiosk.service dashboard-kiosk-gitops.timer
 '
 ```
 
-A restart cycles the X session and reloads Chromium against the live
-dashboard URL.
+Edits to `gitops-pull.sh` *will* be picked up automatically (it runs
+in-place from the clone). Edits to `gitops-pull.service` or
+`gitops-pull.timer` need a manual re-bootstrap of just those two
+files — the loop deliberately doesn't manage the units that manage it,
+to avoid a broken update putting the system in a state where it can't
+fix itself.
 
 ## Verify
 
 ```bash
-ssh -J root@pve.local root@pve2 'systemctl status dashboard-kiosk.service --no-pager'
+ssh -J root@pve.local root@pve2 'systemctl status dashboard-kiosk.service dashboard-kiosk-gitops.timer --no-pager'
 ssh -J root@pve.local root@pve2 'journalctl -u dashboard-kiosk.service -n 50 --no-pager'
 ```
 
@@ -60,16 +120,12 @@ Or just walk over to the monitor.
 
 ## Known cleanup (not done in this commit)
 
-- `Description=Grafana Dashboard Kiosk` in the unit is a stale label
-  from when pve2 displayed Grafana. Rename to
+- `Description=Grafana Dashboard Kiosk` in `dashboard-kiosk.service`
+  is a stale label from when pve2 displayed Grafana. Rename to
   `Description=Home Assistant Dashboard Kiosk` next time the unit is
-  touched.
+  touched (the gitops loop will pick up the change automatically).
 - The chromium URL hard-codes `192.168.139.172` (HAOS VM IP). The HAOS
   VM gets DHCP today — pin the IP in Firewalla (see the *Static DHCP
   reservations* note in `~/CLAUDE.md`) or switch the URL to
   `http://homeassistant.local:8123/dashboard-kiosk/home`. Either makes
   the kiosk survive a lease change.
-- No GitOps-style auto-deploy. Edits to this dir are deployed manually
-  via the scp+restart recipe above; if this surface grows, consider an
-  Ansible role or a small drop-in service on pve2 that `git pull`s and
-  diffs.

--- a/kiosk-host/gitops-pull.service
+++ b/kiosk-host/gitops-pull.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Pull kiosk-host updates from git and redeploy
+Documentation=https://github.com/PitziLabs/homeassistant-config/blob/main/kiosk-host/README.md
+After=network-online.target dashboard-kiosk.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/homeassistant-config/kiosk-host/gitops-pull.sh
+# The script exits cleanly on no-op, so a non-zero exit is a real error
+# worth surfacing in `systemctl status` and journalctl.
+StandardOutput=journal
+StandardError=journal

--- a/kiosk-host/gitops-pull.sh
+++ b/kiosk-host/gitops-pull.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Pull the kiosk-host artifacts from origin/main and re-deploy them
+# if the in-repo copy drifts from what's installed on this host.
+#
+# Mirrors the spirit of the HA-side scripts/gitops-sync.sh: timestamped
+# leveled log with in-script rotation, flock against concurrent runs,
+# branch guard, validation before install, and a no-op fast path so the
+# kiosk doesn't restart on every poll.
+#
+# Intended invocation: oneshot systemd service driven by a 5-min timer
+# (see gitops-pull.service / gitops-pull.timer in this directory).
+
+set -euo pipefail
+
+readonly REPO_DIR="/opt/homeassistant-config"
+readonly REPO_SUBDIR="kiosk-host"
+readonly LOCK_FILE="/run/dashboard-kiosk-gitops.lock"
+readonly LOG_FILE="/var/log/dashboard-kiosk-gitops.log"
+readonly LOG_MAX_BYTES=1048576
+
+readonly SCRIPT_SRC="${REPO_DIR}/${REPO_SUBDIR}/dashboard-kiosk.sh"
+readonly SCRIPT_DST="/usr/local/bin/dashboard-kiosk.sh"
+readonly UNIT_SRC="${REPO_DIR}/${REPO_SUBDIR}/dashboard-kiosk.service"
+readonly UNIT_DST="/etc/systemd/system/dashboard-kiosk.service"
+readonly KIOSK_UNIT="dashboard-kiosk.service"
+
+log() {
+  local level="$1"
+  shift
+  local ts line
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  line="[$ts] [$level] $*"
+  printf '%s\n' "$line"
+  printf '%s\n' "$line" >> "$LOG_FILE"
+}
+
+rotate_log() {
+  if [[ -f "$LOG_FILE" ]]; then
+    local size
+    size=$(stat -c%s "$LOG_FILE")
+    if (( size >= LOG_MAX_BYTES )); then
+      mv "$LOG_FILE" "${LOG_FILE}.1"
+    fi
+  fi
+}
+
+main() {
+  rotate_log
+
+  if [[ ! -d "${REPO_DIR}/.git" ]]; then
+    log ERROR "Repo not found at ${REPO_DIR}. Bootstrap with: git clone https://github.com/PitziLabs/homeassistant-config.git ${REPO_DIR}"
+    exit 1
+  fi
+
+  cd "$REPO_DIR"
+
+  local current_branch
+  current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+  if [[ "$current_branch" != "main" ]]; then
+    log ERROR "Expected branch 'main', got '${current_branch}'. Aborting to avoid deploying wrong branch."
+    exit 1
+  fi
+
+  if ! git fetch --quiet origin main; then
+    log ERROR "git fetch failed — check network or DNS"
+    exit 1
+  fi
+
+  local rollback_sha remote_sha
+  rollback_sha=$(git rev-parse HEAD)
+  remote_sha=$(git rev-parse origin/main)
+
+  if [[ "$rollback_sha" != "$remote_sha" ]]; then
+    log INFO "Updating ${rollback_sha:0:7} → ${remote_sha:0:7}"
+    git reset --hard --quiet origin/main
+  fi
+
+  # Validate before installing so a syntax-broken commit can't put the
+  # kiosk into a crash loop.
+  if ! bash -n "$SCRIPT_SRC"; then
+    log ERROR "dashboard-kiosk.sh failed syntax check; refusing to install"
+    exit 1
+  fi
+  if ! systemd-analyze verify "$UNIT_SRC" 2>/dev/null; then
+    log ERROR "dashboard-kiosk.service failed systemd-analyze verify; refusing to install"
+    exit 1
+  fi
+
+  local script_changed=false unit_changed=false
+  if ! cmp -s "$SCRIPT_SRC" "$SCRIPT_DST"; then
+    script_changed=true
+  fi
+  if ! cmp -s "$UNIT_SRC" "$UNIT_DST"; then
+    unit_changed=true
+  fi
+
+  if [[ "$script_changed" == false && "$unit_changed" == false ]]; then
+    log INFO "no-op, deployed copy matches ${remote_sha:0:7}"
+    exit 0
+  fi
+
+  if [[ "$script_changed" == true ]]; then
+    log INFO "Installing dashboard-kiosk.sh → ${SCRIPT_DST}"
+    install -m 0755 -o root -g root "$SCRIPT_SRC" "$SCRIPT_DST"
+  fi
+  if [[ "$unit_changed" == true ]]; then
+    log INFO "Installing dashboard-kiosk.service → ${UNIT_DST}"
+    install -m 0644 -o root -g root "$UNIT_SRC" "$UNIT_DST"
+    systemctl daemon-reload
+  fi
+
+  log INFO "Restarting ${KIOSK_UNIT}"
+  systemctl restart "$KIOSK_UNIT"
+
+  log INFO "Deployed ${remote_sha:0:7}"
+}
+
+main_locked() {
+  exec 9>"$LOCK_FILE"
+  if ! flock -n 9; then
+    exit 0
+  fi
+  main
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main_locked
+fi

--- a/kiosk-host/gitops-pull.timer
+++ b/kiosk-host/gitops-pull.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Periodic gitops pull for kiosk-host
+Documentation=https://github.com/PitziLabs/homeassistant-config/blob/main/kiosk-host/README.md
+
+[Timer]
+# 2-minute settle after boot so the kiosk service comes up first
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=true
+Unit=dashboard-kiosk-gitops.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Origin

> ok let's get gitops set up on pve2 to pull the script if it changes then

## Summary

A 5-minute oneshot+timer pair on pve2 that pulls `origin/main` and reinstalls `dashboard-kiosk.sh` / `dashboard-kiosk.service` if they've drifted from the in-repo copies. Mirrors the HA-side `scripts/gitops-sync.sh` in shape: timestamped leveled log at `/var/log/dashboard-kiosk-gitops.log` with in-script rotation, flock against concurrent runs, `main`-branch guard, and a clean no-op fast path so the kiosk doesn't restart on every poll.

### Why this is safe

- **Validation before install** — `bash -n` on the script and `systemd-analyze verify` on the unit run *before* the deployed copies are touched. A syntax-broken commit can't put the kiosk into a crash loop.
- **Restart only on real drift** — `cmp -s` per file decides whether to reinstall, and the kiosk service only restarts if at least one of the two files actually changed.
- **Self-managing loop deliberately excluded** — `gitops-pull.service` and `gitops-pull.timer` are installed at bootstrap and *not* managed by the loop. A broken update to the units that manage the system shouldn't be able to leave it unable to fix itself.

### Files

- `kiosk-host/gitops-pull.sh` — the worker
- `kiosk-host/gitops-pull.service` — oneshot, depends on `network-online.target`
- `kiosk-host/gitops-pull.timer` — `OnBootSec=2min`, `OnUnitActiveSec=5min`, `Persistent=true`
- `kiosk-host/README.md` updated:
  - File map now shows which artifacts are managed by the loop vs. bootstrap-only
  - Deploy section describes the PR → loop flow and how to force a pull, watch the log, disable the loop
  - New Bootstrap section: `apt-get install -y git chromium xserver-xorg xinit unclutter`, clone to `/opt/homeassistant-config`, `install` the four artifacts, `systemctl enable --now` the kiosk service + gitops timer. Idempotent.

## Bootstrap (do this after merge)

```bash
ssh -J root@pve.local root@pve2 '
  set -euo pipefail
  apt-get update
  apt-get install -y git chromium xserver-xorg xinit unclutter
  test -d /opt/homeassistant-config || \
    git clone https://github.com/PitziLabs/homeassistant-config.git /opt/homeassistant-config
  cd /opt/homeassistant-config && git checkout main && git pull --ff-only origin main
  install -m 0755 -o root -g root kiosk-host/dashboard-kiosk.sh      /usr/local/bin/dashboard-kiosk.sh
  install -m 0644 -o root -g root kiosk-host/dashboard-kiosk.service /etc/systemd/system/dashboard-kiosk.service
  install -m 0644 -o root -g root kiosk-host/gitops-pull.service     /etc/systemd/system/dashboard-kiosk-gitops.service
  install -m 0644 -o root -g root kiosk-host/gitops-pull.timer       /etc/systemd/system/dashboard-kiosk-gitops.timer
  systemctl daemon-reload
  systemctl enable --now dashboard-kiosk.service
  systemctl enable --now dashboard-kiosk-gitops.timer
  systemctl status --no-pager dashboard-kiosk.service dashboard-kiosk-gitops.timer
'
```

I have not run the bootstrap yet — it installs packages and enables persistent timers on a shared infra node, so I want you to green-light it (or run it yourself). The clone + the two display artifacts will be a no-op against the running service (`cmp` matches), so the first invocation of `gitops-pull.service` will log a no-op and exit clean.

## Test plan

- [ ] `YAML Lint`, `check-config`, `claude-review` green
- [ ] After bootstrap: `systemctl list-timers | grep dashboard-kiosk` shows the timer firing every ~5 min
- [ ] Manual force-pull (`systemctl start dashboard-kiosk-gitops.service` immediately after merge) logs `no-op, deployed copy matches <sha>` to `/var/log/dashboard-kiosk-gitops.log`
- [ ] Future PR touching `kiosk-host/dashboard-kiosk.sh` or `dashboard-kiosk.service` triggers exactly one restart of `dashboard-kiosk.service` on pve2 within 5 min of merge, and the log shows the new SHA
- [ ] No regression: existing kiosk display continues to render `dashboard-kiosk/home`

🤖 Generated with [Claude Code](https://claude.com/claude-code)