### PR TITLE
Fix stale kiosk service description and hardcoded HAOS IP

### DIFF
--- a/kiosk-host/README.md
+++ b/kiosk-host/README.md
@@ -12,7 +12,7 @@ itself lives in `dashboards/kiosk.yaml`; these files configure the
 | **Host** | `pve2` (NUC, i3-6100U, quorum-only PVE node — see top-level `~/CLAUDE.md`) |
 | **Display** | 2560x1440 monitor on `HDMI-2`, mouse + keyboard attached |
 | **Browser** | Chromium in `--kiosk` mode, root-owned, no X session manager |
-| **Display target URL** | `http://192.168.139.172:8123/dashboard-kiosk/home` (= `homeassistant.local`) |
+| **Display target URL** | `http://homeassistant.local:8123/dashboard-kiosk/home` |
 
 ## File map (on pve2)
 
@@ -117,15 +117,3 @@ ssh -J root@pve.local root@pve2 'journalctl -u dashboard-kiosk.service -n 50 --n
 ```
 
 Or just walk over to the monitor.
-
-## Known cleanup (not done in this commit)
-
-- `Description=Grafana Dashboard Kiosk` in `dashboard-kiosk.service`
-  is a stale label from when pve2 displayed Grafana. Rename to
-  `Description=Home Assistant Dashboard Kiosk` next time the unit is
-  touched (the gitops loop will pick up the change automatically).
-- The chromium URL hard-codes `192.168.139.172` (HAOS VM IP). The HAOS
-  VM gets DHCP today — pin the IP in Firewalla (see the *Static DHCP
-  reservations* note in `~/CLAUDE.md`) or switch the URL to
-  `http://homeassistant.local:8123/dashboard-kiosk/home`. Either makes
-  the kiosk survive a lease change.

--- a/kiosk-host/dashboard-kiosk.service
+++ b/kiosk-host/dashboard-kiosk.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Grafana Dashboard Kiosk
+Description=Home Assistant Dashboard Kiosk
 After=network-online.target
 Wants=network-online.target
 

--- a/kiosk-host/dashboard-kiosk.sh
+++ b/kiosk-host/dashboard-kiosk.sh
@@ -16,4 +16,4 @@ chromium \
   --force-device-scale-factor=1 \
   --window-size=2560,1440 \
   --window-position=0,0 \
-  "http://192.168.139.172:8123/dashboard-kiosk/home"
+  "http://homeassistant.local:8123/dashboard-kiosk/home"


### PR DESCRIPTION
## Origin

> fix that stale grafana description and the hardcoded IP. and make a test change to the kiosk to exercise the deployment

## Summary

Both of the *Known cleanup* items left in `kiosk-host/README.md` after PR #284 are resolved here, doubling as the first real exercise of the gitops loop deployed in PR #285:

- `dashboard-kiosk.service`: `Description=Grafana Dashboard Kiosk` → `Home Assistant Dashboard Kiosk`. Cosmetic, but it's been wrong since the surface was repurposed off Grafana.
- `dashboard-kiosk.sh`: chromium URL `http://192.168.139.172:8123/dashboard-kiosk/home` → `http://homeassistant.local:8123/dashboard-kiosk/home`. mDNS resolution from pve2 to `homeassistant.local` was verified working earlier in this branch's work; the kiosk now survives a DHCP lease change on the HAOS VM.
- README: *Where it runs* row updated to the new URL; *Known cleanup* section removed (both items resolved).

## Expected loop behavior after merge

Both managed artifacts are touched, so the next gitops timer fire (or `systemctl start dashboard-kiosk-gitops.service`) should:

1. `git fetch origin main` — finds new SHA
2. `git reset --hard origin/main`
3. `bash -n` and `systemd-analyze verify` — both pass
4. `cmp -s` finds diffs on both files → install both
5. `systemctl daemon-reload` (because the unit changed)
6. `systemctl restart dashboard-kiosk.service` (exactly once)

Verification I'll run after merge:

- `tail /var/log/dashboard-kiosk-gitops.log` shows `Installing dashboard-kiosk.sh` + `Installing dashboard-kiosk.service` + `Restarting dashboard-kiosk.service` + `Deployed <sha>` entries
- `systemctl show dashboard-kiosk.service -p Description` returns `Home Assistant Dashboard Kiosk`
- `ps -ef | grep chromium | grep dashboard-kiosk` shows the new URL
- The kiosk monitor renders the dashboard against `homeassistant.local`

## Test plan

- [ ] `YAML Lint`, `check-config`, `claude-review` green
- [ ] Within ~5 min of merge, gitops log records the install + restart cycle
- [ ] Kiosk monitor briefly blanks then comes back on the same dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)