### PR TITLE
Fix kiosk alarm + meeting top-row tiles not filling their cells

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -100,7 +100,19 @@ views:
               border-radius: 10px;
               border: none;
               background: transparent;
+              display: flex;
+              flex-direction: column;
             }
+            /* Cascade height into the button-card so the green-tinted
+               state background fills the full 300px row instead of
+               collapsing to content height and leaking page bg below. */
+            ha-card > * {
+              flex: 1 1 auto;
+              min-height: 0;
+              display: flex;
+              flex-direction: column;
+            }
+            ha-card > * > * { flex: 1 1 auto; min-height: 0; }
         card:
           type: custom:button-card
           entity: alarm_control_panel.home_alarm
@@ -194,7 +206,17 @@ views:
               border-radius: 10px;
               border: none;
               background: transparent;
+              display: flex;
+              flex-direction: column;
             }
+            /* Same fill cascade as the alarm hero — see comment there. */
+            ha-card > * {
+              flex: 1 1 auto;
+              min-height: 0;
+              display: flex;
+              flex-direction: column;
+            }
+            ha-card > * > * { flex: 1 1 auto; min-height: 0; }
         card:
           type: custom:button-card
           entity: light.meeting_light


### PR DESCRIPTION
## Origin

> no, look here: http://homeassistant.local:8123/dashboard-kiosk/home

(With a screenshot showing the alarm and meeting tiles as thin strips at the top of their grid cells, with 220px of transparent space below leaking page background through.)

## Summary

The `mod-card` wrappers around the alarm hero and meeting indicator put `height: 100%` on their ha-card, but that height never cascaded into the inner button-card — the button-cards rendered at content height with their per-state background tint collapsed to ~80px at the top of the 300px row. Cosmetically broken even at 1080p; the bump to 300px in #283 (the interactive revamp) just made the wasted space more obvious.

Fix copies the cascade pattern the climate column already uses: turn the wrapper ha-card into `display: flex; flex-direction: column`, then push `flex: 1 1 auto; min-height: 0` through the wrapper's direct child *and* grandchild so the button-card's outer custom element and its inner ha-card both inherit available row height. The button-card's own `styles.card.height: 100%` then has a parent to fill against.

Two-cell, identical patch — alarm + meeting wrappers each get the same nine-line addition.

## Out of scope (call I want you to make)

Your screenshot also shows the page scrolling — the lights' OUTDOOR section, the motion sensors, the TVs row, and the full Sonos column are all below the fold. That's because `height: 100vh` on the grid view doesn't account for the ~64px HA header + dashboard-tab strip that admin users see. The `Kiosk` non-admin user has `kiosk_mode` hide the header, so for them `100vh` fits exactly.

Three reasonable fixes, depending on what you want for the desktop session:

1. **Keep header, shrink grid** — change `height: 100vh` to `height: calc(100vh - 64px)`. Admin user sees no scrollbar; Kiosk user gets a 64px dead strip at the bottom.
2. **Hide header for everyone on this dashboard** — extend `kiosk_mode` to drop `hide_header: true` for all users (sidebar stays for nav between dashboards). Both users see the dashboard fit exactly.
3. **Let it scroll** — accept that admin view requires a small scroll. Cheapest but contradicts the at-a-glance intent.

I'd lean (2) for the desktop kiosk use case — sidebar nav covers the use case the header was preserved for. Say which one you want and I'll PR it.

## Test plan

- [ ] `YAML Lint`, `check-config`, `claude-review` green
- [ ] After deploy, playwright screenshot shows alarm + meeting cells filled their full 300px height with the per-state background tint instead of transparent gaps below
- [ ] Sensors / lights / media columns unaffected (only the two top-row wrappers changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)