### PR TITLE
Kiosk visual consistency pass — sensor tints, camera, alarm escalation

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -209,6 +209,41 @@ template:
         state: >
           {{ is_state('switch.play_room_outlet', 'on') }}
 
+      # --- Aggregate openings (doors + garage covers) ---
+      # Used by the kiosk alarm hero to escalate visual state when the
+      # alarm is disarmed but a perimeter opening is detected.
+      - name: "House Openings"
+        unique_id: house_openings
+        state: >
+          {{ is_state('binary_sensor.main_panel_front_door', 'on')
+             or is_state('binary_sensor.main_panel_sliding_door', 'on')
+             or is_state('binary_sensor.main_panel_garage_door', 'on')
+             or is_state('binary_sensor.basement_kitchen_door', 'on')
+             or is_state('cover.garage_door_1_door', 'open')
+             or is_state('cover.garage_door_2_door', 'open') }}
+        attributes:
+          open_list: >
+            {% set names = namespace(open=[]) %}
+            {% if is_state('binary_sensor.main_panel_front_door', 'on') %}
+              {% set names.open = names.open + ['Front'] %}
+            {% endif %}
+            {% if is_state('binary_sensor.main_panel_sliding_door', 'on') %}
+              {% set names.open = names.open + ['Sliding'] %}
+            {% endif %}
+            {% if is_state('binary_sensor.main_panel_garage_door', 'on') %}
+              {% set names.open = names.open + ['Garage Entry'] %}
+            {% endif %}
+            {% if is_state('binary_sensor.basement_kitchen_door', 'on') %}
+              {% set names.open = names.open + ['Basement'] %}
+            {% endif %}
+            {% if is_state('cover.garage_door_1_door', 'open') %}
+              {% set names.open = names.open + ['Garage 1'] %}
+            {% endif %}
+            {% if is_state('cover.garage_door_2_door', 'open') %}
+              {% set names.open = names.open + ['Garage 2'] %}
+            {% endif %}
+            {{ names.open | join(', ') }}
+
   - light:
       - name: "Floor Lamp Composite"
         unique_id: floor_lamp_composite

--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -110,8 +110,41 @@ views:
           show_icon: true
           size: 55%
           layout: icon_name_state
+          # Re-render when openings change so the escalated state below
+          # picks up door/cover events even though the entity is the alarm.
+          triggers_update:
+            - binary_sensor.house_openings
+          # Override the alarm's raw state string with the open-list when
+          # the escalation fires; otherwise show the alarm state directly.
+          state_display: |
+            [[[
+              if (states['alarm_control_panel.home_alarm'].state === 'disarmed'
+                  && states['binary_sensor.house_openings'].state === 'on') {
+                const openList = states['binary_sensor.house_openings'].attributes.open_list || '';
+                return openList ? `OPEN: ${openList}` : 'OPEN';
+              }
+              return entity.state.toUpperCase();
+            ]]]
           tap_action: { action: more-info }
           state:
+            # Escalated: alarm is disarmed but a door/cover is open — amber warning.
+            # Must come before the plain `disarmed` block since first match wins.
+            - operator: template
+              value: |
+                [[[ return states['alarm_control_panel.home_alarm'].state === 'disarmed'
+                     && states['binary_sensor.house_openings'].state === 'on'; ]]]
+              icon: mdi:shield-alert
+              color: 'var(--kiosk-accent-armed)'
+              styles:
+                card:
+                  - background-color: 'rgba(227, 179, 65, 0.20)'
+                  - border-left: '4px solid var(--kiosk-accent-armed)'
+                state:
+                  - color: 'var(--kiosk-accent-armed)'
+                  - font-size: '22px'
+                  - letter-spacing: '1px'
+                  - line-height: '1.2'
+                  - white-space: 'normal'
             - value: disarmed
               icon: mdi:shield-check
               color: 'var(--kiosk-accent-disarmed)'
@@ -241,6 +274,9 @@ views:
               color: 'var(--kiosk-text-tertiary)'
               label: Offline
               styles:
+                card:
+                  - background-color: 'rgba(227, 179, 65, 0.10)'
+                  - border-left: '4px solid var(--kiosk-accent-armed)'
                 label: [{ color: 'var(--kiosk-text-tertiary)' }]
           styles:
             card:
@@ -538,8 +574,9 @@ views:
                         }
 
       # ============================================================
-      # SENSORS COLUMN — 8 sensors in 2x4 grid
-      # (4 doors + 2 garage covers + 2 motion)
+      # SENSORS COLUMN — front-door camera (top) + 8 sensors in 2x4 grid
+      # (4 doors + 2 garage covers + 2 motion). Camera fills a fixed
+      # 120px row at the top of the cell; the 2x4 grid takes the rest.
       # ============================================================
       - type: custom:mod-card
         view_layout: { grid-area: sensors }
@@ -552,383 +589,455 @@ views:
               border-top: 3px solid var(--kiosk-accent-sensors);
               padding: 8px;
               background: var(--kiosk-bg-card);
+              display: flex;
+              flex-direction: column;
+              gap: 6px;
+            }
+            /* Vertical-stack child: flex itself to fill ha-card column. */
+            ha-card hui-vertical-stack-card,
+            ha-card > * {
+              flex: 1 1 auto;
+              min-height: 0;
+              display: flex;
+              flex-direction: column;
+              gap: 6px;
+            }
+            /* Camera row: fixed 120px. Grid row: fills remainder. */
+            ha-card hui-vertical-stack-card > :first-child {
+              flex: 0 0 120px !important;
+              min-height: 120px;
+            }
+            ha-card hui-vertical-stack-card > :nth-child(2) {
+              flex: 1 1 auto !important;
             }
         card:
-          type: grid
-          columns: 2
-          square: false
-          card_mod:
-            style: |
-              :host {
-                height: 100%;
-                display: block;
-              }
-              #root {
-                height: 100%;
-                grid-template-rows: repeat(4, 1fr) !important;
-                gap: 6px !important;
-              }
-              /* Stretch each grid child so the inner button-card's
-                 height: 100% has a parent to fill against. Without
-                 this, hui-card collapses to its content height and
-                 leaves dead space below each row. */
-              #root > * {
-                height: 100% !important;
-                min-height: 0 !important;
-              }
+          type: vertical-stack
           cards:
+            # --- Front-door camera (Nest) ---
+            - type: custom:mod-card
+              card_mod:
+                style: |
+                  ha-card {
+                    height: 100%;
+                    border-radius: 8px;
+                    border: none;
+                    overflow: hidden;
+                    background: var(--kiosk-bg-tile);
+                  }
+                  /* Picture-entity fill: stretch the image to the tile. */
+                  ha-card hui-image, ha-card .image {
+                    height: 100% !important;
+                    width: 100% !important;
+                    object-fit: cover !important;
+                  }
+              card:
+                type: picture-entity
+                entity: camera.front_door
+                camera_view: auto
+                show_name: false
+                show_state: false
+                tap_action: { action: more-info }
+
+            # --- Existing 2x4 sensor grid ---
+            - type: grid
+              columns: 2
+              square: false
+              card_mod:
+                style: |
+                  :host {
+                    height: 100%;
+                    display: block;
+                  }
+                  #root {
+                    height: 100%;
+                    grid-template-rows: repeat(4, 1fr) !important;
+                    gap: 6px !important;
+                  }
+                  /* Stretch each grid child so the inner button-card's
+                     height: 100% has a parent to fill against. Without
+                     this, hui-card collapses to its content height and
+                     leaves dead space below each row. */
+                  #root > * {
+                    height: 100% !important;
+                    min-height: 0 !important;
+                  }
+              cards:
             # === Door sensors (binary_sensor; on=open=red, off=closed=green) ===
-            - type: custom:button-card
-              entity: binary_sensor.main_panel_front_door
-              name: Front
-              show_name: true
-              show_state: true
-              show_icon: true
-              size: 70%
-              tap_action: { action: more-info }
-              state:
-                - value: 'on'
-                  icon: mdi:door-open
-                  color: 'var(--kiosk-accent-triggered)'
+                - type: custom:button-card
+                  entity: binary_sensor.main_panel_front_door
+                  name: Front
+                  show_name: true
+                  show_state: true
+                  show_icon: true
+                  size: 70%
+                  tap_action: { action: more-info }
+                  state:
+                    - value: 'on'
+                      icon: mdi:door-open
+                      color: 'var(--kiosk-accent-triggered)'
+                      styles:
+                        card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
+                    - value: 'off'
+                      icon: mdi:door-closed
+                      color: 'var(--kiosk-accent-sensors)'
+                      styles:
+                        card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                    - value: 'unavailable'
+                      icon: mdi:door
+                      color: 'var(--kiosk-text-tertiary)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
+                    - value: 'unknown'
+                      icon: mdi:door
+                      color: 'var(--kiosk-text-tertiary)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
                   styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
-                - value: 'off'
-                  icon: mdi:door-closed
-                  color: 'var(--kiosk-accent-sensors)'
-                  styles:
-                    card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                - value: 'unavailable'
-                  icon: mdi:door
-                  color: 'var(--kiosk-text-tertiary)'
-                - value: 'unknown'
-                  icon: mdi:door
-                  color: 'var(--kiosk-text-tertiary)'
-              styles:
-                card:
-                  - height: '100%'
-                  - background: 'var(--kiosk-bg-tile)'
-                  - border-radius: '8px'
-                  - border: 'none'
-                  - padding: '12px'
-                name:
-                  - font-size: '18px'
-                  - font-weight: '500'
-                  - color: 'var(--kiosk-text-secondary)'
-                  - padding-top: '8px'
-                state:
-                  - font-size: '22px'
-                  - text-transform: 'uppercase'
-                  - font-weight: '600'
-                  - letter-spacing: '0.5px'
-                  - padding-top: '4px'
+                    card:
+                      - height: '100%'
+                      - background: 'var(--kiosk-bg-tile)'
+                      - border-radius: '8px'
+                      - border: 'none'
+                      - padding: '12px'
+                    name:
+                      - font-size: '18px'
+                      - font-weight: '500'
+                      - color: 'var(--kiosk-text-secondary)'
+                      - padding-top: '8px'
+                    state:
+                      - font-size: '22px'
+                      - text-transform: 'uppercase'
+                      - font-weight: '600'
+                      - letter-spacing: '0.5px'
+                      - padding-top: '4px'
 
-            - type: custom:button-card
-              entity: binary_sensor.main_panel_sliding_door
-              name: Sliding
-              show_name: true
-              show_state: true
-              show_icon: true
-              size: 70%
-              tap_action: { action: more-info }
-              state:
-                - value: 'on'
-                  icon: mdi:door-sliding-open
-                  color: 'var(--kiosk-accent-triggered)'
+                - type: custom:button-card
+                  entity: binary_sensor.main_panel_sliding_door
+                  name: Sliding
+                  show_name: true
+                  show_state: true
+                  show_icon: true
+                  size: 70%
+                  tap_action: { action: more-info }
+                  state:
+                    - value: 'on'
+                      icon: mdi:door-sliding-open
+                      color: 'var(--kiosk-accent-triggered)'
+                      styles:
+                        card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
+                    - value: 'off'
+                      icon: mdi:door-sliding
+                      color: 'var(--kiosk-accent-sensors)'
+                      styles:
+                        card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                    - value: 'unavailable'
+                      icon: mdi:door-sliding
+                      color: 'var(--kiosk-text-tertiary)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
+                    - value: 'unknown'
+                      icon: mdi:door-sliding
+                      color: 'var(--kiosk-text-tertiary)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
                   styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
-                - value: 'off'
-                  icon: mdi:door-sliding
-                  color: 'var(--kiosk-accent-sensors)'
-                  styles:
-                    card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                - value: 'unavailable'
-                  icon: mdi:door-sliding
-                  color: 'var(--kiosk-text-tertiary)'
-                - value: 'unknown'
-                  icon: mdi:door-sliding
-                  color: 'var(--kiosk-text-tertiary)'
-              styles:
-                card:
-                  - height: '100%'
-                  - background: 'var(--kiosk-bg-tile)'
-                  - border-radius: '8px'
-                  - border: 'none'
-                  - padding: '12px'
-                name:
-                  - font-size: '18px'
-                  - font-weight: '500'
-                  - color: 'var(--kiosk-text-secondary)'
-                  - padding-top: '8px'
-                state:
-                  - font-size: '22px'
-                  - text-transform: 'uppercase'
-                  - font-weight: '600'
-                  - letter-spacing: '0.5px'
-                  - padding-top: '4px'
+                    card:
+                      - height: '100%'
+                      - background: 'var(--kiosk-bg-tile)'
+                      - border-radius: '8px'
+                      - border: 'none'
+                      - padding: '12px'
+                    name:
+                      - font-size: '18px'
+                      - font-weight: '500'
+                      - color: 'var(--kiosk-text-secondary)'
+                      - padding-top: '8px'
+                    state:
+                      - font-size: '22px'
+                      - text-transform: 'uppercase'
+                      - font-weight: '600'
+                      - letter-spacing: '0.5px'
+                      - padding-top: '4px'
 
-            - type: custom:button-card
-              entity: binary_sensor.main_panel_garage_door
-              name: Garage Entry
-              show_name: true
-              show_state: true
-              show_icon: true
-              size: 70%
-              tap_action: { action: more-info }
-              state:
-                - value: 'on'
-                  icon: mdi:door-open
-                  color: 'var(--kiosk-accent-triggered)'
+                - type: custom:button-card
+                  entity: binary_sensor.main_panel_garage_door
+                  name: Garage Entry
+                  show_name: true
+                  show_state: true
+                  show_icon: true
+                  size: 70%
+                  tap_action: { action: more-info }
+                  state:
+                    - value: 'on'
+                      icon: mdi:door-open
+                      color: 'var(--kiosk-accent-triggered)'
+                      styles:
+                        card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
+                    - value: 'off'
+                      icon: mdi:door-closed
+                      color: 'var(--kiosk-accent-sensors)'
+                      styles:
+                        card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                    - value: 'unavailable'
+                      icon: mdi:door
+                      color: 'var(--kiosk-text-tertiary)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
+                    - value: 'unknown'
+                      icon: mdi:door
+                      color: 'var(--kiosk-text-tertiary)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
                   styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
-                - value: 'off'
-                  icon: mdi:door-closed
-                  color: 'var(--kiosk-accent-sensors)'
-                  styles:
-                    card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                - value: 'unavailable'
-                  icon: mdi:door
-                  color: 'var(--kiosk-text-tertiary)'
-                - value: 'unknown'
-                  icon: mdi:door
-                  color: 'var(--kiosk-text-tertiary)'
-              styles:
-                card:
-                  - height: '100%'
-                  - background: 'var(--kiosk-bg-tile)'
-                  - border-radius: '8px'
-                  - border: 'none'
-                  - padding: '12px'
-                name:
-                  - font-size: '18px'
-                  - font-weight: '500'
-                  - color: 'var(--kiosk-text-secondary)'
-                  - padding-top: '8px'
-                state:
-                  - font-size: '22px'
-                  - text-transform: 'uppercase'
-                  - font-weight: '600'
-                  - letter-spacing: '0.5px'
-                  - padding-top: '4px'
+                    card:
+                      - height: '100%'
+                      - background: 'var(--kiosk-bg-tile)'
+                      - border-radius: '8px'
+                      - border: 'none'
+                      - padding: '12px'
+                    name:
+                      - font-size: '18px'
+                      - font-weight: '500'
+                      - color: 'var(--kiosk-text-secondary)'
+                      - padding-top: '8px'
+                    state:
+                      - font-size: '22px'
+                      - text-transform: 'uppercase'
+                      - font-weight: '600'
+                      - letter-spacing: '0.5px'
+                      - padding-top: '4px'
 
-            - type: custom:button-card
-              entity: binary_sensor.basement_kitchen_door
-              name: Basement
-              show_name: true
-              show_state: true
-              show_icon: true
-              size: 70%
-              tap_action: { action: more-info }
-              state:
-                - value: 'on'
-                  icon: mdi:door-open
-                  color: 'var(--kiosk-accent-triggered)'
+                - type: custom:button-card
+                  entity: binary_sensor.basement_kitchen_door
+                  name: Basement
+                  show_name: true
+                  show_state: true
+                  show_icon: true
+                  size: 70%
+                  tap_action: { action: more-info }
+                  state:
+                    - value: 'on'
+                      icon: mdi:door-open
+                      color: 'var(--kiosk-accent-triggered)'
+                      styles:
+                        card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
+                    - value: 'off'
+                      icon: mdi:door-closed
+                      color: 'var(--kiosk-accent-sensors)'
+                      styles:
+                        card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                    - value: 'unavailable'
+                      icon: mdi:door
+                      color: 'var(--kiosk-text-tertiary)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
+                    - value: 'unknown'
+                      icon: mdi:door
+                      color: 'var(--kiosk-text-tertiary)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
                   styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
-                - value: 'off'
-                  icon: mdi:door-closed
-                  color: 'var(--kiosk-accent-sensors)'
-                  styles:
-                    card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                - value: 'unavailable'
-                  icon: mdi:door
-                  color: 'var(--kiosk-text-tertiary)'
-                - value: 'unknown'
-                  icon: mdi:door
-                  color: 'var(--kiosk-text-tertiary)'
-              styles:
-                card:
-                  - height: '100%'
-                  - background: 'var(--kiosk-bg-tile)'
-                  - border-radius: '8px'
-                  - border: 'none'
-                  - padding: '12px'
-                name:
-                  - font-size: '18px'
-                  - font-weight: '500'
-                  - color: 'var(--kiosk-text-secondary)'
-                  - padding-top: '8px'
-                state:
-                  - font-size: '22px'
-                  - text-transform: 'uppercase'
-                  - font-weight: '600'
-                  - letter-spacing: '0.5px'
-                  - padding-top: '4px'
+                    card:
+                      - height: '100%'
+                      - background: 'var(--kiosk-bg-tile)'
+                      - border-radius: '8px'
+                      - border: 'none'
+                      - padding: '12px'
+                    name:
+                      - font-size: '18px'
+                      - font-weight: '500'
+                      - color: 'var(--kiosk-text-secondary)'
+                      - padding-top: '8px'
+                    state:
+                      - font-size: '22px'
+                      - text-transform: 'uppercase'
+                      - font-weight: '600'
+                      - letter-spacing: '0.5px'
+                      - padding-top: '4px'
 
-            # === Garage door covers (state: closed/open) ===
-            - type: custom:button-card
-              entity: cover.garage_door_1_door
-              name: Garage 1
-              show_name: true
-              show_state: true
-              show_icon: true
-              size: 70%
-              tap_action: { action: more-info }
-              state:
-                - value: 'closed'
-                  icon: mdi:garage
-                  color: 'var(--kiosk-accent-sensors)'
+                # === Garage door covers (state: closed/open) ===
+                - type: custom:button-card
+                  entity: cover.garage_door_1_door
+                  name: Garage 1
+                  show_name: true
+                  show_state: true
+                  show_icon: true
+                  size: 70%
+                  tap_action: { action: more-info }
+                  state:
+                    - value: 'closed'
+                      icon: mdi:garage
+                      color: 'var(--kiosk-accent-sensors)'
+                      styles:
+                        card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                    - value: 'open'
+                      icon: mdi:garage-open-variant
+                      color: 'var(--kiosk-accent-triggered)'
+                      styles:
+                        card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
+                    - value: 'opening'
+                      icon: mdi:garage-alert-variant
+                      color: 'var(--kiosk-accent-lights)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
+                    - value: 'closing'
+                      icon: mdi:garage-alert-variant
+                      color: 'var(--kiosk-accent-lights)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
                   styles:
-                    card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                - value: 'open'
-                  icon: mdi:garage-open-variant
-                  color: 'var(--kiosk-accent-triggered)'
-                  styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
-                - value: 'opening'
-                  icon: mdi:garage-alert-variant
-                  color: 'var(--kiosk-accent-lights)'
-                  styles:
-                    card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
-                - value: 'closing'
-                  icon: mdi:garage-alert-variant
-                  color: 'var(--kiosk-accent-lights)'
-                  styles:
-                    card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
-              styles:
-                card:
-                  - height: '100%'
-                  - background: 'var(--kiosk-bg-tile)'
-                  - border-radius: '8px'
-                  - border: 'none'
-                  - padding: '12px'
-                name:
-                  - font-size: '18px'
-                  - font-weight: '500'
-                  - color: 'var(--kiosk-text-secondary)'
-                  - padding-top: '8px'
-                state:
-                  - font-size: '22px'
-                  - text-transform: 'uppercase'
-                  - font-weight: '600'
-                  - letter-spacing: '0.5px'
-                  - padding-top: '4px'
+                    card:
+                      - height: '100%'
+                      - background: 'var(--kiosk-bg-tile)'
+                      - border-radius: '8px'
+                      - border: 'none'
+                      - padding: '12px'
+                    name:
+                      - font-size: '18px'
+                      - font-weight: '500'
+                      - color: 'var(--kiosk-text-secondary)'
+                      - padding-top: '8px'
+                    state:
+                      - font-size: '22px'
+                      - text-transform: 'uppercase'
+                      - font-weight: '600'
+                      - letter-spacing: '0.5px'
+                      - padding-top: '4px'
 
-            - type: custom:button-card
-              entity: cover.garage_door_2_door
-              name: Garage 2
-              show_name: true
-              show_state: true
-              show_icon: true
-              size: 70%
-              tap_action: { action: more-info }
-              state:
-                - value: 'closed'
-                  icon: mdi:garage
-                  color: 'var(--kiosk-accent-sensors)'
+                - type: custom:button-card
+                  entity: cover.garage_door_2_door
+                  name: Garage 2
+                  show_name: true
+                  show_state: true
+                  show_icon: true
+                  size: 70%
+                  tap_action: { action: more-info }
+                  state:
+                    - value: 'closed'
+                      icon: mdi:garage
+                      color: 'var(--kiosk-accent-sensors)'
+                      styles:
+                        card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                    - value: 'open'
+                      icon: mdi:garage-open-variant
+                      color: 'var(--kiosk-accent-triggered)'
+                      styles:
+                        card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
+                    - value: 'opening'
+                      icon: mdi:garage-alert-variant
+                      color: 'var(--kiosk-accent-lights)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
+                    - value: 'closing'
+                      icon: mdi:garage-alert-variant
+                      color: 'var(--kiosk-accent-lights)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
                   styles:
-                    card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                - value: 'open'
-                  icon: mdi:garage-open-variant
-                  color: 'var(--kiosk-accent-triggered)'
-                  styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
-                - value: 'opening'
-                  icon: mdi:garage-alert-variant
-                  color: 'var(--kiosk-accent-lights)'
-                  styles:
-                    card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
-                - value: 'closing'
-                  icon: mdi:garage-alert-variant
-                  color: 'var(--kiosk-accent-lights)'
-                  styles:
-                    card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
-              styles:
-                card:
-                  - height: '100%'
-                  - background: 'var(--kiosk-bg-tile)'
-                  - border-radius: '8px'
-                  - border: 'none'
-                  - padding: '12px'
-                name:
-                  - font-size: '18px'
-                  - font-weight: '500'
-                  - color: 'var(--kiosk-text-secondary)'
-                  - padding-top: '8px'
-                state:
-                  - font-size: '22px'
-                  - text-transform: 'uppercase'
-                  - font-weight: '600'
-                  - letter-spacing: '0.5px'
-                  - padding-top: '4px'
+                    card:
+                      - height: '100%'
+                      - background: 'var(--kiosk-bg-tile)'
+                      - border-radius: '8px'
+                      - border: 'none'
+                      - padding: '12px'
+                    name:
+                      - font-size: '18px'
+                      - font-weight: '500'
+                      - color: 'var(--kiosk-text-secondary)'
+                      - padding-top: '8px'
+                    state:
+                      - font-size: '22px'
+                      - text-transform: 'uppercase'
+                      - font-weight: '600'
+                      - letter-spacing: '0.5px'
+                      - padding-top: '4px'
 
-            # === Motion sensors (binary_sensor; on=detected=red pulse, off=clear=gray) ===
-            - type: custom:button-card
-              entity: binary_sensor.main_panel_family_room_motion
-              name: Family
-              show_name: true
-              show_state: true
-              show_icon: true
-              size: 70%
-              tap_action: { action: more-info }
-              state:
-                - value: 'on'
-                  icon: mdi:motion-sensor
-                  color: 'var(--kiosk-accent-triggered)'
+                # === Motion sensors (binary_sensor; on=detected=red pulse, off=clear=green tint) ===
+                - type: custom:button-card
+                  entity: binary_sensor.main_panel_family_room_motion
+                  name: Family
+                  show_name: true
+                  show_state: true
+                  show_icon: true
+                  size: 70%
+                  tap_action: { action: more-info }
+                  state:
+                    - value: 'on'
+                      icon: mdi:motion-sensor
+                      color: 'var(--kiosk-accent-triggered)'
+                      styles:
+                        card: [{ background-color: 'rgba(248, 81, 73, 0.20)' }, { animation: 'pulse 1s infinite' }]
+                    - value: 'off'
+                      icon: mdi:motion-sensor-off
+                      color: 'var(--kiosk-accent-sensors)'
+                      styles:
+                        card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                    - value: 'unavailable'
+                      icon: mdi:motion-sensor-off
+                      color: 'var(--kiosk-text-tertiary)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
                   styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.20)' }, { animation: 'pulse 1s infinite' }]
-                - value: 'off'
-                  icon: mdi:motion-sensor-off
-                  color: 'var(--kiosk-text-tertiary)'
-                - value: 'unavailable'
-                  icon: mdi:motion-sensor-off
-                  color: 'var(--kiosk-text-tertiary)'
-              styles:
-                card:
-                  - height: '100%'
-                  - background: 'var(--kiosk-bg-tile)'
-                  - border-radius: '8px'
-                  - border: 'none'
-                  - padding: '12px'
-                name:
-                  - font-size: '18px'
-                  - font-weight: '500'
-                  - color: 'var(--kiosk-text-secondary)'
-                  - padding-top: '8px'
-                state:
-                  - font-size: '22px'
-                  - text-transform: 'uppercase'
-                  - font-weight: '600'
-                  - letter-spacing: '0.5px'
-                  - padding-top: '4px'
+                    card:
+                      - height: '100%'
+                      - background: 'var(--kiosk-bg-tile)'
+                      - border-radius: '8px'
+                      - border: 'none'
+                      - padding: '12px'
+                    name:
+                      - font-size: '18px'
+                      - font-weight: '500'
+                      - color: 'var(--kiosk-text-secondary)'
+                      - padding-top: '8px'
+                    state:
+                      - font-size: '22px'
+                      - text-transform: 'uppercase'
+                      - font-weight: '600'
+                      - letter-spacing: '0.5px'
+                      - padding-top: '4px'
 
-            - type: custom:button-card
-              entity: binary_sensor.main_panel_office_motion
-              name: Office
-              show_name: true
-              show_state: true
-              show_icon: true
-              size: 70%
-              tap_action: { action: more-info }
-              state:
-                - value: 'on'
-                  icon: mdi:motion-sensor
-                  color: 'var(--kiosk-accent-triggered)'
+                - type: custom:button-card
+                  entity: binary_sensor.main_panel_office_motion
+                  name: Office
+                  show_name: true
+                  show_state: true
+                  show_icon: true
+                  size: 70%
+                  tap_action: { action: more-info }
+                  state:
+                    - value: 'on'
+                      icon: mdi:motion-sensor
+                      color: 'var(--kiosk-accent-triggered)'
+                      styles:
+                        card: [{ background-color: 'rgba(248, 81, 73, 0.20)' }, { animation: 'pulse 1s infinite' }]
+                    - value: 'off'
+                      icon: mdi:motion-sensor-off
+                      color: 'var(--kiosk-accent-sensors)'
+                      styles:
+                        card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                    - value: 'unavailable'
+                      icon: mdi:motion-sensor-off
+                      color: 'var(--kiosk-text-tertiary)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
                   styles:
-                    card: [{ background-color: 'rgba(248, 81, 73, 0.20)' }, { animation: 'pulse 1s infinite' }]
-                - value: 'off'
-                  icon: mdi:motion-sensor-off
-                  color: 'var(--kiosk-text-tertiary)'
-                - value: 'unavailable'
-                  icon: mdi:motion-sensor-off
-                  color: 'var(--kiosk-text-tertiary)'
-              styles:
-                card:
-                  - height: '100%'
-                  - background: 'var(--kiosk-bg-tile)'
-                  - border-radius: '8px'
-                  - border: 'none'
-                  - padding: '12px'
-                name:
-                  - font-size: '18px'
-                  - font-weight: '500'
-                  - color: 'var(--kiosk-text-secondary)'
-                  - padding-top: '8px'
-                state:
-                  - font-size: '22px'
-                  - text-transform: 'uppercase'
-                  - font-weight: '600'
-                  - letter-spacing: '0.5px'
-                  - padding-top: '4px'
+                    card:
+                      - height: '100%'
+                      - background: 'var(--kiosk-bg-tile)'
+                      - border-radius: '8px'
+                      - border: 'none'
+                      - padding: '12px'
+                    name:
+                      - font-size: '18px'
+                      - font-weight: '500'
+                      - color: 'var(--kiosk-text-secondary)'
+                      - padding-top: '8px'
+                    state:
+                      - font-size: '22px'
+                      - text-transform: 'uppercase'
+                      - font-weight: '600'
+                      - letter-spacing: '0.5px'
+                      - padding-top: '4px'
 
       # ============================================================
       # LIGHTS COLUMN — 18 lights, grouped into 5 room sections.
@@ -1359,6 +1468,8 @@ views:
                     - value: 'unavailable'
                       icon: mdi:television-off
                       color: 'var(--kiosk-text-tertiary)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
                     - operator: default
                       icon: mdi:television
                       color: 'var(--kiosk-accent-media)'
@@ -1386,6 +1497,8 @@ views:
                     - value: 'unavailable'
                       icon: mdi:television-off
                       color: 'var(--kiosk-text-tertiary)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
                     - operator: default
                       icon: mdi:television
                       color: 'var(--kiosk-accent-media)'
@@ -1413,6 +1526,8 @@ views:
                     - value: 'unavailable'
                       icon: mdi:television-off
                       color: 'var(--kiosk-text-tertiary)'
+                      styles:
+                        card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
                     - operator: default
                       icon: mdi:television
                       color: 'var(--kiosk-accent-media)'


### PR DESCRIPTION
Three batches in one PR fixing the kiosk dashboard's at-a-glance weaknesses identified during a webcam-driven critique session.

## Origin

Chris asked Home Claude to point a webcam at the kiosk monitor, critique the dashboard for consistency, attractiveness, and usability, then sketch and implement fixes. The critique identified visual inconsistencies in how the sensors column treated "all clear" vs "warning" states, a missing camera surface despite a front-door Nest cam being available, and no escalated visual when the alarm is disarmed but a perimeter opening is detected. Chris picked option (b) — all three batches in one PR. Iteration was driven via a webcam pointed at the kiosk monitor since Playwright crashed on launch under the alacritty snap.

## Changes

### `configuration.yaml`
- New template `binary_sensor.house_openings` — true when any of the four contact sensors (front/sliding/garage entry/basement kitchen) or two garage covers is open. Carries an `open_list` attribute with comma-separated names of currently-open openings, used by the alarm hero's `state_display`.

### `dashboards/kiosk.yaml`

**Alarm hero escalation (Batch 3)**
- New first-match state block fires when `alarm == disarmed` AND `binary_sensor.house_openings == on`: amber tint, `mdi:shield-alert` icon, smaller multi-line font sized to fit the openings list.
- `state_display` template overrides the alarm state string with `"OPEN: FRONT, GARAGE 1"` when escalated, otherwise renders the alarm state uppercase.
- `triggers_update: [binary_sensor.house_openings]` so the card re-renders on opening events.

**Front-door camera tile (Batch 2)**
- `picture-entity` of `camera.front_door` (Nest) at the top of the sensors column, fixed 120px height via flex layout on the outer mod-card.
- Existing 2×4 sensor grid wrapped in a vertical-stack and reindented to nest under the new grid card.

**Visual consistency (Batch 1 + 1b)**
- Motion `off` (CLEAR) tiles get green tint + green icon — match doors' CLOSED treatment instead of being visual holes in the 2×4 grid.
- Motion `unavailable` tiles get amber tint — match doors' unavailable.
- Door `unavailable`/`unknown` tiles (×4 doors × 2 states) get amber tint instead of bare dim text.
- TV `unavailable` tiles (×3) get amber tint.
- Meeting card `unavailable` gets amber tint + amber `border-left` matching the alarm hero's arming color language.

## Validation

- Jinja for `binary_sensor.house_openings` validated against live HA via `ha_eval_template` — state and `open_list` both compute correctly against current entity values.
- Both YAML files parse cleanly under Python's safe loader (with HA include-tag stubs).
- Visual validation TBD after deploy via webcam-pointed-at-kiosk.

## Known risks

- The camera-tile flex layout targets `hui-vertical-stack-card > :first-child` via card_mod; if HA's actual DOM doesn't match that selector the camera may render at default `picture-entity` size and compress the 2×4 grid below. Reversible.
- The alarm hero `state_display` is a JS template — a syntax error would render `undefined` instead of the alarm state. Worth eyeballing post-deploy.