### PR TITLE
Fix kiosk basement door tile pointing at unavailable Zigbee sensor

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -1003,7 +1003,7 @@ views:
                       - padding-top: '4px'
 
                 - type: custom:button-card
-                  entity: binary_sensor.basement_kitchen_door
+                  entity: binary_sensor.main_panel_basement_door
                   name: Basement
                   show_name: true
                   show_state: true


### PR DESCRIPTION
## Summary

Swap the kiosk "Basement" door tile from `binary_sensor.basement_kitchen_door` (Zigbee/Aqara, currently unavailable) to `binary_sensor.main_panel_basement_door` — the Konnected zone for the basement door, which is operational and reports `off` (closed).

## Origin

> basement entry sensor (through Konnected) is operational, but the cards show unavailable. Troubleshoot and fix.

## Diagnosis

`ha_search_entities` for "basement" returned two distinct door sensors:

| Entity | State | Integration |
|---|---|---|
| `binary_sensor.main_panel_basement_door` | `off` | Konnected (Main Panel) |
| `binary_sensor.basement_kitchen_door` | `unavailable` | Zigbee (Aqara contact) |

The Konnected sensor is the one the user reports as operational; the Zigbee one is a separate adopted device that's offline. Three of the four entry tiles on the kiosk (`Front`, `Sliding`, `Garage Entry`) already use the `main_panel_*` Konnected entities, and the Home + Command Deck dashboards both reference `main_panel_basement_door`. Only the kiosk's `Basement` tile was wired to the wrong (Zigbee) sensor — likely a leftover from an earlier mapping.

## Change

`dashboards/kiosk.yaml:1006` — one-line entity swap. Card name, icon set, and state-driven color logic are unchanged.

## Test plan

- [ ] After gitops-sync deploys, the kiosk "Basement" tile shows green (door closed) instead of amber (unavailable).
- [ ] Open/close the basement door and confirm the tile transitions to the red "door-open" state.
- [ ] No regression on the other entry tiles (Front / Sliding / Garage Entry) or on Home / Command Deck dashboards.