### PR TITLE
Kiosk: restore forecast strip + fix alarm hero height collapse

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -149,7 +149,19 @@ views:
                       {{ fc.temperature | round }}° / {{ fc.templow | round }}°
                     icon: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[0] %}
-                      {% set m = {'clear-night':'mdi:weather-night','sunny':'mdi:weather-sunny','cloudy':'mdi:weather-cloudy','partlycloudy':'mdi:weather-partly-cloudy','rainy':'mdi:weather-rainy','pouring':'mdi:weather-pouring','snowy':'mdi:weather-snowy','snowy-rainy':'mdi:weather-snowy-rainy','windy':'mdi:weather-windy','fog':'mdi:weather-fog','lightning':'mdi:weather-lightning','lightning-rainy':'mdi:weather-lightning-rainy','hail':'mdi:weather-hail'} %}
+                      {% set m = {'clear-night':'mdi:weather-night',
+                                  'sunny':'mdi:weather-sunny',
+                                  'cloudy':'mdi:weather-cloudy',
+                                  'partlycloudy':'mdi:weather-partly-cloudy',
+                                  'rainy':'mdi:weather-rainy',
+                                  'pouring':'mdi:weather-pouring',
+                                  'snowy':'mdi:weather-snowy',
+                                  'snowy-rainy':'mdi:weather-snowy-rainy',
+                                  'windy':'mdi:weather-windy',
+                                  'fog':'mdi:weather-fog',
+                                  'lightning':'mdi:weather-lightning',
+                                  'lightning-rainy':'mdi:weather-lightning-rainy',
+                                  'hail':'mdi:weather-hail'} %}
                       {{ m.get(fc.condition, 'mdi:weather-cloudy') }}
                     icon_color: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[0] %}
@@ -192,7 +204,19 @@ views:
                       {{ fc.temperature | round }}° / {{ fc.templow | round }}°
                     icon: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[1] %}
-                      {% set m = {'clear-night':'mdi:weather-night','sunny':'mdi:weather-sunny','cloudy':'mdi:weather-cloudy','partlycloudy':'mdi:weather-partly-cloudy','rainy':'mdi:weather-rainy','pouring':'mdi:weather-pouring','snowy':'mdi:weather-snowy','snowy-rainy':'mdi:weather-snowy-rainy','windy':'mdi:weather-windy','fog':'mdi:weather-fog','lightning':'mdi:weather-lightning','lightning-rainy':'mdi:weather-lightning-rainy','hail':'mdi:weather-hail'} %}
+                      {% set m = {'clear-night':'mdi:weather-night',
+                                  'sunny':'mdi:weather-sunny',
+                                  'cloudy':'mdi:weather-cloudy',
+                                  'partlycloudy':'mdi:weather-partly-cloudy',
+                                  'rainy':'mdi:weather-rainy',
+                                  'pouring':'mdi:weather-pouring',
+                                  'snowy':'mdi:weather-snowy',
+                                  'snowy-rainy':'mdi:weather-snowy-rainy',
+                                  'windy':'mdi:weather-windy',
+                                  'fog':'mdi:weather-fog',
+                                  'lightning':'mdi:weather-lightning',
+                                  'lightning-rainy':'mdi:weather-lightning-rainy',
+                                  'hail':'mdi:weather-hail'} %}
                       {{ m.get(fc.condition, 'mdi:weather-cloudy') }}
                     icon_color: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[1] %}
@@ -211,7 +235,19 @@ views:
                       {{ fc.temperature | round }}° / {{ fc.templow | round }}°
                     icon: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[2] %}
-                      {% set m = {'clear-night':'mdi:weather-night','sunny':'mdi:weather-sunny','cloudy':'mdi:weather-cloudy','partlycloudy':'mdi:weather-partly-cloudy','rainy':'mdi:weather-rainy','pouring':'mdi:weather-pouring','snowy':'mdi:weather-snowy','snowy-rainy':'mdi:weather-snowy-rainy','windy':'mdi:weather-windy','fog':'mdi:weather-fog','lightning':'mdi:weather-lightning','lightning-rainy':'mdi:weather-lightning-rainy','hail':'mdi:weather-hail'} %}
+                      {% set m = {'clear-night':'mdi:weather-night',
+                                  'sunny':'mdi:weather-sunny',
+                                  'cloudy':'mdi:weather-cloudy',
+                                  'partlycloudy':'mdi:weather-partly-cloudy',
+                                  'rainy':'mdi:weather-rainy',
+                                  'pouring':'mdi:weather-pouring',
+                                  'snowy':'mdi:weather-snowy',
+                                  'snowy-rainy':'mdi:weather-snowy-rainy',
+                                  'windy':'mdi:weather-windy',
+                                  'fog':'mdi:weather-fog',
+                                  'lightning':'mdi:weather-lightning',
+                                  'lightning-rainy':'mdi:weather-lightning-rainy',
+                                  'hail':'mdi:weather-hail'} %}
                       {{ m.get(fc.condition, 'mdi:weather-cloudy') }}
                     icon_color: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[2] %}
@@ -230,7 +266,19 @@ views:
                       {{ fc.temperature | round }}° / {{ fc.templow | round }}°
                     icon: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[3] %}
-                      {% set m = {'clear-night':'mdi:weather-night','sunny':'mdi:weather-sunny','cloudy':'mdi:weather-cloudy','partlycloudy':'mdi:weather-partly-cloudy','rainy':'mdi:weather-rainy','pouring':'mdi:weather-pouring','snowy':'mdi:weather-snowy','snowy-rainy':'mdi:weather-snowy-rainy','windy':'mdi:weather-windy','fog':'mdi:weather-fog','lightning':'mdi:weather-lightning','lightning-rainy':'mdi:weather-lightning-rainy','hail':'mdi:weather-hail'} %}
+                      {% set m = {'clear-night':'mdi:weather-night',
+                                  'sunny':'mdi:weather-sunny',
+                                  'cloudy':'mdi:weather-cloudy',
+                                  'partlycloudy':'mdi:weather-partly-cloudy',
+                                  'rainy':'mdi:weather-rainy',
+                                  'pouring':'mdi:weather-pouring',
+                                  'snowy':'mdi:weather-snowy',
+                                  'snowy-rainy':'mdi:weather-snowy-rainy',
+                                  'windy':'mdi:weather-windy',
+                                  'fog':'mdi:weather-fog',
+                                  'lightning':'mdi:weather-lightning',
+                                  'lightning-rainy':'mdi:weather-lightning-rainy',
+                                  'hail':'mdi:weather-hail'} %}
                       {{ m.get(fc.condition, 'mdi:weather-cloudy') }}
                     icon_color: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[3] %}

--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -72,21 +72,174 @@ views:
               border-radius: 10px;
               border: none;
               background: linear-gradient(135deg, #1e3a5f 0%, #0f1f3a 100%);
+              display: flex;
+              flex-direction: column;
+              gap: 4px;
+              padding: 6px;
+            }
+            ha-card hui-vertical-stack-card,
+            ha-card > * {
+              flex: 1 1 auto;
+              min-height: 0;
+              display: flex;
+              flex-direction: column;
+              gap: 4px;
+            }
+            /* Clock card grows; forecast strip fixed 100px at bottom. */
+            ha-card hui-vertical-stack-card > :first-child {
+              flex: 1 1 auto;
+              min-height: 0;
+            }
+            ha-card hui-vertical-stack-card > :last-child {
+              flex: 0 0 100px;
             }
         card:
-          type: custom:clock-weather-card
-          entity: weather.forecast_home
-          forecast_rows: 3
-          time_format: 12
-          date_pattern: "EEEE, MMM d"
-          card_mod:
-            style: |
-              ha-card {
-                background: transparent !important;
-                border: none !important;
-                box-shadow: none !important;
-                height: 100%;
-              }
+          type: vertical-stack
+          cards:
+            # --- Clock + current conditions (forecast disabled; strip below handles it) ---
+            - type: custom:mod-card
+              card_mod:
+                style: |
+                  ha-card {
+                    height: 100%;
+                    background: transparent !important;
+                    border: none !important;
+                    box-shadow: none !important;
+                  }
+              card:
+                type: custom:clock-weather-card
+                entity: weather.forecast_home
+                forecast_rows: 0
+                time_format: 12
+                date_pattern: "EEEE, MMM d"
+                card_mod:
+                  style: |
+                    ha-card {
+                      background: transparent !important;
+                      border: none !important;
+                      box-shadow: none !important;
+                      height: 100%;
+                    }
+
+            # --- 4-day forecast strip from sensor.weather_forecast_daily ---
+            # weather.forecast_home no longer exposes a static `forecast`
+            # attribute (HA deprecated it); the trigger-based template
+            # sensor.weather_forecast_daily in configuration.yaml is the
+            # supported path now.
+            - type: custom:mod-card
+              card_mod:
+                style: |
+                  ha-card {
+                    height: 100%;
+                    background: rgba(0,0,0,0.18);
+                    border: none;
+                    border-radius: 8px;
+                    padding: 4px;
+                  }
+              card:
+                type: horizontal-stack
+                cards:
+                  - &forecast_day
+                    type: custom:mushroom-template-card
+                    primary: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[0] %}
+                      {{ (fc.datetime | as_datetime | as_local).strftime('%a') }}
+                    secondary: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[0] %}
+                      {{ fc.temperature | round }}° / {{ fc.templow | round }}°
+                    icon: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[0] %}
+                      {% set m = {'clear-night':'mdi:weather-night','sunny':'mdi:weather-sunny','cloudy':'mdi:weather-cloudy','partlycloudy':'mdi:weather-partly-cloudy','rainy':'mdi:weather-rainy','pouring':'mdi:weather-pouring','snowy':'mdi:weather-snowy','snowy-rainy':'mdi:weather-snowy-rainy','windy':'mdi:weather-windy','fog':'mdi:weather-fog','lightning':'mdi:weather-lightning','lightning-rainy':'mdi:weather-lightning-rainy','hail':'mdi:weather-hail'} %}
+                      {{ m.get(fc.condition, 'mdi:weather-cloudy') }}
+                    icon_color: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[0] %}
+                      {% set c = fc.condition %}
+                      {% if c in ['sunny','clear-night'] %}amber
+                      {% elif c in ['rainy','pouring','snowy-rainy'] %}blue
+                      {% elif c == 'snowy' %}light-blue
+                      {% else %}grey
+                      {% endif %}
+                    fill_container: true
+                    tap_action: { action: none }
+                    card_mod:
+                      style: |
+                        ha-card {
+                          background: rgba(255,255,255,0.04) !important;
+                          border: none !important;
+                          box-shadow: none !important;
+                          border-radius: 6px !important;
+                          padding: 4px 2px !important;
+                          height: 100%;
+                        }
+                        mushroom-state-info {
+                          --card-primary-font-size: 13px;
+                          --card-primary-font-weight: 600;
+                          --card-primary-color: var(--kiosk-text-primary);
+                          --card-primary-text-transform: uppercase;
+                          --card-secondary-font-size: 12px;
+                          --card-secondary-color: var(--kiosk-text-secondary);
+                        }
+                        mushroom-shape-icon {
+                          --icon-size: 28px;
+                          --shape-color: transparent;
+                        }
+                  - <<: *forecast_day
+                    primary: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[1] %}
+                      {{ (fc.datetime | as_datetime | as_local).strftime('%a') }}
+                    secondary: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[1] %}
+                      {{ fc.temperature | round }}° / {{ fc.templow | round }}°
+                    icon: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[1] %}
+                      {% set m = {'clear-night':'mdi:weather-night','sunny':'mdi:weather-sunny','cloudy':'mdi:weather-cloudy','partlycloudy':'mdi:weather-partly-cloudy','rainy':'mdi:weather-rainy','pouring':'mdi:weather-pouring','snowy':'mdi:weather-snowy','snowy-rainy':'mdi:weather-snowy-rainy','windy':'mdi:weather-windy','fog':'mdi:weather-fog','lightning':'mdi:weather-lightning','lightning-rainy':'mdi:weather-lightning-rainy','hail':'mdi:weather-hail'} %}
+                      {{ m.get(fc.condition, 'mdi:weather-cloudy') }}
+                    icon_color: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[1] %}
+                      {% set c = fc.condition %}
+                      {% if c in ['sunny','clear-night'] %}amber
+                      {% elif c in ['rainy','pouring','snowy-rainy'] %}blue
+                      {% elif c == 'snowy' %}light-blue
+                      {% else %}grey
+                      {% endif %}
+                  - <<: *forecast_day
+                    primary: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[2] %}
+                      {{ (fc.datetime | as_datetime | as_local).strftime('%a') }}
+                    secondary: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[2] %}
+                      {{ fc.temperature | round }}° / {{ fc.templow | round }}°
+                    icon: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[2] %}
+                      {% set m = {'clear-night':'mdi:weather-night','sunny':'mdi:weather-sunny','cloudy':'mdi:weather-cloudy','partlycloudy':'mdi:weather-partly-cloudy','rainy':'mdi:weather-rainy','pouring':'mdi:weather-pouring','snowy':'mdi:weather-snowy','snowy-rainy':'mdi:weather-snowy-rainy','windy':'mdi:weather-windy','fog':'mdi:weather-fog','lightning':'mdi:weather-lightning','lightning-rainy':'mdi:weather-lightning-rainy','hail':'mdi:weather-hail'} %}
+                      {{ m.get(fc.condition, 'mdi:weather-cloudy') }}
+                    icon_color: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[2] %}
+                      {% set c = fc.condition %}
+                      {% if c in ['sunny','clear-night'] %}amber
+                      {% elif c in ['rainy','pouring','snowy-rainy'] %}blue
+                      {% elif c == 'snowy' %}light-blue
+                      {% else %}grey
+                      {% endif %}
+                  - <<: *forecast_day
+                    primary: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[3] %}
+                      {{ (fc.datetime | as_datetime | as_local).strftime('%a') }}
+                    secondary: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[3] %}
+                      {{ fc.temperature | round }}° / {{ fc.templow | round }}°
+                    icon: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[3] %}
+                      {% set m = {'clear-night':'mdi:weather-night','sunny':'mdi:weather-sunny','cloudy':'mdi:weather-cloudy','partlycloudy':'mdi:weather-partly-cloudy','rainy':'mdi:weather-rainy','pouring':'mdi:weather-pouring','snowy':'mdi:weather-snowy','snowy-rainy':'mdi:weather-snowy-rainy','windy':'mdi:weather-windy','fog':'mdi:weather-fog','lightning':'mdi:weather-lightning','lightning-rainy':'mdi:weather-lightning-rainy','hail':'mdi:weather-hail'} %}
+                      {{ m.get(fc.condition, 'mdi:weather-cloudy') }}
+                    icon_color: |-
+                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[3] %}
+                      {% set c = fc.condition %}
+                      {% if c in ['sunny','clear-night'] %}amber
+                      {% elif c in ['rainy','pouring','snowy-rainy'] %}blue
+                      {% elif c == 'snowy' %}light-blue
+                      {% else %}grey
+                      {% endif %}
 
       # ============================================================
       # ALARM CELL — hero + arm/disarm action row
@@ -124,9 +277,18 @@ views:
             ha-card hui-vertical-stack-card > :last-child {
               flex: 0 0 90px;
             }
-            /* Cascade height into the button-card so the green-tinted
-               state background fills the full 300px row instead of
-               collapsing to content height and leaking page bg below. */
+            /* Cascade height into each vstack child's content card so the
+               green-tinted state background fills the entire flex slot
+               instead of collapsing to the button-card's natural content
+               height. Target both the immediate vstack-child wrapper and
+               any inner ha-card or hui-card. */
+            ha-card hui-vertical-stack-card > :first-child > *,
+            ha-card hui-vertical-stack-card > :last-child > *,
+            ha-card hui-vertical-stack-card > :first-child ha-card,
+            ha-card hui-vertical-stack-card > :last-child ha-card {
+              height: 100% !important;
+              min-height: 0 !important;
+            }
             ha-card > * {
               flex: 1 1 auto;
               min-height: 0;


### PR DESCRIPTION
Two top-row improvements caught in the post-#290 native-resolution review.

## Origin

Continuation of the kiosk visual iteration. After PR #290 shipped the arm/disarm action buttons and meeting-cell time-since/chips, Chris pointed out two remaining issues that were visible at native 2560×1440 (via the new scrot-on-pve2 workflow):

1. The 3-day forecast strip the clock-weather-card was supposed to render — never appears. The weather cell shows clock + date + giant moon icon and a big empty gradient below it.
2. The alarm hero is collapsing to content height inside its vertical-stack, leaving a ~150px dark band between the green "DISARMED" strip and the arm/disarm action buttons.

## Changes

### Forecast strip — `dashboards/kiosk.yaml` weather cell

Root cause: `weather.forecast_home` no longer exposes a static `forecast` attribute (HA deprecated it in favor of the `weather.get_forecasts` service). The clock-weather-card looks for `attributes.forecast` and finds nothing.

Fix: the weather cell now wraps the existing clock-weather-card (`forecast_rows: 0`) in a vertical-stack with a 4-day forecast strip below it. The strip is a `horizontal-stack` of four `mushroom-template-card`s reading from `sensor.weather_forecast_daily.attributes.forecast` — that's the trigger-based template sensor already defined in `configuration.yaml` that calls `weather.get_forecasts` every 30 min.

Each forecast day shows:
- Day-of-week (`Sat`, `Sun`, etc.)
- High / low temperatures
- A condition icon (mapped from `clear-night` / `rainy` / `sunny` / etc. to mdi:weather-*)

### Alarm hero height collapse — `dashboards/kiosk.yaml` alarm cell

Root cause: the button-card hero inside the vstack received `flex: 1 1 auto` on its wrapper, but the button-card *itself* didn't expand to fill — so its `styles.card.background-color` only tinted the content area, not the full flex slot.

Fix: a more specific card_mod cascade — `ha-card hui-vertical-stack-card > :first-child > *` and `… ha-card` get `height: 100% !important`. Forces the button-card's host to fill its allocated space so the green DISARMED tint covers the full ~200px hero slot. The same selectors apply to the action row so the horizontal-stack also fills its 90px allocation.

## Validation

- All forecast Jinja templates validated against live HA via `ha_eval_template`. Note: `| strftime('%a')` is NOT a valid HA Jinja filter — must use `.strftime('%a')` as a method call on the `as_datetime`-converted value. All 4 forecast cards use the method-call form.
- YAML parses clean.
- Visual validation TBD via scrot post-deploy.

## Known risks

- The forecast strip reads `state_attr(...).forecast[N]` — if `sensor.weather_forecast_daily` has fewer than 4 entries (rare), one or more cards would render with template errors. Today the sensor returns 6 days.
- The `height: 100% !important` cascade is a broad hammer; if a future child in the vstack should NOT fill (e.g. a centered button), it'll still stretch. Acceptable for the current cell contents.

Builds on #290.