### PR TITLE
Kiosk alarm hero: force button-card to fill its 200px mod-card slot

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -349,6 +349,13 @@ views:
                   border: none !important;
                   box-shadow: none !important;
                 }
+                /* Force the button-card host element to fill the
+                   200px slot — the inner styles.card.height: 100%
+                   only resolves if this host is also 100%. */
+                ha-card > * {
+                  height: 100% !important;
+                  display: block !important;
+                }
             card:
               type: custom:button-card
               entity: alarm_control_panel.home_alarm


### PR DESCRIPTION
Continuing visual iteration after #295.

## Origin
The hero mod-card is correctly 200px tall (visible in scrot), but the inner button-card collapsed within that slot — the green DISARMED tint only covered the top ~70px. The button-card's `styles.card.height: 100%` needs the host element to also be 100%; without that, 100% of nothing is nothing.

## Change
Adds `ha-card > * { height: 100% !important; display: block }` to the hero mod-card's card_mod. The `> *` matches the button-card host directly under mod-card's ha-card.

## Validation
- YAML parses
- Visual TBD via scrot

Follow-up to #295.