### PR TITLE
Kiosk weather: apply explicit-height mod-card pattern to clock + forecast

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -105,10 +105,14 @@ views:
               card_mod:
                 style: |
                   ha-card {
-                    height: 100%;
+                    height: 190px !important;
                     background: transparent !important;
                     border: none !important;
                     box-shadow: none !important;
+                  }
+                  ha-card > * {
+                    height: 100% !important;
+                    display: block !important;
                   }
               card:
                 type: custom:clock-weather-card
@@ -134,11 +138,15 @@ views:
               card_mod:
                 style: |
                   ha-card {
-                    height: 100%;
+                    height: 95px !important;
                     background: rgba(0,0,0,0.18);
                     border: none;
                     border-radius: 8px;
                     padding: 4px;
+                  }
+                  ha-card > * {
+                    height: 100% !important;
+                    display: block !important;
                   }
               card:
                 type: horizontal-stack


### PR DESCRIPTION
Same fix that resolved the alarm hero (#296) applied to the weather cell.

## Origin
Forecast strip was being squeezed to ~30px while clock-weather-card oversized to ~270px in the 300px cell. The vstack `flex: 0 0 NNpx` slots weren't being applied to the inner mod-cards.

## Change
- Clock mod-card: `height: 190px !important` (was `height: 100%`)
- Forecast mod-card: `height: 95px !important` (was `height: 100%`)
- Both add `ha-card > * { height: 100% !important; display: block }` so the inner card fills the mod-card slot.

## Validation
- YAML parses
- Visual TBD via scrot

Follow-up to #296.