### PR TITLE
Kiosk weather: overflow hidden to stop clock bleed into forecast strip

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -106,12 +106,16 @@ views:
                 style: |
                   ha-card {
                     height: 190px !important;
+                    max-height: 190px !important;
+                    overflow: hidden !important;
                     background: transparent !important;
                     border: none !important;
                     box-shadow: none !important;
                   }
                   ha-card > * {
                     height: 100% !important;
+                    max-height: 190px !important;
+                    overflow: hidden !important;
                     display: block !important;
                   }
               card:


### PR DESCRIPTION
Clock-weather-card content overflowed its 190px slot, overlapping with the forecast row. Adds overflow:hidden + max-height to clip.

Follow-up to #297.