### PR TITLE
Kiosk weather: remove outer padding so forecast strip fits within 300px row

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -75,7 +75,7 @@ views:
               display: flex;
               flex-direction: column;
               gap: 4px;
-              padding: 6px;
+              padding: 0;
             }
             ha-card hui-vertical-stack-card,
             ha-card > * {


### PR DESCRIPTION
Outer weather mod-card had padding: 6px (12px total) which left only 288px for the inner 200px clock + 95px forecast + 4px gap (299px needed). Forecast strip was being clipped off the bottom of the cell.

Follow-up to #299.