### PR TITLE
Kiosk forecast: revert layout to horizontal

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -187,7 +187,7 @@ views:
                       {% elif c == 'snowy' %}light-blue
                       {% else %}grey
                       {% endif %}
-                    layout: vertical
+                    layout: horizontal
                     fill_container: true
                     tap_action: { action: none }
                     card_mod:


### PR DESCRIPTION
After #301, forecast cards rendered blank — reverting layout: vertical → horizontal.