### PR TITLE
Add Screen Time dashboard: 3-day TV app timeline + daily totals

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -76,6 +76,12 @@ lovelace:
       title: Command Deck
       icon: mdi:gamepad-variant
       show_in_sidebar: true
+    dashboard-screen-time:
+      mode: yaml
+      filename: dashboards/screen-time.yaml
+      title: Screen Time
+      icon: mdi:television-clock
+      show_in_sidebar: true
 
 # Prometheus
 prometheus:
@@ -326,3 +332,91 @@ template:
         state: "{{ forecast_data['weather.forecast_home'].forecast | length }}"
         attributes:
           forecast: "{{ forecast_data['weather.forecast_home'].forecast }}"
+
+# Screen-time tracking — per (TV × app) daily totals via history_stats.
+# Reads from sensor.<tv>_active_app (Roku integration). Used by the
+# Screen Time dashboard (dashboards/screen-time.yaml). The Roku ECP
+# integration flaps briefly (~10-40s of `unavailable`) during long
+# sessions; history_stats time-in-state counts only the resolved
+# segments, which undercounts by <5% — acceptable without smoothing.
+sensor:
+  # ---- Play Room TV ----
+  - platform: history_stats
+    name: Play Room Netflix Today
+    entity_id: sensor.play_room_tv_active_app
+    state: "Netflix"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Play Room YouTube Today
+    entity_id: sensor.play_room_tv_active_app
+    state: "YouTube"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Play Room Prime Video Today
+    entity_id: sensor.play_room_tv_active_app
+    state: "Prime Video"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Play Room Apple TV Today
+    entity_id: sensor.play_room_tv_active_app
+    state: "Apple TV"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Play Room Disney Plus Today
+    entity_id: sensor.play_room_tv_active_app
+    state: "Disney Plus"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  # ---- Basement TV ----
+  - platform: history_stats
+    name: Basement Netflix Today
+    entity_id: sensor.basement_tv_active_app
+    state: "Netflix"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Basement YouTube Today
+    entity_id: sensor.basement_tv_active_app
+    state: "YouTube"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Basement Prime Video Today
+    entity_id: sensor.basement_tv_active_app
+    state: "Prime Video"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  # ---- Office TV ----
+  - platform: history_stats
+    name: Office Netflix Today
+    entity_id: sensor.office_tv_active_app
+    state: "Netflix"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Office YouTube Today
+    entity_id: sensor.office_tv_active_app
+    state: "YouTube"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Office Prime Video Today
+    entity_id: sensor.office_tv_active_app
+    state: "Prime Video"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"

--- a/dashboards/screen-time.yaml
+++ b/dashboards/screen-time.yaml
@@ -1,0 +1,93 @@
+# =================================================================
+# SCREEN TIME DASHBOARD
+# Per-TV app activity over the last 3 days + today's per-app totals.
+#
+# Data sources:
+# - sensor.<tv>_active_app — raw Roku app state (Netflix/YouTube/etc.)
+# - sensor.<location>_<app>_today — history_stats helpers from
+#   configuration.yaml that total today's time in each app per TV
+#
+# The history-graph card renders each app as a colored band across the
+# timeline; the tile grid below shows today's totals as decimal hours.
+# =================================================================
+
+title: Screen Time
+views:
+  - title: Today
+    path: today
+    icon: mdi:television-clock
+    cards:
+      # --- 3-day app activity timeline (all three TVs) ---
+      - type: history-graph
+        title: TV App Activity — Last 3 Days
+        hours_to_show: 72
+        refresh_interval: 60
+        entities:
+          - entity: sensor.play_room_tv_active_app
+            name: Play Room
+          - entity: sensor.basement_tv_active_app
+            name: Basement
+          - entity: sensor.office_tv_active_app
+            name: Office
+
+      # --- Play Room today's totals ---
+      - type: entities
+        title: Play Room TV — Today
+        entities:
+          - entity: sensor.play_room_netflix_today
+            name: Netflix
+            icon: mdi:netflix
+          - entity: sensor.play_room_youtube_today
+            name: YouTube
+            icon: mdi:youtube
+          - entity: sensor.play_room_prime_video_today
+            name: Prime Video
+            icon: mdi:filmstrip
+          - entity: sensor.play_room_apple_tv_today
+            name: Apple TV
+            icon: mdi:apple
+          - entity: sensor.play_room_disney_plus_today
+            name: Disney Plus
+            icon: mdi:movie-open-star
+        state_color: false
+
+      # --- Basement today's totals ---
+      - type: entities
+        title: Basement TV — Today
+        entities:
+          - entity: sensor.basement_netflix_today
+            name: Netflix
+            icon: mdi:netflix
+          - entity: sensor.basement_youtube_today
+            name: YouTube
+            icon: mdi:youtube
+          - entity: sensor.basement_prime_video_today
+            name: Prime Video
+            icon: mdi:filmstrip
+
+      # --- Office today's totals ---
+      - type: entities
+        title: Office TV — Today
+        entities:
+          - entity: sensor.office_netflix_today
+            name: Netflix
+            icon: mdi:netflix
+          - entity: sensor.office_youtube_today
+            name: YouTube
+            icon: mdi:youtube
+          - entity: sensor.office_prime_video_today
+            name: Prime Video
+            icon: mdi:filmstrip
+
+      # --- Current state at the bottom for live awareness ---
+      - type: glance
+        title: Right Now
+        entities:
+          - entity: media_player.play_room_tv
+            name: Play Room
+          - entity: media_player.basement_tv
+            name: Basement
+          - entity: media_player.office_tv
+            name: Office
+        state_color: true
+        show_state: true


### PR DESCRIPTION
New dashboard at `/dashboard-screen-time` visualizing TV app activity.

## Origin
Chris: "harvest what app and how long and visualize in ha" + "3 days" + "go ahead autonomously".

Started as a Netflix-only user-data question — Netflix has no public API. Pivoted to HA's Roku integration, which exposes which app is active on each Roku TV (not what's playing inside the app; titles are covered by Firewalla DPI).

## Changes

### `configuration.yaml`
- 11 new `history_stats` sensors at the top-level `sensor:` block, tracking today's time-in-app per (TV × app) combination:
  - Play Room: Netflix, YouTube, Prime Video, Apple TV, Disney Plus (5)
  - Basement: Netflix, YouTube, Prime Video (3)
  - Office: Netflix, YouTube, Prime Video (3)
- New dashboard registration `dashboard-screen-time` in `lovelace.dashboards`.

### `dashboards/screen-time.yaml` (new)
- `history-graph` card showing 72h (3 days) of `active_app` per TV — colored bands per app.
- Per-TV `entities` cards listing today's totals (decimal hours) for top apps.
- Bottom `glance` card showing live `media_player` state for awareness.

## Known caveats
- Roku ECP integration flaps briefly during sessions (~10-40s of `unavailable` every minute). `history_stats` time-in-state counts only resolved segments; that's an <5% undercount. Acceptable without complex smoothing — can refine later if real-world accuracy proves bad.
- Decimal hours rather than `Nh Mm` — tile card default formatting.
- Basement and Office TVs are unavailable most of the week (only Play Room actively used over the past 7 days), so their helpers will stay near 0 until those TVs are used.