### PR TITLE
kiosk-host: SSH-driven toggle for ad-hoc browser mode

### DIFF
--- a/kiosk-host/README.md
+++ b/kiosk-host/README.md
@@ -11,8 +11,8 @@ itself lives in `dashboards/kiosk.yaml`; these files configure the
 |---|---|
 | **Host** | `pve2` (NUC, i3-6100U, quorum-only PVE node — see top-level `~/CLAUDE.md`) |
 | **Display** | 2560x1440 monitor on `HDMI-2`, mouse + keyboard attached |
-| **Browser** | Chromium in `--kiosk` mode, root-owned, no X session manager |
-| **Display target URL** | `http://homeassistant.local:8123/dashboard-kiosk/home` |
+| **Browser** | Chromium, root-owned, no X session manager. Two modes (see *Toggle* below). |
+| **Display target URL (default)** | `http://homeassistant.local:8123/dashboard-kiosk/home` |
 
 ## File map (on pve2)
 
@@ -20,15 +20,58 @@ itself lives in `dashboards/kiosk.yaml`; these files configure the
 |---|---|---|---|---|
 | `dashboard-kiosk.sh` | `/usr/local/bin/dashboard-kiosk.sh` | `0755` | `root:root` | gitops loop |
 | `dashboard-kiosk.service` | `/etc/systemd/system/dashboard-kiosk.service` | `0644` | `root:root` | gitops loop |
+| `kiosk-show` | `/usr/local/bin/kiosk-show` | `0755` | `root:root` | gitops loop |
 | `gitops-pull.sh` | (run in place from `/opt/homeassistant-config/kiosk-host/`) | `0755` | `root:root` | bootstrap only |
 | `gitops-pull.service` | `/etc/systemd/system/dashboard-kiosk-gitops.service` | `0644` | `root:root` | bootstrap only |
 | `gitops-pull.timer` | `/etc/systemd/system/dashboard-kiosk-gitops.timer` | `0644` | `root:root` | bootstrap only |
 
+Also on pve2, *not* managed by the loop:
+
+| Path | Owner | Purpose |
+|---|---|---|
+| `/etc/default/dashboard-kiosk` | `kiosk-show` | Mutable runtime state (`KIOSK_MODE`, `KIOSK_URL`). Absent → defaults apply. |
+
 The kiosk `systemd` unit launches a bare `xinit` session pinned to
-display `:0` (no display manager) and the script forks `unclutter` +
-`chromium` in front of it. The gitops loop is a oneshot service driven
-by a 5-minute timer that pulls `origin/main` and reinstalls the two
-kiosk artifacts if they drift.
+display `:0` (no display manager) and the script forks `chromium` in
+front of it. The gitops loop is a oneshot service driven by a 5-minute
+timer that pulls `origin/main` and reinstalls the three kiosk artifacts
+if they drift.
+
+## Toggle: kiosk dashboard ⇄ ad-hoc browser
+
+`dashboard-kiosk.sh` reads `/etc/default/dashboard-kiosk` and branches
+on `KIOSK_MODE`:
+
+- **`kiosk`** (default) — fullscreen Chromium, no chrome, no WM,
+  `unclutter` hiding the mouse. Renders the household HA dashboard.
+- **`browser`** — windowed Chromium with the normal UI (tabs, address
+  bar, devtools), under an `openbox` WM so the window is movable and
+  resizable. For ad-hoc "put this URL on the household monitor"
+  workflows driven over SSH.
+
+The state file is owned by `/usr/local/bin/kiosk-show` and is **not**
+managed by the gitops loop. Edits are clobbered on the next
+`kiosk-show` run; if the file is absent, the script falls back to the
+kiosk-dashboard defaults.
+
+```bash
+# Put a URL on the household monitor (browser mode, default)
+ssh -J root@pve.local root@pve2 'kiosk-show https://grafana.example/d/foo'
+
+# Fullscreen kiosk an arbitrary URL (no chrome)
+ssh -J root@pve.local root@pve2 'kiosk-show --kiosk https://example.com'
+
+# Snap back to the HA kiosk dashboard
+ssh -J root@pve.local root@pve2 'kiosk-show --dashboard'
+
+# Show current state
+ssh -J root@pve.local root@pve2 'kiosk-show --show'
+```
+
+Each call rewrites the state file and `systemctl restart`s
+`dashboard-kiosk.service` — the screen blinks once and lands on the
+new URL within a few seconds. The display has no kiosk lockout in
+browser mode; whoever's at the keyboard can navigate normally.
 
 ## Deploy
 
@@ -36,14 +79,15 @@ Push a change through the standard PitziLabs PR flow. The merged
 change is picked up by the gitops loop on pve2 within ~5 minutes:
 
 1. Loop fetches `origin/main` and resets the clone if it has diverged.
-2. Loop `bash -n`'s the script and `systemd-analyze verify`'s the unit
-   before touching the deployed copies — a syntax-broken commit can't
-   put the kiosk into a crash loop.
-3. If either differs from the deployed copy, the loop reinstalls it,
-   runs `daemon-reload` if the unit changed, then
-   `systemctl restart dashboard-kiosk.service` — a single restart
-   cycles X + Chromium against the new state. No-op polls do not
-   restart anything.
+2. Loop `bash -n`'s the two scripts (`dashboard-kiosk.sh`, `kiosk-show`)
+   and `systemd-analyze verify`'s the unit before touching the deployed
+   copies — a syntax-broken commit can't put the kiosk into a crash loop.
+3. If any of the three artifacts differs from the deployed copy, the
+   loop reinstalls just the ones that drifted, runs `daemon-reload` if
+   the unit changed, then `systemctl restart dashboard-kiosk.service`
+   *only if the runner script or unit changed* — a `kiosk-show`-only
+   update doesn't flicker the display. No-op polls do not restart
+   anything.
 
 The loop refuses to deploy unless the clone is on the `main` branch,
 mirroring the HA-side `scripts/gitops-sync.sh` guard.
@@ -79,7 +123,7 @@ itself, so the initial setup is manual:
 ssh -J root@pve.local root@pve2 '
   set -euo pipefail
   apt-get update
-  apt-get install -y git chromium xserver-xorg xinit unclutter
+  apt-get install -y git chromium xserver-xorg xinit unclutter openbox
 
   # Clone the canonical config
   test -d /opt/homeassistant-config || \
@@ -89,6 +133,7 @@ ssh -J root@pve.local root@pve2 '
   # Install the kiosk display artifacts (the loop manages these going forward)
   install -m 0755 -o root -g root kiosk-host/dashboard-kiosk.sh         /usr/local/bin/dashboard-kiosk.sh
   install -m 0644 -o root -g root kiosk-host/dashboard-kiosk.service    /etc/systemd/system/dashboard-kiosk.service
+  install -m 0755 -o root -g root kiosk-host/kiosk-show                 /usr/local/bin/kiosk-show
 
   # Install the gitops loop units (the loop does NOT manage these — bootstrap only)
   install -m 0644 -o root -g root kiosk-host/gitops-pull.service        /etc/systemd/system/dashboard-kiosk-gitops.service

--- a/kiosk-host/dashboard-kiosk.sh
+++ b/kiosk-host/dashboard-kiosk.sh
@@ -1,19 +1,58 @@
 #!/bin/bash
+# Dashboard kiosk runner. Two modes, selected by KIOSK_MODE in
+# /etc/default/dashboard-kiosk (sourced below if present):
+#
+#   kiosk    — fullscreen Chromium, no chrome, no WM. The default; renders
+#              the household HA dashboard.
+#   browser  — windowed Chromium with the normal UI (tabs, address bar),
+#              under an openbox WM so the window is movable/resizable.
+#              Use for ad-hoc "put this URL on the household monitor"
+#              from SSH via /usr/local/bin/kiosk-show.
+#
+# The state file is NOT managed by the gitops loop — it's mutable runtime
+# state owned by kiosk-show. Defaults below apply when the file is absent.
+set -eu
+
+KIOSK_MODE="kiosk"
+KIOSK_URL="http://homeassistant.local:8123/dashboard-kiosk/home"
+
+if [ -r /etc/default/dashboard-kiosk ]; then
+  # shellcheck disable=SC1091
+  . /etc/default/dashboard-kiosk
+fi
+
 xrandr --output HDMI-2 --mode 2560x1440 --rate 60
 xset s off
 xset -dpms
 xset s noblank
-unclutter -idle 3 -root &
-chromium \
-  --no-sandbox \
-  --kiosk \
-  --noerrdialogs \
-  --disable-infobars \
-  --no-first-run \
-  --disable-session-crashed-bubble \
-  --disable-features=TranslateUI \
-  --check-for-update-interval=31536000 \
-  --force-device-scale-factor=1 \
-  --window-size=2560,1440 \
-  --window-position=0,0 \
-  "http://homeassistant.local:8123/dashboard-kiosk/home"
+
+case "${KIOSK_MODE}" in
+  browser)
+    openbox &
+    exec chromium \
+      --no-sandbox \
+      --no-first-run \
+      --disable-session-crashed-bubble \
+      --disable-features=TranslateUI \
+      --check-for-update-interval=31536000 \
+      --force-device-scale-factor=1 \
+      --start-maximized \
+      "${KIOSK_URL}"
+    ;;
+  kiosk|*)
+    unclutter -idle 3 -root &
+    exec chromium \
+      --no-sandbox \
+      --kiosk \
+      --noerrdialogs \
+      --disable-infobars \
+      --no-first-run \
+      --disable-session-crashed-bubble \
+      --disable-features=TranslateUI \
+      --check-for-update-interval=31536000 \
+      --force-device-scale-factor=1 \
+      --window-size=2560,1440 \
+      --window-position=0,0 \
+      "${KIOSK_URL}"
+    ;;
+esac

--- a/kiosk-host/gitops-pull.sh
+++ b/kiosk-host/gitops-pull.sh
@@ -22,6 +22,8 @@ readonly SCRIPT_SRC="${REPO_DIR}/${REPO_SUBDIR}/dashboard-kiosk.sh"
 readonly SCRIPT_DST="/usr/local/bin/dashboard-kiosk.sh"
 readonly UNIT_SRC="${REPO_DIR}/${REPO_SUBDIR}/dashboard-kiosk.service"
 readonly UNIT_DST="/etc/systemd/system/dashboard-kiosk.service"
+readonly HELPER_SRC="${REPO_DIR}/${REPO_SUBDIR}/kiosk-show"
+readonly HELPER_DST="/usr/local/bin/kiosk-show"
 readonly KIOSK_UNIT="dashboard-kiosk.service"
 
 log() {
@@ -81,20 +83,27 @@ main() {
     log ERROR "dashboard-kiosk.sh failed syntax check; refusing to install"
     exit 1
   fi
+  if ! bash -n "$HELPER_SRC"; then
+    log ERROR "kiosk-show failed syntax check; refusing to install"
+    exit 1
+  fi
   if ! systemd-analyze verify "$UNIT_SRC" 2>/dev/null; then
     log ERROR "dashboard-kiosk.service failed systemd-analyze verify; refusing to install"
     exit 1
   fi
 
-  local script_changed=false unit_changed=false
+  local script_changed=false unit_changed=false helper_changed=false
   if ! cmp -s "$SCRIPT_SRC" "$SCRIPT_DST"; then
     script_changed=true
   fi
   if ! cmp -s "$UNIT_SRC" "$UNIT_DST"; then
     unit_changed=true
   fi
+  if ! cmp -s "$HELPER_SRC" "$HELPER_DST"; then
+    helper_changed=true
+  fi
 
-  if [[ "$script_changed" == false && "$unit_changed" == false ]]; then
+  if [[ "$script_changed" == false && "$unit_changed" == false && "$helper_changed" == false ]]; then
     log INFO "no-op, deployed copy matches ${remote_sha:0:7}"
     exit 0
   fi
@@ -108,9 +117,17 @@ main() {
     install -m 0644 -o root -g root "$UNIT_SRC" "$UNIT_DST"
     systemctl daemon-reload
   fi
+  if [[ "$helper_changed" == true ]]; then
+    log INFO "Installing kiosk-show → ${HELPER_DST}"
+    install -m 0755 -o root -g root "$HELPER_SRC" "$HELPER_DST"
+  fi
 
-  log INFO "Restarting ${KIOSK_UNIT}"
-  systemctl restart "$KIOSK_UNIT"
+  # Helper-only changes don't affect the running display; skip the
+  # restart so a kiosk-show update doesn't flicker the screen.
+  if [[ "$script_changed" == true || "$unit_changed" == true ]]; then
+    log INFO "Restarting ${KIOSK_UNIT}"
+    systemctl restart "$KIOSK_UNIT"
+  fi
 
   log INFO "Deployed ${remote_sha:0:7}"
 }

--- a/kiosk-host/kiosk-show
+++ b/kiosk-host/kiosk-show
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# kiosk-show — point pve2's HDMI display at a URL.
+#
+# Usage:
+#   kiosk-show URL                  Browser mode (windowed Chromium with chrome).
+#   kiosk-show --browser URL        Explicit browser mode.
+#   kiosk-show --kiosk URL          Fullscreen kiosk mode (no chrome, no WM).
+#   kiosk-show --dashboard          Snap back to the HA kiosk dashboard.
+#   kiosk-show --show               Print current state.
+#   kiosk-show --help               This message.
+#
+# Writes /etc/default/dashboard-kiosk and restarts dashboard-kiosk.service.
+# State file is mutable runtime state — NOT managed by the gitops loop.
+#
+# Intended for SSH-driven workflows:
+#   ssh -J root@pve.local root@pve2 'kiosk-show https://example.com'
+set -euo pipefail
+
+readonly STATE_FILE=/etc/default/dashboard-kiosk
+readonly DASHBOARD_URL="http://homeassistant.local:8123/dashboard-kiosk/home"
+readonly UNIT=dashboard-kiosk.service
+
+usage() {
+  sed -n '3,13p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+require_root() {
+  if [[ $EUID -ne 0 ]]; then
+    echo "kiosk-show: must run as root (writes ${STATE_FILE})" >&2
+    exit 1
+  fi
+}
+
+validate_url() {
+  if [[ ! "$1" =~ ^https?:// ]]; then
+    echo "kiosk-show: URL must start with http:// or https://" >&2
+    exit 1
+  fi
+}
+
+write_state() {
+  local mode="$1" url="$2"
+  require_root
+  cat > "$STATE_FILE" <<EOF
+# Managed by /usr/local/bin/kiosk-show — manual edits are clobbered on next run.
+KIOSK_MODE=${mode}
+KIOSK_URL=${url}
+EOF
+  systemctl restart "$UNIT"
+  echo "kiosk-show: ${mode} → ${url}"
+}
+
+mode=browser
+url=""
+
+case "${1:-}" in
+  ""|--help|-h)
+    usage
+    exit 0
+    ;;
+  --show)
+    if [[ -r "$STATE_FILE" ]]; then
+      cat "$STATE_FILE"
+    else
+      echo "(no state file — defaults apply: KIOSK_MODE=kiosk, KIOSK_URL=${DASHBOARD_URL})"
+    fi
+    exit 0
+    ;;
+  --dashboard)
+    write_state kiosk "$DASHBOARD_URL"
+    exit 0
+    ;;
+  --kiosk)
+    mode=kiosk
+    shift
+    url="${1:-}"
+    ;;
+  --browser)
+    mode=browser
+    shift
+    url="${1:-}"
+    ;;
+  -*)
+    echo "kiosk-show: unknown option: $1" >&2
+    usage >&2
+    exit 1
+    ;;
+  *)
+    url="$1"
+    ;;
+esac
+
+if [[ -z "$url" ]]; then
+  echo "kiosk-show: URL required" >&2
+  usage >&2
+  exit 1
+fi
+
+validate_url "$url"
+write_state "$mode" "$url"


### PR DESCRIPTION
SSH-driven toggle on pve2 so an ad-hoc URL can be pushed to the household HDMI display from any shell — without standing up a full desktop environment on the quorum node.

## Origin

Conversational thread (not an issue). Chris asked whether pve2 could support a full desktop env to HDMI; I noted it could (Intel HD 520 already runs X via xinit) but flagged the trade-off — pve2 is the quorum node, tight on RAM/SSD, and a DE adds attack surface to a hypervisor host. Chris's reply: *"hmmm. alternatively, we could just fire up unkiosked chrome."* Then: *"yeah set up the toggle, and keep it accessible over ssh so our workflows can use it. Claude can display something to me and I can turn to my right and see it, quickly."*

Constraints:

- SSH-callable so Claude workflows can drive it (one-liner from any shell).
- Don't break the existing kiosk-dashboard default — that's the household's primary use of the screen.
- Mutable state shouldn't fight the gitops loop.

## What changed

- **`kiosk-host/kiosk-show`** (new, `/usr/local/bin/kiosk-show`) — Helper that rewrites `/etc/default/dashboard-kiosk` and restarts `dashboard-kiosk.service`. Subcommands: `URL` (browser mode), `--kiosk URL` (fullscreen), `--browser URL` (explicit), `--dashboard` (snap back to HA kiosk), `--show`, `--help`. Validates `http(s)://` URLs, refuses non-root, rejects unknown flags.
- **`kiosk-host/dashboard-kiosk.sh`** — Sources `/etc/default/dashboard-kiosk` if present, branches on `KIOSK_MODE`. Browser mode launches `openbox &` then `chromium --start-maximized` without `--kiosk`. Kiosk mode is the original code path. Defaults render the HA dashboard if the state file is absent.
- **`kiosk-host/gitops-pull.sh`** — Validates and installs the new helper alongside the runner script and unit. Helper-only drift skips the kiosk service restart (no display flicker for `kiosk-show` updates).
- **`kiosk-host/README.md`** — File map gains `kiosk-show` + the unmanaged state file; new *Toggle* section documents the workflow; bootstrap apt line gains `openbox`.

## Out of band

`openbox` was apt-installed on pve2 ahead of this PR so the gitops loop has its dependency the moment it lands. Without it, browser mode would fail to start a WM (kiosk mode would be unaffected).

## Usage from any shell

```bash
ssh -J root@pve.local root@pve2 'kiosk-show https://grafana.example/d/foo'   # browser, with chrome
ssh -J root@pve.local root@pve2 'kiosk-show --kiosk https://example.com'     # fullscreen
ssh -J root@pve.local root@pve2 'kiosk-show --dashboard'                     # back to HA kiosk
ssh -J root@pve.local root@pve2 'kiosk-show --show'                          # inspect state
```

## Test plan

- [x] `bash -n` clean on all three scripts; `systemd-analyze verify` accepts the existing unit unchanged.
- [x] `kiosk-show --help`, `--show` (no state file), URL-scheme rejection, unknown-flag rejection all behave correctly when smoke-tested locally as non-root.
- [ ] After auto-merge + gitops pull (~5 min): `ssh -J root@pve.local root@pve2 'kiosk-show --show'` reports defaults; `kiosk-show https://homeassistant.local:8123/lovelace/0` lands the windowed dashboard on HDMI-2; `kiosk-show --dashboard` returns to the kiosk view.