### PR TITLE
Add kiosk-host memory gauge to Homelab Status dashboard

### DIFF
--- a/dashboards/homelab-status.yaml
+++ b/dashboards/homelab-status.yaml
@@ -183,6 +183,38 @@ views:
           - entity: sensor.backup_next_scheduled_automatic_backup
             name: Next Scheduled
 
+      # Kiosk host memory watch — pve2 drives the household dashboard
+      # display via Chromium. The renderer has a slow leak that ends in
+      # a V8 OOM after ~7h (see issue #308); pve2 only runs the kiosk
+      # plus bare PVE/corosync, so host memory % is a reliable proxy
+      # for "kiosk Chromium has bloated." Pre-OOM peak observed at ~65%.
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: gauge
+            entity: sensor.pve2_memory_usage_percentage_2
+            name: Kiosk Host Memory
+            unit: '%'
+            min: 0
+            max: 100
+            needle: true
+            severity:
+              green: 0
+              yellow: 50
+              red: 70
+          - type: entities
+            title: pve2 (kiosk host)
+            entities:
+              - entity: sensor.pve2_status_2
+                name: Status
+              - entity: sensor.pve2_cpu_usage_2
+                name: CPU
+              - entity: sensor.pve2_memory_usage_2
+                name: Memory (GB)
+              - entity: sensor.pve2_uptime_2
+                name: Host Uptime
+
 
       # ═══════════════════════════════════════════════════════════
       # 3. UPS — CyberPower CP1500PFCLCDa


### PR DESCRIPTION
## Summary

Surface pve2 host memory as a gauge on the Homelab Status dashboard so the kiosk Chromium leak (issue #308) is visible at a glance instead of requiring an SSH session.

## Origin

> and let's get a memory gauge somewhere

Followed the 2026-05-31 kiosk OOM observation. The dashboard tab had been silently showing a Google new-tab page for hours after V8 OOM'd; caught by accident while taking a screenshot. Issue #308 tracks the leak itself; this PR adds the visibility piece so future degradation is noticed in normal use.

## Change

`dashboards/homelab-status.yaml` — inserts a small "Kiosk host memory watch" sub-section into the existing "Proxmox — pve" block (right after the Backup card), with:

- A `gauge` card driven by `sensor.pve2_memory_usage_percentage_2` (entity from the existing Proxmox HA integration, already exposed). Thresholds: green <50, yellow 50–70, red >70 — pre-OOM peak observed at ~65%.
- A small entities card with pve2 status, CPU, raw memory (GB), and host uptime so the gauge has context next to it.

## Why a host-level proxy

pve2 only runs the kiosk plus bare PVE/corosync, so host memory % is a reliable proxy for "Chromium has bloated." A surgical per-service metric (`dashboard-kiosk.service` memory) would require enabling node_exporter's `systemd` collector on pve2 plus the permission bump that goes with it — fine work for a follow-up, but the host-level signal is sufficient to spot the leak today with zero infra changes.

## Test plan

- [ ] CI: `YAML Lint`, `check-config`, `claude-review` green.
- [ ] After deploy: Homelab Status dashboard renders the new gauge under the Proxmox section without errors.
- [ ] Watch the gauge climb during normal kiosk uptime — should be in the green/yellow band, never lingering in red unless Chromium has gone unhealthy.