### PR TITLE
Add kiosk-host/kiosk-snapshot for live-frame kiosk screen grabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ ha-context-dump.log.*
 # Python bytecode
 __pycache__/
 *.pyc
+
+# kiosk-snapshot tool output — throwaway frame grabs from pve2's display
+/kiosk-snapshot-*.png

--- a/kiosk-host/README.md
+++ b/kiosk-host/README.md
@@ -24,6 +24,7 @@ itself lives in `dashboards/kiosk.yaml`; these files configure the
 | `gitops-pull.sh` | (run in place from `/opt/homeassistant-config/kiosk-host/`) | `0755` | `root:root` | bootstrap only |
 | `gitops-pull.service` | `/etc/systemd/system/dashboard-kiosk-gitops.service` | `0644` | `root:root` | bootstrap only |
 | `gitops-pull.timer` | `/etc/systemd/system/dashboard-kiosk-gitops.timer` | `0644` | `root:root` | bootstrap only |
+| `kiosk-snapshot` | (run from your workstation, not deployed) | `0755` | n/a | n/a |
 
 Also on pve2, *not* managed by the loop:
 
@@ -72,6 +73,37 @@ Each call rewrites the state file and `systemctl restart`s
 `dashboard-kiosk.service` — the screen blinks once and lands on the
 new URL within a few seconds. The display has no kiosk lockout in
 browser mode; whoever's at the keyboard can navigate normally.
+
+## Snapshot the live display
+
+`kiosk-snapshot` is the **preferred way to capture what the household
+monitor is showing** — it grabs the actual rendered frame from pve2's
+X session, so you see the real kiosk state (alarm color, current Sonos
+art, active media tile, etc.) rather than a fresh, just-loaded render.
+
+Run it from your workstation (it is not deployed to pve2):
+
+```bash
+# Drop a snapshot in cwd → ./kiosk-snapshot-<UTC-timestamp>.png
+kiosk-host/kiosk-snapshot
+
+# Custom output path
+kiosk-host/kiosk-snapshot -o /tmp/before-fix.png
+
+# Capture and open in the default image viewer
+kiosk-host/kiosk-snapshot --open
+```
+
+Under the hood: `ssh -J root@pve.local root@pve2`, `scrot` against
+`DISPLAY=:0` as root (the kiosk's bare-xinit session), `scp` back, then
+`rm` the remote temp file. Requires `scrot` on pve2 — added to the
+bootstrap recipe below.
+
+This is also the fallback path when local Playwright/Chromium fails to
+launch (Gdk portal / sandbox crashes have been seen on the workstation).
+Even when Playwright works, prefer `kiosk-snapshot` for kiosk captures —
+Playwright would render a clean, just-authed session, missing the live
+state.
 
 ## Deploy
 
@@ -123,7 +155,7 @@ itself, so the initial setup is manual:
 ssh -J root@pve.local root@pve2 '
   set -euo pipefail
   apt-get update
-  apt-get install -y git chromium xserver-xorg xinit unclutter openbox
+  apt-get install -y git chromium xserver-xorg xinit unclutter openbox scrot
 
   # Clone the canonical config
   test -d /opt/homeassistant-config || \

--- a/kiosk-host/kiosk-snapshot
+++ b/kiosk-host/kiosk-snapshot
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# kiosk-snapshot — capture the live pve2 kiosk display and copy it locally.
+#
+# Usage:
+#   kiosk-snapshot [-o OUTFILE] [--open]
+#   kiosk-snapshot --help
+#
+# Defaults to ./kiosk-snapshot-<UTC-timestamp>.png in the current directory.
+#
+# Runs on the workstation (not on pve2). SSHs to pve2 via the pve.local
+# jump host, grabs the X :0 framebuffer with `scrot`, copies the PNG back
+# over scp, then deletes the remote temp file. This captures the *real*
+# rendered kiosk frame — same pixels you'd see on the household monitor —
+# rather than a fresh browser session that would need to re-authenticate
+# to Home Assistant.
+#
+# Use this when you need a kiosk screenshot. Specifically, prefer it over
+# spinning up Playwright/Chromium locally: Playwright captures a clean
+# headless render, but the workstation Chrome currently crashes on
+# launch (Gdk portal sandbox / SIGSEGV), and even when it works it has
+# to re-auth to HA each time. This path has neither problem.
+#
+# Requires `scrot` on pve2 (added to the bootstrap recipe in README.md).
+set -euo pipefail
+
+readonly JUMP=root@pve.local
+readonly TARGET=root@pve2
+
+usage() {
+  sed -n '3,9p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+ts=$(date -u +%Y%m%dT%H%M%SZ)
+outfile="kiosk-snapshot-${ts}.png"
+open_after=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--output)
+      outfile="${2:?--output requires a path}"
+      shift 2
+      ;;
+    --open)
+      open_after=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "kiosk-snapshot: unknown arg: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+remote_tmp="/tmp/kiosk-snapshot-${ts}-$$.png"
+
+ssh -J "$JUMP" "$TARGET" \
+  "DISPLAY=:0 XAUTHORITY=/root/.Xauthority scrot '$remote_tmp'"
+
+scp -J "$JUMP" -q "$TARGET:$remote_tmp" "$outfile"
+
+ssh -J "$JUMP" "$TARGET" "rm -f '$remote_tmp'"
+
+echo "$outfile"
+
+if [[ $open_after -eq 1 ]]; then
+  if command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$outfile" >/dev/null 2>&1 &
+    disown || true
+  else
+    echo "kiosk-snapshot: --open requested but xdg-open not found" >&2
+  fi
+fi


### PR DESCRIPTION
Adds a workstation-side helper that captures the pve2 kiosk display by SSHing in and running `scrot` against its X `:0` session, then copying the PNG back. Documented in `kiosk-host/README.md` as the preferred kiosk capture path.

## Origin

> codify the scrot method for our workflows since we have a playwright issue right now. name it something other than scrot, too

Context: in this session, `mcp__playwright__browser_navigate` crashed on local Chrome launch (Gdk portal / sandbox → SIGSEGV), so I fell back to ssh + scrot on pve2's running kiosk session to capture the dashboard. That ad-hoc path needed to be a tool, with a name that doesn't tie us to the underlying utility.

## What's in this PR

- **`kiosk-host/kiosk-snapshot`** — workstation-side bash wrapper. Defaults to `./kiosk-snapshot-<UTC-timestamp>.png`; supports `-o PATH` and `--open`. SSHes via the `root@pve.local` jump host to `root@pve2`, runs `scrot` against `DISPLAY=:0 XAUTHORITY=/root/.Xauthority`, scp's the file back, deletes the remote tmp.
- **`kiosk-host/README.md`** — new "Snapshot the live display" section documenting when to reach for it (preferred over Playwright for kiosk captures because it grabs the actual rendered live frame, not a fresh re-render). File map row added. Bootstrap apt-install list gains `scrot`.
- **`.gitignore`** — `/kiosk-snapshot-*.png` so the auto-named outputs don't accumulate in `git status` at repo root.

Not installed onto pve2 — `kiosk-snapshot` runs only on the workstation; the bootstrap change is just adding `scrot` (the dependency it ssh-invokes) to fresh pve2 installs.

## Test plan

- [x] `bash -n kiosk-host/kiosk-snapshot` syntax-clean
- [x] `kiosk-host/kiosk-snapshot --help` prints usage
- [x] End-to-end smoke test: `kiosk-snapshot -o /tmp/kiosk-snapshot-smoketest.png` produced a valid 2560x1440 PNG and `ssh ... root@pve2 ls /tmp/kiosk-snapshot-*.png` confirmed remote cleanup
- [x] README renders correctly (file-map row aligned, code blocks fenced)
- [ ] CI: YAML Lint / check-config / claude-review (no YAML changed, but they run anyway)