### PR TITLE
snapshot-server: fix empty-body bug + gitops verify chicken-and-egg

### DIFF
--- a/kiosk-host/gitops-pull.sh
+++ b/kiosk-host/gitops-pull.sh
@@ -96,12 +96,30 @@ main() {
     log ERROR "snapshot-server failed python syntax check; refusing to install"
     exit 1
   fi
-  if ! systemd-analyze verify "$UNIT_SRC" 2>/dev/null; then
-    log ERROR "dashboard-kiosk.service failed systemd-analyze verify; refusing to install"
+  # systemd-analyze verify checks ExecStart's first word exists on disk.
+  # When we're first-deploying a new unit+script pair, the script isn't
+  # installed yet — verify will warn "Command X is not executable: No such
+  # file or directory" and exit 1. That's a chicken-and-egg false positive
+  # in our context because the install step right after places the binary.
+  # Tolerate that specific warning; refuse on anything else.
+  verify_unit() {
+    local unit_src="$1" unit_name="$2"
+    local verify_out
+    if verify_out=$(systemd-analyze verify "$unit_src" 2>&1); then
+      return 0
+    fi
+    local residual
+    residual=$(printf '%s\n' "$verify_out" | grep -v 'is not executable: No such file or directory' || true)
+    if [[ -z "$residual" ]]; then
+      return 0
+    fi
+    log ERROR "${unit_name} failed systemd-analyze verify: ${residual}"
+    return 1
+  }
+  if ! verify_unit "$UNIT_SRC" "dashboard-kiosk.service"; then
     exit 1
   fi
-  if ! systemd-analyze verify "$SNAP_UNIT_SRC" 2>/dev/null; then
-    log ERROR "snapshot-server.service failed systemd-analyze verify; refusing to install"
+  if ! verify_unit "$SNAP_UNIT_SRC" "snapshot-server.service"; then
     exit 1
   fi
 

--- a/kiosk-host/snapshot-server
+++ b/kiosk-host/snapshot-server
@@ -28,12 +28,18 @@ ENV = {
 
 
 def capture() -> bytes:
-    """Run scrot to a tempfile, read it back, unlink. Returns PNG bytes."""
+    """Run scrot to a tempfile, read it back, unlink. Returns PNG bytes.
+
+    mkstemp creates the file as a side effect of reserving the name; scrot
+    (1.12+) treats an existing target as a collision and silently writes to
+    a fallback path, leaving the original empty. Pass --overwrite so scrot
+    writes to the exact path we asked for.
+    """
     fd, path = tempfile.mkstemp(prefix="kiosk-snapshot-", suffix=".png")
     os.close(fd)
     try:
         subprocess.run(
-            ["scrot", path],
+            ["scrot", "--overwrite", path],
             env=ENV,
             check=True,
             timeout=SCROT_TIMEOUT,


### PR DESCRIPTION
Fix-forward for two bugs caught during the live timing test of #312.

## Origin

> press the dump button to test it. let's see how fast it really is, if you were in the middle of a workstream and wanted to check the result of a working change

The timing test surfaced two real defects in the snapshot-server / gitops-pull integration:

1. **Snapshot-server returned 200 with `Content-Length: 0`.** scrot 1.12.1 (Debian bookworm) refuses to overwrite an existing target — it silently writes to a `_000.png` fallback path and exits with rc=0. My `capture()` used `tempfile.mkstemp`, which creates the empty file as a side effect of reserving the name. scrot saw the existing empty file, sidestepped to a fallback, and my read of the original path returned 0 bytes. The server logged a `200 OK` because subprocess.run reported success.

2. **Kiosk-host gitops loop refused to install snapshot-server on first deploy.** `systemd-analyze verify` checks ExecStart's first word exists on disk; for a brand-new unit+script pair the script hasn't been installed yet, so verify emits `Command /usr/local/bin/snapshot-server is not executable: No such file or directory` and exits 1 — refusing to install both the script and the unit. Chicken-and-egg: the only thing that installs the script is the loop that just refused to install it. dashboard-kiosk.service didn't hit this because its script was bootstrap-installed on a fresh pve2 long before the loop's first poll.

## Fixes

**`kiosk-host/snapshot-server`** — pass `--overwrite` to scrot so it writes to the exact path mkstemp returned. Comment in the docstring explains why.

**`kiosk-host/gitops-pull.sh`** — extract a `verify_unit()` helper that runs `systemd-analyze verify`, captures stderr, and tolerates *only* the `is not executable: No such file` warning. Anything else (real syntax errors, malformed directives, etc.) still fails the loop. Applied to both managed units. Future new unit+script pairs in this loop will Just Work on first deploy.

## State on pve2 right now

The snapshot-server binary currently installed at `/usr/local/bin/snapshot-server` was a manual `install -m 0755` during the post-merge debug — necessary because the gitops loop had refused to do it. Once this PR merges, the next 5-min poll will:
- Validate (now-tolerant) → pass
- `cmp -s` against the manually-installed `/usr/local/bin/snapshot-server` → drift (the manually-installed file is the *broken* pre-fix version)
- Install the fix → restart snapshot-server.service → empty-body bug gone

The loop self-heals; no further manual intervention needed.

## Test plan

- [x] `bash -n` clean on `gitops-pull.sh`
- [x] `python3 -m py_compile` clean on `snapshot-server`
- [x] `shellcheck` clean on shell scripts (Python script flagged SC1071 only — expected, not a shell file)
- [x] Reproduced bug #1 locally: `subprocess.run(["scrot", path])` on pve2 with a pre-existing tempfile → rc=0, stderr "already exists, attempting <path>_000.png instead", file 0 bytes
- [x] Confirmed `scrot --overwrite` is supported on pve2's scrot 1.12.1
- [ ] Post-merge: kiosk-host loop self-heals, `curl http://pve2.local:9999/` returns a PNG, next dump-button press lands `context/kiosk-latest.png`