### PR TITLE
kiosk-preview: scp → ssh-stdin-redirect (HAOS port 22 has no sftp-server)

### DIFF
--- a/kiosk-host/README.md
+++ b/kiosk-host/README.md
@@ -128,10 +128,8 @@ kiosk-host/kiosk-preview --no-snapshot
 
 Under the hood, each call:
 
-1. `python3 yaml.safe_load`s the local file (refuses to push broken YAML)
-2. `scp -p 22 root@homeassistant.local:/config/dashboards/<name>` to the
-   HA VM. **Requires** SSH key access to the HAOS host — root@homeassistant.local
-   on port 22.
+1. `python3 yaml.safe_load`s the local file (refuses to push broken YAML).
+2. `ssh -p 22 root@homeassistant.local 'cat > /homeassistant/dashboards/.<name>.preview-tmp && mv ... <name>'` — atomic write via stdin redirect. **Requires** SSH key access to `root@homeassistant.local` port 22 (HAOS host SSH). `scp` does *not* work on HAOS port 22 (no sftp-server); the Core container's `/config` maps to `/homeassistant` on the HAOS host filesystem.
 3. Calls `lovelace.reload_resources` via the HA REST API to clear the
    frontend resource cache. Optional — looks for a long-lived access
    token at `~/.config/kiosk-preview/ha-token`; skipped silently if
@@ -159,8 +157,10 @@ Under the hood, each call:
 - **First-time SSH setup.** Both the HA host (`homeassistant.local`) and
   the kiosk-snapshot path (via `pve.local` jump) need your workstation
   key in their `authorized_keys`. The kiosk-snapshot jump already works
-  for the rest of this tooling; HA-host SSH may need a one-time setup
-  of `/root/.ssh/authorized_keys` on HAOS — see the HA developer docs.
+  for the rest of this tooling; HA-host SSH (port 22, NOT the
+  Terminal & SSH add-on on 22222) needs a one-time `authorized_keys.txt`
+  drop on the HAOS data partition — see the HA developer docs. Verify
+  with `ssh -p 22 root@homeassistant.local 'echo ok'`.
 - **Optional HA token for resource reload.** If you want
   `lovelace.reload_resources` to actually fire (rarely needed for pure
   dashboard YAML edits — see step 3 above), put a long-lived access

--- a/kiosk-host/kiosk-preview
+++ b/kiosk-host/kiosk-preview
@@ -20,6 +20,9 @@
 #
 # Requires:
 #   - SSH key access to root@homeassistant.local on port 22 (HAOS host SSH).
+#     The push uses an `ssh ... 'cat > /homeassistant/dashboards/<name>'`
+#     stdin redirect — scp doesn't work on HAOS port 22 (no sftp-server).
+#     The Core container's /config maps to /homeassistant on the host.
 #   - SSH access to root@pve2 via the root@pve.local jump host (standard).
 #   - xdotool installed on pve2 (added to bootstrap in README.md).
 set -euo pipefail
@@ -27,7 +30,11 @@ set -euo pipefail
 readonly HA_HOST="homeassistant.local"
 readonly HA_USER="root"
 readonly HA_SSH_PORT=22
-readonly HA_TARGET_DIR="/config/dashboards"
+# HAOS root SSH (port 22) is a BusyBox shell on the host filesystem,
+# NOT inside HA Core. The Core container's /config maps to /homeassistant
+# on the host. scp doesn't work here (no sftp-server); we use ssh-stdin
+# redirect with `cat >` instead, which only needs basic shell builtins.
+readonly HA_TARGET_DIR="/homeassistant/dashboards"
 readonly KIOSK_JUMP="root@pve.local"
 readonly KIOSK_HOST="root@pve2"
 readonly KIOSK_SNAPSHOT_URL="http://pve2.local:9999/"
@@ -70,15 +77,26 @@ if ! python3 -c "import sys, yaml; yaml.safe_load(open(sys.argv[1]))" "$yaml_pat
 fi
 
 target_name=$(basename "$yaml_path")
+# Defense in depth: refuse anything that isn't a plain dashboard YAML name.
+# basename already strips path separators; this catches the rest.
+if [[ ! "$target_name" =~ ^[a-zA-Z0-9._-]+\.yaml$ ]]; then
+  err "target filename must match [A-Za-z0-9._-]+\\.yaml: ${target_name}"
+  exit 2
+fi
 ts=$(date -u +%Y%m%dT%H%M%SZ)
 total_start=$EPOCHREALTIME
 
 # --- 2. Push to HA ---------------------------------------------------------
 step "pushing → ${HA_USER}@${HA_HOST}:${HA_TARGET_DIR}/${target_name}"
 push_start=$EPOCHREALTIME
-if ! scp -P "$HA_SSH_PORT" -q -o ConnectTimeout=5 -o BatchMode=yes \
-      "$yaml_path" "${HA_USER}@${HA_HOST}:${HA_TARGET_DIR}/${target_name}"; then
-  err "scp to HA failed. Verify SSH key access:"
+# HAOS port-22 SSH has no sftp-server; pipe via stdin to `cat` instead.
+# Write to a hidden tmpfile first, then atomic mv — a partial transfer
+# (network blip, ctrl-C) can't replace a working dashboard with garbage.
+if ! ssh -p "$HA_SSH_PORT" -o ConnectTimeout=5 -o BatchMode=yes \
+        "${HA_USER}@${HA_HOST}" \
+        "set -e; tmp='${HA_TARGET_DIR}/.${target_name}.preview-tmp'; cat > \"\$tmp\" && mv \"\$tmp\" '${HA_TARGET_DIR}/${target_name}'" \
+        < "$yaml_path"; then
+  err "ssh-stdin push to HA failed. Verify SSH access:"
   err "  ssh -p ${HA_SSH_PORT} ${HA_USER}@${HA_HOST} 'echo ok'"
   err "If you haven't set up HAOS SSH yet, see HA docs:"
   err "  https://developers.home-assistant.io/docs/operating-system/debugging"


### PR DESCRIPTION
Fix-forward for #316: kiosk-preview's `scp` fails on HAOS root SSH because there's no sftp-server, and HA's `/config` maps to `/homeassistant` on the HAOS host (not `/config` or `/mnt/data/...`).

## Origin

User report after #316 merged:
\`\`\`
❯ kiosk-host/kiosk-preview --open
→ pushing → root@homeassistant.local:/config/dashboards/kiosk.yaml
scp: Connection closed
\`\`\`

## Diagnosis

- **HAOS port 22** is a BusyBox shell on the host filesystem. It happily runs `echo`, `cat`, `find`, `mv`, etc., but there's no `sftp-server` binary, so `scp` (which uses SFTP under the hood) closes the connection.
- **The official Terminal & SSH add-on** (`core_ssh`, listens on 22222) *would* provide sftp-server, but it's not installed on this instance. I tried `hassio.addon_install` via the MCP service call; it returned 502 and the add-on stayed `installed: false`.
- **The host path** for HA Core's `/config` is `/homeassistant/` on HAOS — found via `find / -maxdepth 5 -name homeassistant -type d`. Not `/mnt/data/supervisor/...` (that layout is older).

## Fix

Replace `scp` with `ssh ... 'cat > /homeassistant/dashboards/.<name>.preview-tmp && mv ... <name>'`. Atomic-mv pattern survives partial transfers (network blip, ctrl-C → tmpfile dangles, working dashboard untouched). Uses only shell builtins available in HAOS BusyBox — no add-on, no LLAT, no new credentials needed.

Filename validation tightened: `^[a-zA-Z0-9._-]+\.yaml$` is enforced before the ssh command is built, defense-in-depth against argument-injection should someone ever pass a weird path.

## Test plan

- [x] `bash -n` and `shellcheck` clean
- [x] **Push smoke test (no F5, no display flicker):**
      `ssh -p 22 root@homeassistant.local "set -e; tmp='/homeassistant/dashboards/.kiosk.yaml.preview-tmp'; cat > \"\$tmp\" && mv ..." < dashboards/kiosk.yaml`
      → 470ms wall-clock, remote md5 matches local md5 byte-for-byte
- [ ] Post-merge: full loop end-to-end with `kiosk-host/kiosk-preview --open` — should print step timings and produce a fresh PNG matching the live monitor