### PR TITLE
Codify the kiosk dashboard live design loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ to them when implementing:
 | `dashboards/README.md` | All four Lovelace dashboards (Home, Kiosk, Homelab Status, Command Deck) |
 | `themes/README.md` | Noctis Kiosk theme, kiosk_polish tokens |
 | `scripts/README.md` | gitops-sync.sh, ha-context-dump.sh, Script auth conventions |
-| `kiosk-host/README.md` | Chromium kiosk launcher running on pve2, its gitops pull loop, bootstrap recipe |
+| `kiosk-host/README.md` | Chromium kiosk launcher running on pve2, gitops pull loop, bootstrap recipe, **live preview iteration loop + design session protocol** |
 | `context/README.md` | What each `context/*.json` file is |
 | `docs/` | Long-form design notes, migration write-ups |
 
@@ -183,6 +183,46 @@ in `kiosk-host/README.md`. The kiosk dashboard YAML itself
 (`dashboards/kiosk.yaml`) is still deployed by the HA-side loop above —
 the pve2 loop only handles the display host's runner script and
 systemd unit, not the dashboard content it points at.
+
+---
+
+## Live Design Loop (kiosk dashboard)
+
+For non-trivial kiosk dashboard work, prefer the **live preview loop**
+over the slower edit→commit→wait-for-gitops cycle:
+
+```
+edit dashboards/kiosk.yaml  →  kiosk-host/kiosk-preview --open
+                                  ↳ 4–8s: push to HA, F5 Chromium,
+                                    wait for stable frame, snapshot
+                                    back to ./kiosk-preview-<UTC>.png
+                                  ↳ discuss the captured frame
+                                  ↳ repeat
+                                  ↳ commit at logical checkpoints (PR
+                                    + auto-merge, one coherent change
+                                    per PR)
+```
+
+The push goes via `ssh -p 22 root@homeassistant.local 'cat > /homeassistant/dashboards/<name>'`
+(HAOS-host SSH, NOT scp — HAOS port 22 has no sftp-server). The
+HA-side gitops-sync resets `/homeassistant/dashboards/` to `origin/main`
+every 5 min, so each preview survives whatever's left in the current
+poll window. That's the discipline: iterate freely in-session, commit
+when a coherent unit is ready, let gitops make it permanent.
+
+**Live-state caveat.** The captured PNG reflects current entity values
+(alarm color, current Sonos art, "Unavailable" labels on cards whose
+entities are genuinely down right now). If a frame surprises you, look
+at the entity, not the dashboard.
+
+**When to skip the loop:** trivial copy edits (just commit), additions
+that reference entities not yet in `context/entities.json` (refresh
+context first), or changes to `extra_module_url` JS resources (need
+the optional HA token for `lovelace.reload_resources`).
+
+Full protocol + setup (HAOS SSH key, xdotool on pve2, optional HA
+token) in `kiosk-host/README.md` § "Live preview iteration" and
+§ "Design session protocol".
 
 ---
 

--- a/kiosk-host/README.md
+++ b/kiosk-host/README.md
@@ -139,9 +139,15 @@ Under the hood, each call:
 4. `ssh -J root@pve.local root@pve2 'DISPLAY=:0 xdotool key F5'` to
    refresh Chromium on the household monitor. **Requires** `xdotool`
    on pve2 (in the bootstrap apt-install list).
-5. Sleeps ~1.5s for Chromium to repaint, then `curl`s the snapshot
+5. Waits for a **stable** rendered frame, then `curl`s the snapshot
    server (`http://pve2.local:9999/`) into
-   `./kiosk-preview-<UTC-timestamp>.png`.
+   `./kiosk-preview-<UTC-timestamp>.png`. Stability heuristic: short
+   initial wait (1.2s), then poll until two consecutive PNG sizes are
+   within 1% of each other (or a 6s cap is hit). md5 equality won't
+   work — clock seconds + small dashboard animations make settled
+   frames vary in pixels but cluster within ~0.2% of size, while a
+   mid-paint skeleton is typically 50–75% smaller than a settled
+   frame. Typical end-to-end loop is 4–8s.
 
 ### Things to know
 
@@ -166,6 +172,56 @@ Under the hood, each call:
   dashboard YAML edits — see step 3 above), put a long-lived access
   token at `~/.config/kiosk-preview/ha-token` (mode `0600`). Without
   it the call is skipped and the tool still works for dashboard YAML.
+
+### Design session protocol
+
+For non-trivial kiosk dashboard work (layout changes, theming, new
+cards, alarm-state polish), use this loop instead of the slower
+edit→commit→wait-5min-for-gitops cycle:
+
+1. **Start clean.** Branch off `main`:
+   ```bash
+   git checkout main && git pull && git checkout -b kiosk-<topic>
+   ```
+2. **Iterate.** Edit `dashboards/kiosk.yaml`, run
+   `kiosk-host/kiosk-preview --open`, look at the PNG, discuss, repeat.
+   Each loop is 4–8s.
+3. **Checkpoint at logical units.** When a coherent change is ready
+   (one card refactored, one theme tweak landed, one alarm-state polish
+   complete), commit + PR + arm auto-merge with the usual repo flow.
+   Don't pile multiple unrelated changes into one PR — small PRs are
+   easier to revert if a downstream issue surfaces.
+4. **Mind the gitops clobber.** Every 5 min, the HA-side gitops-sync
+   resets `/homeassistant/dashboards/` to `origin/main`. While
+   iterating you have whatever's left in the current poll window. If
+   you want a YAML change that survives past the next poll, commit
+   and let auto-merge land it.
+
+**Live-state caveats** (look at the captured PNG with these in mind):
+
+- Cards labeled *Unavailable* reflect the actual current entity
+  states, not a kiosk bug. If you're surprised, check the upstream
+  device/integration; consider whether the dashboard should hide vs.
+  show unavailable entities for that card type.
+- The clock and Sonos art are dynamic — comparing PNGs from runs a
+  few seconds apart won't be pixel-identical even on an unchanged
+  dashboard.
+- The snapshot captures the **live** kiosk session (alarm color,
+  current Sonos coordinator, last media played, current weather). If
+  a hero card looks empty, the entity may genuinely have no value
+  right now — try again later or simulate the state via the HA UI.
+
+**When NOT to use this loop:**
+
+- Trivial copy edits — too much friction; just commit.
+- Adding cards that reference entities not yet in
+  `context/entities.json` — `kiosk-preview` only refreshes Lovelace;
+  HA must already know about the entity. Refresh the context snapshot
+  first (`input_button.ha_context_dump_now`) and let the
+  context-snapshot PR land.
+- Theme or `extra_module_url` changes — those need
+  `lovelace.reload_resources`, which requires the optional HA token
+  (see above).
 
 ## Snapshot server (network endpoint for HA)
 

--- a/kiosk-host/kiosk-preview
+++ b/kiosk-host/kiosk-preview
@@ -38,7 +38,14 @@ readonly HA_TARGET_DIR="/homeassistant/dashboards"
 readonly KIOSK_JUMP="root@pve.local"
 readonly KIOSK_HOST="root@pve2"
 readonly KIOSK_SNAPSHOT_URL="http://pve2.local:9999/"
-readonly REFRESH_WAIT_SEC=1.5
+# Give Chromium an initial beat before polling for a stable frame.
+# Too short → first poll catches mid-paint; too long → wasted seconds.
+readonly INITIAL_WAIT_SEC=1.2
+# Stability poll: after the initial wait, take snapshots at this interval
+# and stop as soon as two consecutive frames match by md5. Caps total
+# post-F5 wait at INITIAL_WAIT_SEC + MAX_STABILITY_SEC.
+readonly STABILITY_INTERVAL_SEC=0.7
+readonly MAX_STABILITY_SEC=6.0
 
 usage() {
   sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
@@ -144,21 +151,58 @@ fi
 refresh_ms=$(awk "BEGIN { printf \"%.0f\", ($EPOCHREALTIME - $refresh_start) * 1000 }")
 ok "F5 sent (${refresh_ms}ms)"
 
-# Chromium needs a beat to re-render. Tune REFRESH_WAIT_SEC at the top if
-# the snapshot consistently catches a stale or mid-paint frame.
-sleep "$REFRESH_WAIT_SEC"
-
-# --- 4. Snapshot -----------------------------------------------------------
+# --- 4. Snapshot (with frame-stability detection) --------------------------
+# After F5, Chromium repaints over 1–4s depending on dashboard complexity
+# and entity-stream readiness. A fixed sleep risks capturing a half-painted
+# skeleton. Instead: short initial wait, then poll until two consecutive
+# snapshots are within STABILITY_SIZE_PCT% of each other in size. (md5 won't
+# work — clock seconds + minor animations make pixel-stable comparison fail
+# even on a fully-rendered dashboard; settled frames cluster within ~0.2%
+# of size while a mid-paint frame is typically 50–75% smaller.)
+readonly STABILITY_SIZE_PCT=1.0
 if (( snapshot == 1 )); then
   outfile="kiosk-preview-${ts}.png"
-  step "capturing snapshot → ${outfile}"
+  step "capturing snapshot → ${outfile} (waiting for stable frame)"
   snap_start=$EPOCHREALTIME
-  if ! curl -fsS --max-time 8 -o "$outfile" "$KIOSK_SNAPSHOT_URL"; then
-    err "snapshot fetch from ${KIOSK_SNAPSHOT_URL} failed"
-    exit 1
-  fi
+  sleep "$INITIAL_WAIT_SEC"
+  prev_size=0
+  attempts=0
+  stable=0
+  poll_tmp=$(mktemp --suffix=.png)
+  trap 'rm -f "$poll_tmp"' EXIT
+  while :; do
+    attempts=$((attempts + 1))
+    if ! curl -fsS --max-time 8 -o "$poll_tmp" "$KIOSK_SNAPSHOT_URL"; then
+      err "snapshot fetch from ${KIOSK_SNAPSHOT_URL} failed"
+      exit 1
+    fi
+    cur_size=$(stat -c%s "$poll_tmp")
+    if (( prev_size > 0 )); then
+      # |Δ size| / max(prev, cur) * 100 < STABILITY_SIZE_PCT → settled
+      stable_flag=$(awk -v a="$prev_size" -v b="$cur_size" -v pct="$STABILITY_SIZE_PCT" \
+        'BEGIN { d = (a>b)?(a-b):(b-a); m = (a>b)?a:b; print (d / m * 100 < pct) ? 1 : 0 }')
+      if [[ "$stable_flag" == "1" ]]; then
+        stable=1
+        break
+      fi
+    fi
+    prev_size=$cur_size
+    elapsed=$(awk "BEGIN { printf \"%.2f\", $EPOCHREALTIME - $snap_start }")
+    if awk "BEGIN { exit !($elapsed > $MAX_STABILITY_SEC) }"; then
+      break
+    fi
+    sleep "$STABILITY_INTERVAL_SEC"
+  done
+  mv "$poll_tmp" "$outfile"
+  trap - EXIT
   snap_ms=$(awk "BEGIN { printf \"%.0f\", ($EPOCHREALTIME - $snap_start) * 1000 }")
-  ok "captured ${outfile} (${snap_ms}ms, $(stat -c%s "$outfile") bytes)"
+  final_size=$(stat -c%s "$outfile")
+  if (( stable == 1 )); then
+    ok "captured ${outfile} (${snap_ms}ms, ${attempts} polls, ${final_size} bytes)"
+  else
+    printf '\033[33m!\033[0m captured %s after %s polls but frame did not stabilize before %ss cap — paint may still be in progress (size=%s)\n' \
+      "$outfile" "$attempts" "$MAX_STABILITY_SEC" "$final_size"
+  fi
 fi
 
 total_ms=$(awk "BEGIN { printf \"%.0f\", ($EPOCHREALTIME - $total_start) * 1000 }")


### PR DESCRIPTION
Captures the iteration workflow we just developed as documented process, plus fixes the mid-paint capture bug that the first live run of kiosk-preview surfaced.

## Origin

> ok codify this loop as part of our design process. we should be able to make dash changes live, confirm collaboratively, and codify at logical checkpoints

After landing #316 / #317, the first end-to-end run captured a half-painted skeleton — the colored card top-borders without their contents streamed in. We re-grabbed manually and confirmed the loop *can* produce a clean settled frame; this PR makes that the default and writes down the workflow.

## What's in this PR

**1. Stability detection (the fix).** `kiosk-host/kiosk-preview` no longer uses a fixed `sleep 1.5; curl`. New flow:

```
sleep 1.2  # initial wait
loop:
  curl snapshot → tmpfile
  if |size_delta| / max(prev,cur) * 100 < 1.0%:  → stable, break
  prev = cur; sleep 0.7
  if total > 6s: break (cap hit, log warning)
```

md5 equality fails because clock seconds + small dashboard animations make pixel-stable comparison fail even on a settled display. But settled frames cluster within **~0.2%** of each other in PNG size (verified: 526768 / 526806 / 526651 / 526650 / 526530 / 526073), while a mid-paint frame is **50–75% smaller** than settled (verified: 141701 bytes mid-paint vs ~525000 settled). So "two consecutive frames within 1%" is a clean signal.

Live-verified after the fix: 5 polls, 524793 bytes, frame matches the household monitor.

**2. Codified protocol.** Two doc updates:

- `kiosk-host/README.md` — new "Design session protocol" subsection under "Live preview iteration". Branch off main → iterate with `kiosk-preview --open` → commit at logical checkpoints. Includes:
  - Live-state caveats (cards labeled "Unavailable" reflect real entity state — look at the entity, not the dashboard)
  - When NOT to use the loop (trivial edits, new-entity cards, `extra_module_url` JS changes)
  - The 5-min gitops clobber as deliberate discipline
- `CLAUDE.md` — new top-level "Live Design Loop (kiosk dashboard)" section between the parallel-loop and PR Authoring. ASCII flow diagram, the live-state caveat, "when to skip", and a pointer to the kiosk-host README protocol. Subdir-README index row updated to mention the protocol.

## Test plan

- [x] `bash -n` and `shellcheck` clean on the updated script
- [x] **Settled-frame size variance**: 6 back-to-back polls on a stable display showed 526073–526806 bytes (max delta 733 bytes = 0.14%); confirms the 1% threshold is well-calibrated
- [x] **Live run end-to-end** after edits: 8135ms total, 5 polls during snapshot, 524793 byte capture matching the household monitor (clock + Rachel status + Sonos art all coherent)
- [ ] Post-merge: future iterations should consistently land settled frames without manual re-grabs