### PR TITLE
Fix dashboard entity allowlist: prune resolved CyberPower, add unregistered screen-time sensors

### DIFF
--- a/dashboards/entity-allowlist.txt
+++ b/dashboards/entity-allowlist.txt
@@ -14,6 +14,22 @@
 # --- Valid but unregistered (no unique_id) ---
 alarm_control_panel.home_alarm   # YAML-defined manual alarm panel (configuration.yaml)
 
+# Screen-time per-app duration sensors (screen-time.yaml). These have live
+# state (verified ~0.0 h) but no entity-registry entry — they carry no
+# unique_id, so they never appear in context/entities.json. Allowlisted, not
+# pending: a context dump will never resolve them.
+sensor.basement_netflix_today
+sensor.basement_prime_video_today
+sensor.basement_youtube_today
+sensor.office_netflix_today
+sensor.office_prime_video_today
+sensor.office_youtube_today
+sensor.play_room_apple_tv_today
+sensor.play_room_disney_plus_today
+sensor.play_room_netflix_today
+sensor.play_room_prime_video_today
+sensor.play_room_youtube_today
+
 # --- CyberPower UPS (homelab-status.yaml "UPS" section) ---
 # Integration now online — most sensors resolve in the snapshot and were pruned.
 # Only battery_runtime remains absent (entity not exposed by the integration yet).

--- a/dashboards/entity-allowlist.txt
+++ b/dashboards/entity-allowlist.txt
@@ -14,12 +14,9 @@
 # --- Valid but unregistered (no unique_id) ---
 alarm_control_panel.home_alarm   # YAML-defined manual alarm panel (configuration.yaml)
 
-# --- Pending integration: CyberPower UPS (homelab-status.yaml "UPS" section) ---
-sensor.cyberpower_status_data
-sensor.cyberpower_load
-sensor.cyberpower_input_voltage
-sensor.cyberpower_output_voltage
-sensor.cyberpower_battery_charge
+# --- CyberPower UPS (homelab-status.yaml "UPS" section) ---
+# Integration now online — most sensors resolve in the snapshot and were pruned.
+# Only battery_runtime remains absent (entity not exposed by the integration yet).
 sensor.cyberpower_battery_runtime
 
 # --- Pending integration: cpitzi/prompts GitHub sensors (homelab-status.yaml) ---


### PR DESCRIPTION
## Origin

Started as a follow-up to PR #321's review (the `Dashboard Entities` check noted resolved CyberPower entries could be pruned), then grew while babysitting that check's failures.

> yes, both

Babysitting #321/#323 surfaced the real cause of the `screen-time.yaml` failure: it is **not** a stale snapshot. PR #322 (a brand-new context dump) *also* failed `Dashboard Entities` on the same sensors, and `ha_get_entity` returns "Entity not found" for them despite live state — they're valid-but-unregistered (no `unique_id`), so they never enter `context/entities.json` and no dump can fix them. The fix is to allowlist them.

## Changes to `dashboards/entity-allowlist.txt`

**Pruned** — CyberPower UPS integration is online; these now resolve in the snapshot and were flagged removable by the checker:
- `sensor.cyberpower_status_data`, `…_load`, `…_input_voltage`, `…_output_voltage`, `…_battery_charge`
- `sensor.cyberpower_battery_runtime` **kept** (still not exposed by the integration).

**Added** — 11 screen-time per-app duration sensors referenced by `screen-time.yaml`, verified to have live state (~`0.0 h`) but no registry entry. Filed under "valid but unregistered" alongside `alarm_control_panel.home_alarm`:
- `sensor.{basement,office}_{netflix,prime_video,youtube}_today`
- `sensor.play_room_{apple_tv,disney_plus,netflix,prime_video,youtube}_today`

## Verification

`python3 scripts/check-dashboard-entities.py --strict` against all five dashboards:

```
command-deck.yaml:   OK (44 references)
home.yaml:           OK (55 references)
homelab-status.yaml: OK (79 references)
kiosk.yaml:          OK (42 references)
screen-time.yaml:    OK (17 references)
```

This makes the `Dashboard Entities` check green repo-wide — it was previously red on `main` (and on #321, #322, #323) due to the unregistered screen-time sensors.

https://claude.ai/code/session_01En6RSbdHwHDqG6Zy3h92Tq