### PR TITLE
Add debounced context dump on entity/device/area registry change

### DIFF
--- a/context/README.md
+++ b/context/README.md
@@ -25,5 +25,9 @@ pipeline (see `.github/workflows/ha-context-sync.yml`).
 
 - **Manual:** press `input_button.ha_context_dump_now` in the HA UI.
 - **Periodic:** every 6 hours via the `ha_context_dump_periodic` automation.
+- **On registry change (debounced):** the `ha_context_dump_on_registry_change`
+  automation fires a dump 15 minutes after the last entity/device/area
+  registry change (`mode: restart` coalesces a burst into one dump), so the
+  snapshot tracks material changes without waiting for the 6-hour cycle.
 
 Snapshots that match the current `main` content produce no PR (silent no-op).

--- a/packages/ha_context_dump.yaml
+++ b/packages/ha_context_dump.yaml
@@ -29,3 +29,25 @@ automation:
         hours: "/6"
     actions:
       - action: shell_command.ha_context_dump
+
+  # Event-driven, debounced. Registry changes (entities/devices/areas
+  # created, removed, or renamed) make context/ stale until the next 6h
+  # snapshot — that lag is what surfaces as "entity not found" against the
+  # snapshot. mode:restart resets the 15-minute timer on every new registry
+  # event, so a burst of changes coalesces into a single dump fired 15 min
+  # after the LAST change. Fires on registry events only (not state changes),
+  # so normal operation never triggers it. The 6h periodic dump above remains
+  # as a backstop. The dump script is a no-op (no PR) when nothing changed.
+  - id: ha_context_dump_on_registry_change
+    alias: "Context Dump: Debounced on registry change"
+    mode: restart
+    triggers:
+      - trigger: event
+        event_type: entity_registry_updated
+      - trigger: event
+        event_type: device_registry_updated
+      - trigger: event
+        event_type: area_registry_updated
+    actions:
+      - delay: "00:15:00"
+      - action: shell_command.ha_context_dump


### PR DESCRIPTION
## Origin

Follow-up from the "should we dump more frequently / after any material change?" discussion while babysitting the `Dashboard Entities` CI failures (PRs #321/#322/#323). Conclusion: event-driven beats high-frequency polling — polling adds PR/CI churn while idle; the drift that actually bites is registry change (new/renamed/removed entities), which fires concrete events we can hook.

> ok [implement the event-driven debounced context dump as a follow-up PR]

## Change

Adds a third automation to `packages/ha_context_dump.yaml`:

```yaml
- id: ha_context_dump_on_registry_change
  alias: "Context Dump: Debounced on registry change"
  mode: restart
  triggers:
    - trigger: event
      event_type: entity_registry_updated
    - trigger: event
      event_type: device_registry_updated
    - trigger: event
      event_type: area_registry_updated
  actions:
    - delay: "00:15:00"
    - action: shell_command.ha_context_dump
```

**How the debounce works:** `mode: restart` cancels the in-flight run on each new trigger, so every registry event restarts the 15-minute `delay`. A burst of changes (e.g. adding an integration that registers 30 entities) coalesces into a **single** dump fired 15 min after the *last* change.

**Why it's quiet:**
- Triggers on **registry** events only (create/remove/rename of entities, devices, areas) — not state changes — so routine operation never fires it.
- Calls `shell_command.ha_context_dump` directly (like the periodic dump), not the button, so no persistent-notification spam.
- The dump script is a no-op (no branch/PR) when content matches `main`.
- No feedback loop: the dump reads registries and writes to git/`context/`; it doesn't mutate the registry.

The existing 6-hour `ha_context_dump_periodic` stays as a backstop. `context/README.md` refresh-cadence list updated to document the new trigger.

## Validation

- `yamllint -c .yamllint.yml packages/ha_context_dump.yaml` → PASS
- YAML parses; three automations present (`…_trigger`, `…_periodic`, `…_on_registry_change`)
- Skill consulted (`references/automation-patterns.md`): confirms `mode: restart` as the timer-reset/debounce idiom, native `event` triggers, and `entity_id`/service targeting.

15-minute window is a balance (coalesce bursts vs. freshness) and is trivially tunable.

https://claude.ai/code/session_01En6RSbdHwHDqG6Zy3h92Tq

---
_Generated by [Claude Code](https://claude.ai/code/session_01En6RSbdHwHDqG6Zy3h92Tq)_