### PR TITLE
Extract + test the sync-workflow input validators

### DIFF
--- a/.github/workflows/ha-context-sync.yml
+++ b/.github/workflows/ha-context-sync.yml
@@ -18,22 +18,22 @@ jobs:
   open-context-pr:
     runs-on: ubuntu-latest
     steps:
-      - name: Validate dispatch payload
-        env:
-          BRANCH: ${{ github.event.client_payload.branch }}
-        run: |
-          if [[ ! "$BRANCH" =~ ^context-sync/[0-9]{8}-[0-9]{6}$ ]]; then
-            echo "::error::Invalid branch name pattern: $BRANCH"
-            echo "::error::Expected: context-sync/YYYYMMDD-HHMMSS"
-            exit 1
-          fi
-          echo "Branch validated: $BRANCH"
-
       - name: Checkout main
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.HA_SYNC_PAT }}
           fetch-depth: 0
+
+      - name: Validate dispatch payload
+        env:
+          BRANCH: ${{ github.event.client_payload.branch }}
+        run: |
+          if ! scripts/validate-context-branch.sh "$BRANCH"; then
+            echo "::error::Invalid branch name pattern: $BRANCH"
+            echo "::error::Expected: context-sync/YYYYMMDD-HHMMSS"
+            exit 1
+          fi
+          echo "Branch validated: $BRANCH"
 
       - name: Verify branch exists on remote
         env:

--- a/.github/workflows/ha-version-sync.yml
+++ b/.github/workflows/ha-version-sync.yml
@@ -11,20 +11,20 @@ jobs:
   sync-version:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.HA_SYNC_PAT }}
+
       - name: Validate version payload
         env:
           RAW_VERSION: ${{ github.event.client_payload.version }}
         run: |
-          if ! printf '%s' "$RAW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(b[0-9]+)?$'; then
+          if ! VERSION=$(scripts/validate-ha-version.sh "$RAW_VERSION"); then
             echo "::error::Version '${RAW_VERSION}' failed format check." \
               "Expected: YYYY.MM.N or YYYY.MM.NbN. Dev builds not supported — update regex to widen."
             exit 1
           fi
-          echo "VERSION=$RAW_VERSION" >> "$GITHUB_ENV"
-
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.HA_SYNC_PAT }}
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - name: Compare versions
         id: compare

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,6 +84,27 @@ config but does not duplicate the registry entry. The git-managed
 (`/dashboard-home/home` from YAML, `/home-ui` from storage) until cutover
 is decided.
 
+## `validate-ha-version.sh` / `validate-context-branch.sh`
+
+Tiny input validators used by the sync workflows, factored out of inline
+workflow YAML so the regexes have a single source of truth that CI can test.
+
+- `validate-ha-version.sh <version>` — accepts a stable (`YYYY.MM.N`) or beta
+  (`YYYY.MM.NbN`) HA version, rejects everything else; echoes the validated
+  version on success. Called by `ha-version-sync.yml` before it commits
+  `.ha-version`.
+- `validate-context-branch.sh <branch>` — accepts only
+  `context-sync/YYYYMMDD-HHMMSS`. The branch is an externally-supplied
+  `repository_dispatch` payload that `ha-context-sync.yml` turns into a PR, so
+  this is a trust boundary. Echoes the branch on success.
+
+Both expose a sourceable function (`validate_ha_version` /
+`validate_context_branch`) guarded by `BASH_SOURCE == $0`, exercised by
+`tests/validate_inputs.bats`. Because the workflows now call these scripts, they
+checkout the repo *before* validating the payload (an early checkout for an
+invalid payload is the only behavioral change; the payload isn't used in
+checkout, so there's no security impact).
+
 ## Script auth conventions
 
 Three conventions learned the hard way during context-sync work. Future scripts

--- a/scripts/validate-context-branch.sh
+++ b/scripts/validate-context-branch.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Validate a context-sync branch name: context-sync/YYYYMMDD-HHMMSS. This is the
+# externally-supplied repository_dispatch payload that ha-context-sync.yml turns
+# into a PR, so the pattern is a trust boundary — reject anything that isn't the
+# exact timestamped form. On success the branch is echoed to stdout; on failure
+# a message is written to stderr and the exit code is non-zero.
+#
+# Source of truth for the regex gating ha-context-sync.yml. The bats suite in
+# tests/ sources this file (the BASH_SOURCE == $0 guard keeps the CLI body from
+# running) and exercises validate_context_branch directly.
+#
+# Usage: validate-context-branch.sh <branch>
+set -euo pipefail
+
+readonly CONTEXT_BRANCH_RE='^context-sync/[0-9]{8}-[0-9]{6}$'
+
+validate_context_branch() {
+  [[ "$1" =~ $CONTEXT_BRANCH_RE ]]
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  branch="${1-}"
+  if ! validate_context_branch "$branch"; then
+    echo "Invalid branch name pattern: '${branch}'." \
+         "Expected: context-sync/YYYYMMDD-HHMMSS" >&2
+    exit 1
+  fi
+  printf '%s\n' "$branch"
+fi

--- a/scripts/validate-ha-version.sh
+++ b/scripts/validate-ha-version.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Validate an HA version string. Accepts a stable release (YYYY.MM.N) or a
+# beta (YYYY.MM.NbN); rejects dev builds and anything else. On success the
+# validated version is echoed to stdout so callers can capture it; on failure
+# a message is written to stderr and the exit code is non-zero.
+#
+# Source of truth for the regex gating ha-version-sync.yml. The bats suite in
+# tests/ sources this file (the BASH_SOURCE == $0 guard keeps the CLI body from
+# running) and exercises validate_ha_version directly.
+#
+# Usage: validate-ha-version.sh <version>
+set -euo pipefail
+
+# Assigned to a variable and used unquoted in =~ — the portable way to apply a
+# regex without quoting it into a literal string.
+readonly HA_VERSION_RE='^[0-9]+\.[0-9]+\.[0-9]+(b[0-9]+)?$'
+
+validate_ha_version() {
+  [[ "$1" =~ $HA_VERSION_RE ]]
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  version="${1-}"
+  if ! validate_ha_version "$version"; then
+    echo "Version '${version}' failed format check." \
+         "Expected: YYYY.MM.N or YYYY.MM.NbN. Dev builds not supported." >&2
+    exit 1
+  fi
+  printf '%s\n' "$version"
+fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -62,6 +62,14 @@ bats tests/
   YAML entity with no `unique_id`) or pending an integration that isn't set up
   yet; prune it as the checker's "can be removed" note directs.
 
+- **`validate_inputs.bats`** — tests `scripts/validate-ha-version.sh` and
+  `scripts/validate-context-branch.sh`, the regex validators the sync workflows
+  use to gate what gets auto-committed (`.ha-version`) and which externally-
+  supplied `repository_dispatch` branch becomes a PR. Covers accept/reject cases
+  (dev builds, prefixes, partials, wrong separators, path traversal, trailing
+  whitespace, injection-shaped input) plus the CLI exit-code/stdout contract the
+  workflows depend on.
+
 ## Making a script testable
 
 Scripts that self-execute at the bottom should guard that call so the file can

--- a/tests/validate_inputs.bats
+++ b/tests/validate_inputs.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+#
+# Tests for the two sync-workflow input validators:
+#   scripts/validate-ha-version.sh     (gates ha-version-sync.yml)
+#   scripts/validate-context-branch.sh (gates ha-context-sync.yml)
+#
+# These regexes guard what gets auto-committed (.ha-version) and which
+# externally-supplied repository_dispatch branch gets turned into a PR — a trust
+# boundary. They previously lived only inline in workflow YAML and ran only in
+# production. The suite sources each script (the BASH_SOURCE == $0 guard keeps
+# the CLI body from executing) to exercise the validator functions, and also
+# drives the scripts as CLIs to lock in the exit code + stdout contract the
+# workflows rely on.
+
+setup() {
+  HA_VER="${BATS_TEST_DIRNAME}/../scripts/validate-ha-version.sh"
+  CTX_BR="${BATS_TEST_DIRNAME}/../scripts/validate-context-branch.sh"
+  # shellcheck source=../scripts/validate-ha-version.sh
+  source "$HA_VER"
+  # shellcheck source=../scripts/validate-context-branch.sh
+  source "$CTX_BR"
+}
+
+# --- validate_ha_version ---------------------------------------------------
+
+@test "ha version: accepts stable releases and betas" {
+  for v in 2026.5.1 2024.12.0 2026.6.0b3 1.0.0; do
+    run validate_ha_version "$v"
+    [ "$status" -eq 0 ] || { echo "should accept: $v"; return 1; }
+  done
+}
+
+@test "ha version: rejects dev builds, prefixes, partials, and junk" {
+  for v in "2026.5.1-dev" "v2026.5.1" "2026.5" "2026.5.1b" "1.2.3.4" \
+           "2026.5.1 " " 2026.5.1" "2026.5.1; rm -rf /" "" "2026.05.1a"; do
+    run validate_ha_version "$v"
+    [ "$status" -ne 0 ] || { echo "should reject: '$v'"; return 1; }
+  done
+}
+
+@test "ha version CLI: valid input echoes version and exits 0" {
+  run "$HA_VER" "2026.5.1"
+  [ "$status" -eq 0 ]
+  [ "$output" = "2026.5.1" ]
+}
+
+@test "ha version CLI: invalid input exits non-zero with a message" {
+  run "$HA_VER" "2026.5.1-dev"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed format check"* ]]
+}
+
+# --- validate_context_branch -----------------------------------------------
+
+@test "context branch: accepts the timestamped form" {
+  run validate_context_branch "context-sync/20260601-191918"
+  [ "$status" -eq 0 ]
+}
+
+@test "context branch: rejects wrong shapes, separators, and traversal" {
+  for b in "context-sync/2026601-191918" "context-sync/20260601_191918" \
+           "context-sync/20260601-1919" "context-sync/20260601-191918extra" \
+           "main" "../context-sync/20260601-191918" \
+           "context-sync/20260601-191918/x" ""; do
+    run validate_context_branch "$b"
+    [ "$status" -ne 0 ] || { echo "should reject: '$b'"; return 1; }
+  done
+}
+
+@test "context branch CLI: valid input echoes branch and exits 0" {
+  run "$CTX_BR" "context-sync/20260601-191918"
+  [ "$status" -eq 0 ]
+  [ "$output" = "context-sync/20260601-191918" ]
+}
+
+@test "context branch CLI: invalid input exits non-zero with a message" {
+  run "$CTX_BR" "main"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid branch name pattern"* ]]
+}


### PR DESCRIPTION
Closes the last open gap (**#3**) from the test-coverage analysis.

## Origin

Follow-on to the analysis. The user asked to take on #3 after rebasing onto the latest `main`, and signed off on the **"extract to scripts + rewire the workflows to checkout-first"** approach (over a no-rewiring, test-only alternative).

## Problem

Two regexes gated production behaviour but lived only inline in workflow YAML and ran only in production — never tested:
- `ha-version-sync.yml`: `^[0-9]+\.[0-9]+\.[0-9]+(b[0-9]+)?$` — gates the commit to `.ha-version`.
- `ha-context-sync.yml`: `^context-sync/[0-9]{8}-[0-9]{6}$` — gates which **externally-supplied** `repository_dispatch` branch gets turned into a PR. That's a trust boundary.

## Change

Factored each validator into a small, sourceable script with the regex as the single source of truth:

| Script | Accepts | Used by |
|---|---|---|
| `scripts/validate-ha-version.sh` | `YYYY.MM.N` / `YYYY.MM.NbN` (echoes the version) | `ha-version-sync.yml` |
| `scripts/validate-context-branch.sh` | `context-sync/YYYYMMDD-HHMMSS` (echoes the branch) | `ha-context-sync.yml` |

Both workflows now **checkout before validating** and call the script. The only behavioural change is an early checkout for an invalid payload — the payload isn't used in checkout, so there's no security impact, and the `::error::` annotations are preserved verbatim.

`tests/validate_inputs.bats` (8 cases) exercises both validators: accept cases plus rejects for dev builds, prefixes, partials, wrong separators, path traversal (`../`), trailing whitespace, and injection-shaped input (`2026.5.1; rm -rf /`), plus the CLI exit-code/stdout contract the workflows depend on.

## Verification

`bats tests/` → **39/39** (31 prior + 8 new). `shellcheck scripts/*.sh` clean (both new scripts are `100755`). `yamllint -c .yamllint.yml .github/workflows/` clean. Validators spot-checked end-to-end on the CLI for every accept/reject case above.

## Coverage status

With this merged, all of the analysis's proposed gaps are implemented: ShellCheck, the `apply_reload` routing tests, context-dump transform tests, `!secret` coverage, ESPHome config validation, the dashboard entity-reference gate, and now the sync-workflow validators — a 39-test bats suite plus four CI gates on top of the original YAML/check-config/review gates.

> Reminder from #277, still worth a glance: the `homelab-status.yaml` battery card I repointed from the (nonexistent) "Sonos Office" battery to `sensor.office_switch_battery` — confirm that's the device you meant.

https://claude.ai/code/session_014UUn1yZ1E1LG6XfuBAWfQa

---
_Generated by [Claude Code](https://claude.ai/code/session_014UUn1yZ1E1LG6XfuBAWfQa)_