### PR TITLE
Rename office Sonos to media_player.office and dedupe phantom cards

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -145,13 +145,6 @@ template:
              and state_attr('media_player.master_bedroom', 'group_members') is not none
              and state_attr('media_player.master_bedroom', 'group_members')[0] == 'media_player.master_bedroom' }}
 
-      - name: "Sonos Basement Leader"
-        unique_id: sonos_basement_leader
-        state: >
-          {{ is_state('media_player.basement', 'playing')
-             and state_attr('media_player.basement', 'group_members') is not none
-             and state_attr('media_player.basement', 'group_members')[0] == 'media_player.basement' }}
-
       - name: "Sonos Roam Leader"
         unique_id: sonos_roam_leader
         state: >

--- a/dashboards/command-deck.yaml
+++ b/dashboards/command-deck.yaml
@@ -148,7 +148,4 @@ views:
             entity: media_player.master_bedroom
 
           - type: media-control
-            entity: media_player.basement
-
-          - type: media-control
             entity: media_player.roam_2

--- a/dashboards/home.yaml
+++ b/dashboards/home.yaml
@@ -91,15 +91,6 @@ views:
       - type: conditional
         conditions:
           - condition: state
-            entity: binary_sensor.sonos_basement_leader
-            state: "on"
-        card:
-          type: media-control
-          entity: media_player.basement
-
-      - type: conditional
-        conditions:
-          - condition: state
             entity: binary_sensor.sonos_roam_leader
             state: "on"
         card:

--- a/dashboards/homelab-status.yaml
+++ b/dashboards/homelab-status.yaml
@@ -335,19 +335,6 @@ views:
         square: false
         cards:
           - type: custom:mushroom-template-card
-            primary: Office Switch
-            secondary: "{{ states('sensor.office_switch_battery') }}%"
-            icon: >
-              {% set v = states('sensor.office_switch_battery') | int(100) %}
-              {% if v < 20 %}mdi:battery-10{% elif v < 40 %}mdi:battery-40{% elif v < 60 %}mdi:battery-60{% elif v < 80 %}mdi:battery-80{% else %}mdi:battery{% endif %}
-            icon_color: >
-              {% set v = states('sensor.office_switch_battery') | int(100) %}
-              {% if v < 20 %}red{% elif v < 40 %}amber{% else %}green{% endif %}
-            entity: sensor.office_switch_battery
-            tap_action:
-              action: more-info
-
-          - type: custom:mushroom-template-card
             primary: Basement Kitchen Door
             secondary: "{{ states('sensor.basement_kitchen_door_battery') }}%"
             icon: >

--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -1681,50 +1681,6 @@ views:
                       }
                   card:
                     type: custom:mini-media-player
-                    entity: media_player.basement
-                    name: Basement
-                    artwork: full-cover-fit
-                    info: scroll
-                    hide: { source: true, sound_mode: true, shuffle: true, runtime: true, name: false }
-                    tap_action: { action: more-info }
-                    card_mod:
-                      style: |
-                        ha-card {
-                          background: transparent !important;
-                          border: none !important;
-                          {% set members = state_attr(config.entity, 'group_members') or [] %}
-                          {% if members | length > 1 and members[0] != config.entity %}
-                            opacity: 0.5;
-                            filter: grayscale(0.4);
-                          {% endif %}
-                        }
-                        {% set members = state_attr(config.entity, 'group_members') or [] %}
-                        {% if members | length > 1 and members[0] != config.entity %}
-                        ha-card::after {
-                          content: "↳ {{ state_attr(members[0], 'friendly_name') or 'leader' }}";
-                          position: absolute;
-                          bottom: 6px;
-                          left: 8px;
-                          font-size: 10px;
-                          color: white;
-                          text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-                          z-index: 10;
-                        }
-                        {% endif %}
-
-                - type: custom:mod-card
-                  card_mod:
-                    style: |
-                      ha-card {
-                        height: 100%;
-                        min-height: 100px;
-                        background: var(--kiosk-bg-tile);
-                        border-radius: 6px;
-                        border: none;
-                        overflow: hidden;
-                      }
-                  card:
-                    type: custom:mini-media-player
                     entity: media_player.office
                     name: Office
                     artwork: full-cover-fit


### PR DESCRIPTION
## Origin

Follow-up to the dashboard entity-reference work (#277). The "Office" battery card on Homelab Status was a phantom; investigating it surfaced that the **office Sonos speaker carried the entity_id `media_player.basement`** (a stale adoption name) while a separate **`media_player.office` sat orphaned** (`restored`, no live device). The configs treated them as two speakers — the dead `media_player.office` cards/template showed an always-`unavailable` entity, and the `media_player.basement` cards were really the office speaker.

You asked to fix the office Sonos entity ID (rename + dedupe), explicitly accepting the override of the repo's "entity IDs retain adoption names" convention for this case.

## Live changes already executed (via MCP)

- Removed the orphaned ghost `media_player.office` from the entity registry.
- Renamed `media_player.basement` → `media_player.office` (history preserved). Verified: it's now `paused`, friendly name "Office".

These are `.storage` (runtime) changes, not in git. This PR brings the **git INTENT layer** in line.

## YAML changes

- **configuration.yaml** — drop the now-redundant `sonos_basement_leader` template; `sonos_office_leader` (keyed on `media_player.office`) is now correct.
- **home.yaml / command-deck.yaml** — remove the duplicate "Basement" Sonos cards; the "Office" cards now resolve to the real speaker.
- **kiosk.yaml** — remove the broken "Basement" mini-media-player tile; the media grid now shows 5 real speaker tiles (master bedroom, office, kitchen, dining room, roam). The 2×3 grid has one empty cell now — flagging in case you want to rebalance it in the kiosk design loop.
- Also folds in the agreed removal of the phantom "Office Switch" battery card from homelab-status.yaml.

## ⚠️ Cross-layer ordering note

The **LIVE rename was executed first**, so until this merges and gitops deploys (~5 min), the deployed dashboards/template dangle on the old `media_player.basement` and a few Sonos cards render `unavailable`. **Merging closes that window.** After merge, please press `input_button.ha_context_dump_now` so the `context/` snapshot reconciles. (This PR is exactly the cross-layer-stacking case we were just discussing.)

## Verification

`yamllint` clean; all dashboards parse; the `Dashboard Entities` strict gate passes (`media_player.office` resolves in the snapshot). No remaining `media_player.basement` / `sonos_basement_leader` references in git config. No UI-managed automations/scripts referenced either entity (checked via `ha_deep_search`).

> Note: opened from `claude/office-sonos-rename` rather than the usual `claude/test-coverage-analysis-N2yTA`, because that branch currently holds the open validators PR #327 — this is an unrelated change and shouldn't ride on it.

https://claude.ai/code/session_014UUn1yZ1E1LG6XfuBAWfQa

---
_Generated by [Claude Code](https://claude.ai/code/session_014UUn1yZ1E1LG6XfuBAWfQa)_