### PR TITLE
Codify cross-layer runbook, force-sync helper, and auto-merge convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,12 @@ YAML and letting GitOps redeploy. The *Drift guardrail* subsection under
 *HA Runtime Access* below catalogs which object types live in `.storage/`
 vs YAML.
 
+**Mutating across layers**: a change that spans LIVE, INTENT, and SNAPSHOT
+(e.g. an entity rename) needs a deliberate order, or one layer ends up
+referencing state another doesn't have. The runbook — ordering by change
+type, the rename recipe, and the `scripts/force-sync.sh` window-collapse
+helper — is in `docs/cross-layer-changes.md`.
+
 ---
 
 ## Key Patterns & Conventions
@@ -229,7 +235,19 @@ token) in `kiosk-host/README.md` § "Live preview iteration" and
 ## PR Authoring Without Issues
 
 PR workflow + auto-merge arming protocol is fleet-wide; see
-`~/repos/CLAUDE.md`. Two repo-specific deviations follow.
+`~/repos/CLAUDE.md`. Restated locally below so it survives that file being
+out of context, followed by two repo-specific deviations.
+
+### Always arm auto-merge
+
+Arm **every** PR you open for auto-merge (squash) immediately after creating
+it — `gh pr merge --auto --squash <pr>`, or the `enable_pr_auto_merge` MCP
+tool with `mergeMethod: SQUASH`. If the PR's checks have already gone green by
+then (arming returns "already clean"), merge it directly with squash instead —
+same outcome. Required checks (`YAML Lint`, `check-config`, `claude-review`,
+plus the `Tests` and `ESPHome Config` gates) still gate the merge; auto-merge
+just lands it the instant they pass, with no human round-trip. This is the
+fleet-wide rule restated here precisely so it can't fall out of context.
 
 ### No issues for change dispatch — PRs are the canonical record
 

--- a/docs/cross-layer-changes.md
+++ b/docs/cross-layer-changes.md
@@ -1,0 +1,96 @@
+# Cross-Layer Changes — a stacking runbook
+
+**Status:** Active runbook
+
+A companion to the *Three-Layer State Model* in `CLAUDE.md`. That section
+describes what the three layers **are**; this one describes how to **mutate
+across them** without leaving a window of inconsistency.
+
+## The hazard
+
+A single logical change ("rename the office Sonos", "add a UPS dashboard
+section") fans out across layers that have different latencies and different
+durability:
+
+| Layer | Write path | Propagation | Durable? |
+|---|---|---|---|
+| **LIVE** (`.storage`) | MCP (`ha_set_entity`, `ha_config_set_*`, …) | immediate | no — gitignored runtime state |
+| **INTENT** (git YAML) | PR → merge → `gitops-sync` | ~5 min after merge | yes — source of truth |
+| **SNAPSHOT** (`context/`) | `ha-context-dump.sh` | 6 h, or on `input_button.ha_context_dump_now` | derived, read-only |
+
+The failure mode is **any moment where a consuming layer references state the
+providing layer doesn't have** — yet, or anymore:
+
+- Rename the LIVE entity before INTENT is updated → the deployed dashboards
+  dangle on the old id until the YAML PR merges and deploys.
+- Merge INTENT referencing a new id before the LIVE entity exists → the new
+  YAML refs are broken until you create the entity.
+- Either way, the SNAPSHOT lags both and the `Dashboard Entities` gate reads
+  the (stale) snapshot, not live state.
+
+## Order depends on the change type
+
+There is no single safe order — it depends on whether the change adds, removes,
+or renames the thing other layers consume:
+
+| Change type | Safe order | Why |
+|---|---|---|
+| **Add** (new entity + YAML that uses it) | LIVE → SNAPSHOT → INTENT | the consumer (YAML) must land *after* the entity exists. The `Dashboard Entities` gate enforces this: it checks refs against the snapshot, so YAML can't merge referencing an entity the snapshot doesn't yet have. |
+| **Remove** (drop an entity and its refs) | INTENT → deploy → LIVE | remove the consumers *before* the thing they consume, so nothing ever dangles. |
+| **Modify in place** (retune a value, no id change) | INTENT only | nothing else references a new identity. |
+| **Rename** (atomic remove+add on the LIVE side) | the hard one — see below | the old id vanishes the instant you rename; old and new can't coexist. |
+
+## Rename recipe (the hard case)
+
+HA's entity rename is atomic — there's no moment where both ids exist — so some
+window is unavoidable. Minimise it:
+
+1. **Prepare INTENT first, green but unmerged.** Open the YAML PR with *every*
+   consumer edited (find them with `grep` over git + `ha_deep_search` for
+   UI-managed automations/scripts + a `context/` check). Get CI green.
+   - The `Dashboard Entities` gate will fail because the new id isn't in the
+     snapshot yet. **Temporarily add the new id to
+     `dashboards/entity-allowlist.txt` with a `# pending rename` note** — the
+     allowlist is the coordination ledger for in-flight ids.
+2. **Execute the LIVE change, verify.** `ha_set_entity new_entity_id=…`, then
+   `ha_get_state` to confirm the new id resolves and the old one is gone.
+3. **Merge INTENT and force the deploy.** Merge the green PR, then run
+   `scripts/force-sync.sh` (or call `shell_command.gitops_sync`) instead of
+   waiting on the 5-minute poll. Post-deploy, `ha_check_config` + an
+   error-log scan. The window shrinks from "5+ min" to "seconds".
+4. **Reconcile the SNAPSHOT.** `force-sync.sh` also presses
+   `input_button.ha_context_dump_now`; the drift PR updates `context/`. Once the
+   new id is in the snapshot, the checker's **"can be removed"** note flags the
+   temporary allowlist entry — prune it.
+
+## The machinery already exists
+
+Most of the pieces are already in the repo; the discipline is the ordering:
+
+- **Coordination ledger** — `dashboards/entity-allowlist.txt`. A "pending rename"
+  or "pending integration" id lives here until the snapshot catches up;
+  `scripts/check-dashboard-entities.py` emits a "can be removed" note when it
+  becomes redundant, which is the burn-down signal.
+- **Window collapse** — `scripts/force-sync.sh` triggers an immediate gitops
+  deploy + context dump so you don't wait on the 5-min / 6-h timers.
+- **Deploy + validate** — `scripts/gitops-sync.sh` (validates via `/core/check`,
+  rolls back on failure).
+- **Snapshot reconcile** — `ha-context-dump.sh` + the `ha-context-sync.yml`
+  drift PR.
+
+## Worked example — renaming the office Sonos (PR #328)
+
+The office speaker carried `media_player.basement` (stale adoption name) while an
+orphaned `media_player.office` ghost occupied the desired id.
+
+1. Mapped consumers: `configuration.yaml` (leader template), `home.yaml`,
+   `command-deck.yaml`, `kiosk.yaml`; `ha_deep_search` confirmed no UI
+   automations referenced either id.
+2. LIVE: removed the ghost, renamed `media_player.basement` →
+   `media_player.office`, verified with `ha_get_state`.
+3. INTENT: dropped the duplicate `sonos_basement_leader` template and the
+   "Basement" cards (the `sonos_office_leader` / "Office" cards became correct).
+4. **Ordering miss to learn from:** the LIVE rename was done *before* the INTENT
+   PR merged, so the deployed dashboards rendered a few Sonos cards
+   `unavailable` until merge + deploy. Next time, prepare-INTENT-green-first and
+   `force-sync.sh` immediately after merge to close that window.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -105,6 +105,16 @@ checkout the repo *before* validating the payload (an early checkout for an
 invalid payload is the only behavioral change; the payload isn't used in
 checkout, so there's no security impact).
 
+## `force-sync.sh`
+
+Collapses the cross-layer latency windows on demand: fires an immediate
+`shell_command.gitops_sync` (deploy now, rather than waiting for the 5-minute
+poll) and presses `input_button.ha_context_dump_now` (snapshot now, rather than
+the 6-hour dump). Use it after a coordinated LIVE + INTENT change so the layers
+reconcile in seconds — see `docs/cross-layer-changes.md` (rename recipe,
+steps 3–4). Runs inside the HA Core container; uses `SUPERVISOR_TOKEN` like
+`gitops-sync.sh`.
+
 ## Script auth conventions
 
 Three conventions learned the hard way during context-sync work. Future scripts

--- a/scripts/force-sync.sh
+++ b/scripts/force-sync.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Collapse the cross-layer latency windows on demand. Triggers an immediate
+# gitops deploy (instead of waiting for the 5-minute poll) and an immediate
+# context snapshot (instead of the 6-hour dump), so a coordinated LIVE+INTENT
+# change reconciles in seconds rather than minutes/hours.
+#
+# Runs inside the HA Core container, where SUPERVISOR_TOKEN is injected — same
+# auth pattern as gitops-sync.sh. See docs/cross-layer-changes.md for when to
+# reach for this (step 3/4 of the rename recipe).
+#
+# Usage: force-sync.sh
+set -euo pipefail
+
+readonly SUPERVISOR_BASE="${SUPERVISOR_BASE:-http://supervisor}"
+
+# Call a HA service through the Supervisor's Core API proxy.
+# Args: <domain> <service> [json_data]
+ha_call_service() {
+  local domain="$1" service="$2" data="${3:-}"
+  [[ -z "$data" ]] && data='{}'
+  curl -fsS -X POST \
+    -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$data" \
+    "${SUPERVISOR_BASE}/core/api/services/${domain}/${service}"
+}
+
+# Deploy INTENT now, then reconcile the SNAPSHOT. Deploy first so the snapshot
+# that follows reflects the just-deployed YAML as well as the live registry.
+force_sync() {
+  echo "[force-sync] Triggering immediate gitops deploy (shell_command.gitops_sync)…"
+  ha_call_service shell_command gitops_sync >/dev/null
+
+  echo "[force-sync] Triggering immediate context snapshot (input_button.ha_context_dump_now)…"
+  ha_call_service input_button press '{"entity_id":"input_button.ha_context_dump_now"}' >/dev/null
+
+  echo "[force-sync] Both fired. Watch /config/gitops-sync.log and" \
+       "/config/ha-context-dump.log for results."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if [[ -z "${SUPERVISOR_TOKEN:-}" ]]; then
+    echo "error: SUPERVISOR_TOKEN is not set — run inside the HA Core container." >&2
+    exit 1
+  fi
+  force_sync
+fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -70,6 +70,12 @@ bats tests/
   whitespace, injection-shaped input) plus the CLI exit-code/stdout contract the
   workflows depend on.
 
+- **`force_sync.bats`** — tests `scripts/force-sync.sh`, the helper that
+  collapses the cross-layer latency windows. Sources the script, stubs
+  `ha_call_service`, and asserts `force_sync` deploys (gitops) *before*
+  reconciling the snapshot (dump button), plus that the CLI refuses to run
+  without `SUPERVISOR_TOKEN`.
+
 ## Making a script testable
 
 Scripts that self-execute at the bottom should guard that call so the file can

--- a/tests/force_sync.bats
+++ b/tests/force_sync.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/force-sync.sh — the helper that collapses the cross-layer
+# latency windows by firing an immediate gitops deploy and context snapshot.
+# The service calls are side effects, so the suite sources the script (the
+# BASH_SOURCE == $0 guard keeps the CLI body from running), stubs ha_call_service
+# to record invocations, and asserts force_sync fires both services in the right
+# order. The CLI guard (refusing to run without SUPERVISOR_TOKEN) is checked
+# end-to-end.
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../scripts/force-sync.sh"
+  # shellcheck source=../scripts/force-sync.sh
+  source "$SCRIPT"
+  CALLS_FILE="${BATS_TEST_TMPDIR}/calls"
+  : > "$CALLS_FILE"
+  ha_call_service() { printf '%s %s %s\n' "$1" "$2" "${3:-}" >> "$CALLS_FILE"; }
+  export CALLS_FILE
+}
+
+@test "force_sync deploys (gitops) before reconciling the snapshot (dump button)" {
+  run force_sync
+  [ "$status" -eq 0 ]
+  # gitops deploy fires first…
+  [ "$(sed -n '1p' "$CALLS_FILE")" = "shell_command gitops_sync " ]
+  # …then the context dump button press
+  [[ "$(sed -n '2p' "$CALLS_FILE")" == "input_button press "*"ha_context_dump_now"* ]]
+}
+
+@test "CLI refuses to run without SUPERVISOR_TOKEN" {
+  run env -u SUPERVISOR_TOKEN bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SUPERVISOR_TOKEN is not set"* ]]
+}


### PR DESCRIPTION
## Origin

The office-Sonos rename (#328) opened an inconsistency window by mutating the LIVE registry before the INTENT YAML deployed. You said *"we should develop a method for stacking changes to different layers reliably,"* then *"yes — codify then wrap this thread,"* then *"always arm PRs to auto-merge. This should be codified for CC in this repo. I thought it was, but I think it fell out of context."* This captures both.

## What's here

- **`docs/cross-layer-changes.md`** — the cross-layer runbook (companion to the *Three-Layer State Model* in `CLAUDE.md`): the hazard, safe ordering by change type (add / remove / modify / rename), the rename recipe (prepare INTENT green → mutate LIVE → merge + `force-sync.sh` → reconcile SNAPSHOT), how the existing machinery composes, and the Sonos rename as a worked example.
- **`scripts/force-sync.sh`** — fires `shell_command.gitops_sync` and presses `input_button.ha_context_dump_now` so a coordinated change reconciles in seconds rather than waiting on the 5-min / 6-h timers. Sourceable; uses `SUPERVISOR_TOKEN`.
- **`tests/force_sync.bats`** — asserts `force_sync` deploys before reconciling the snapshot, and that the CLI refuses to run without `SUPERVISOR_TOKEN`.
- **`CLAUDE.md` → new "Always arm auto-merge" subsection** under *PR Authoring* — arm every opened PR for squash auto-merge (or merge directly if already green). This was a fleet-wide rule (`~/repos/CLAUDE.md`) that wasn't restated in this repo, so it fell out of context; now it's local. Plus a pointer to the cross-layer runbook from the Three-Layer State Model section.
- Pointers from the `scripts/` + `tests/` READMEs.

## Verification

Rebased onto current `main` (post #327/#328); README conflicts resolved by keeping both sections. `shellcheck` clean, full bats suite passes, no YAML config touched.

> Rebased after #327/#328 merged — this branch now sits cleanly on top of both.

https://claude.ai/code/session_014UUn1yZ1E1LG6XfuBAWfQa