### PR TITLE
Reconcile light template entity refs against current registry

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -108,9 +108,8 @@ light:
       - light.kitchen_main
       - light.kitchen_island
       - light.kitchen_table
-      - light.family_room
       - light.family_room_2
-      - light.floor_lamp
+      - light.floor_lamp_composite
 
 # Template sensors for Sonos group-aware dashboard
 template:
@@ -163,9 +162,7 @@ template:
       - name: "Office Lights On"
         unique_id: office_lights_on
         state: >
-          {{ is_state('light.office', 'on')
-             or is_state('light.office_lamp', 'on')
-             or is_state('light.bookcase_lamp', 'on')
+          {{ is_state('light.bookcase_lamp', 'on')
              or is_state('light.corner_lamp', 'on')
              or is_state('light.door_lamp', 'on')
              or is_state('light.desk_lamp_2', 'on')
@@ -174,8 +171,7 @@ template:
       - name: "Play Room Lights On"
         unique_id: play_room_lights_on
         state: >
-          {{ is_state('light.play_room', 'on')
-             or is_state('light.playroom_1', 'on')
+          {{ is_state('light.playroom_1', 'on')
              or is_state('light.playroom_2', 'on')
              or is_state('light.playroom_3', 'on')
              or is_state('light.playroom_4', 'on') }}
@@ -183,17 +179,13 @@ template:
       - name: "Family Room Lights On"
         unique_id: family_room_lights_on
         state: >
-          {{ is_state('light.family_room', 'on')
-             or is_state('light.family_room_2', 'on')
-             or is_state('light.floor_lamp', 'on')
-             or is_state('switch.family_room_outlets', 'on') }}
+          {{ is_state('light.family_room_2', 'on')
+             or is_state('light.floor_lamp_composite', 'on') }}
 
       - name: "Entry Lights On"
         unique_id: entry_lights_on
         state: >
-          {{ is_state('light.entry_1', 'on')
-             or is_state('light.entry_2', 'on')
-             or is_state('light.downstairs_hallway', 'on')
+          {{ is_state('light.downstairs_hallway', 'on')
              or is_state('light.upstairs_hallway_light', 'on')
              or is_state('light.meeting_light', 'on') }}
 
@@ -250,30 +242,18 @@ template:
           - service: switch.turn_on
             target:
               entity_id: switch.family_room_outlets
-          - delay: "00:00:01"
-          - service: light.turn_on
-            target:
-              entity_id: light.floor_lamp
-            data:
-              brightness: "{{ brightness | default(255) }}"
         turn_off:
-          - service: light.turn_off
-            target:
-              entity_id: light.floor_lamp
-          - delay: "00:00:01"
           - service: switch.turn_off
             target:
               entity_id: switch.family_room_outlets
-        state: >
-          {{ is_state('switch.family_room_outlets', 'on') and is_state('light.floor_lamp', 'on') }}
-        level: "{{ state_attr('light.floor_lamp', 'brightness') | int(0) }}"
+        state: "{{ is_state('switch.family_room_outlets', 'on') }}"
 
   - sensor:
       - name: "Lights On Office Count"
         unique_id: lights_on_office_count
         state: >
-          {{ ['light.office','light.bookcase_lamp','light.corner_lamp',
-              'light.door_lamp','light.office_lamp','light.meeting_light',
+          {{ ['light.bookcase_lamp','light.corner_lamp',
+              'light.door_lamp','light.meeting_light',
               'light.desk_lamp_2','light.desk_lamp_2_2']
              | select('is_state','on') | list | count }}
         icon: mdi:lightbulb-group
@@ -281,7 +261,7 @@ template:
       - name: "Lights On Family Room Count"
         unique_id: lights_on_family_room_count
         state: >
-          {{ ['light.family_room','light.family_room_2','light.floor_lamp_composite']
+          {{ ['light.family_room_2','light.floor_lamp_composite']
              | select('is_state','on') | list | count }}
         icon: mdi:lightbulb-group
 

--- a/groups.yaml
+++ b/groups.yaml
@@ -20,7 +20,6 @@ downstairs_lights:
     - light.kitchen_main
     - light.kitchen_island
     - light.kitchen_table
-    - light.family_room
     - light.family_room_2
     - light.floor_lamp_composite
 


### PR DESCRIPTION
## Origin

> ok let's review my watchman reports on the HA instance. Check ~/repos/homeassistant-config changes for reference

Watchman report at 2026-06-01T21:11Z surfaced 37 missing entities. Triage split them into (A) dead YAML refs, (B) currently-offline devices, (C) state-noise, (D) test fixtures. This PR is **Group A** — the dead YAML refs.

## Summary

Drops 7 light entity_ids that no longer resolve in the HA registry:

- `light.family_room` — only `light.family_room_2` exists
- `light.floor_lamp` — the smart bulb is gone; outlet (`switch.family_room_outlets`) remains
- `light.office`, `light.office_lamp` — only `light.office_switch` exists, role unclear so not auto-substituted
- `light.play_room` — `light.playroom_1..4` are the real ones (already in OR-chain)
- `light.entry_1`, `light.entry_2` — never resolved in registry

Touches: `configuration.yaml` (Downstairs group, four "Lights On" template binary sensors, Office + Family Room count sensors, Floor Lamp Composite light) and `groups.yaml` (`downstairs_lights`).

### Floor Lamp Composite decision

The composite template light is kept (3 dashboards reference it: `home.yaml`, `command-deck.yaml`, `kiosk.yaml`) but rewritten as a thin on/off wrapper over `switch.family_room_outlets`. The brightness plumbing and the bulb/outlet pairing delays are removed since the smart bulb is gone. The mushroom-light-card brightness slider on those dashboards becomes a no-op, but the on/off control still works. If a new smart bulb gets installed later, the composite can be restored to its prior shape.

### Conservative scoping

No replacements added where the dead ref had no obvious 1:1 successor — specifically `light.office` and `light.office_lamp` are removed without subbing in `light.office_switch`, since office_switch's role (overhead vs. lamp) isn't unambiguous from the registry alone.

### Watchman impact

13 of 37 missing entities cleared. Remaining Group B (transient unavail), Group C (state noise), Group D (test fixtures ignore-path) will land in separate PRs/issues.

## Test plan

- [ ] `YAML Lint` passes
- [ ] `check-config` passes (CI spins up clean HA + new YAML)
- [ ] `Tests` and `ESPHome Config` gates pass
- [ ] After gitops-sync deploys to live HA, confirm Watchman parse drops `light.family_room`, `light.floor_lamp`, `light.office`, `light.office_lamp`, `light.play_room`, `light.entry_1`, `light.entry_2` from missing list
- [ ] Confirm `light.floor_lamp_composite` still toggles `switch.family_room_outlets` from the Home / Command Deck / Kiosk dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)