### PR TITLE
Replace cpitzi/prompts GitHub block with PitziLabs fleet (8 repos)

### DIFF
--- a/dashboards/entity-allowlist.txt
+++ b/dashboards/entity-allowlist.txt
@@ -35,10 +35,31 @@ sensor.play_room_youtube_today
 # Only battery_runtime remains absent (entity not exposed by the integration yet).
 sensor.cyberpower_battery_runtime
 
-# --- Pending integration: cpitzi/prompts GitHub sensors (homelab-status.yaml) ---
-sensor.cpitzi_prompts_latest_commit
-sensor.cpitzi_prompts_issues
-sensor.cpitzi_prompts_pull_requests
-sensor.cpitzi_prompts_stars
-sensor.cpitzi_prompts_forks
-sensor.cpitzi_prompts_watchers
+# --- Pending integration: PitziLabs/* GitHub sensors (homelab-status.yaml) ---
+# Populated by the HA core `github` integration once configured with the eight
+# PitziLabs org repos. Three sensors per repo: latest_commit, open_issues,
+# open_pull_requests. Prune as each repo's sensors land in entities.json.
+sensor.pitzilabs_firewalla_axiom_pipeline_latest_commit
+sensor.pitzilabs_firewalla_axiom_pipeline_open_issues
+sensor.pitzilabs_firewalla_axiom_pipeline_open_pull_requests
+sensor.pitzilabs_foundry_platform_demo_latest_commit
+sensor.pitzilabs_foundry_platform_demo_open_issues
+sensor.pitzilabs_foundry_platform_demo_open_pull_requests
+sensor.pitzilabs_homeassistant_config_latest_commit
+sensor.pitzilabs_homeassistant_config_open_issues
+sensor.pitzilabs_homeassistant_config_open_pull_requests
+sensor.pitzilabs_homelab_observability_latest_commit
+sensor.pitzilabs_homelab_observability_open_issues
+sensor.pitzilabs_homelab_observability_open_pull_requests
+sensor.pitzilabs_ice_cream_book_latest_commit
+sensor.pitzilabs_ice_cream_book_open_issues
+sensor.pitzilabs_ice_cream_book_open_pull_requests
+sensor.pitzilabs_reference_checker_latest_commit
+sensor.pitzilabs_reference_checker_open_issues
+sensor.pitzilabs_reference_checker_open_pull_requests
+sensor.pitzilabs_shared_workflows_latest_commit
+sensor.pitzilabs_shared_workflows_open_issues
+sensor.pitzilabs_shared_workflows_open_pull_requests
+sensor.pitzilabs_workstation_bootstrap_latest_commit
+sensor.pitzilabs_workstation_bootstrap_open_issues
+sensor.pitzilabs_workstation_bootstrap_open_pull_requests

--- a/dashboards/homelab-status.yaml
+++ b/dashboards/homelab-status.yaml
@@ -487,41 +487,94 @@ views:
 
 
       # ═══════════════════════════════════════════════════════════
-      # 7. GitHub
+      # 7. GitHub — PitziLabs fleet
       # ═══════════════════════════════════════════════════════════
+      # Entity IDs follow HA core `github` integration naming:
+      # sensor.<owner>_<repo>_{latest_commit,open_issues,open_pull_requests}.
+      # Repo hyphens become underscores in the entity_id slug.
       - type: markdown
-        content: "### 🐙 GitHub"
+        content: "### 🐙 GitHub — PitziLabs"
 
       - type: entities
-        title: cpitzi/prompts
+        title: Fleet activity
+        show_header_toggle: false
         entities:
-          - entity: sensor.cpitzi_prompts_latest_commit
+          - type: section
+            label: firewalla-axiom-pipeline
+          - entity: sensor.pitzilabs_firewalla_axiom_pipeline_latest_commit
             name: Latest Commit
-          - entity: sensor.cpitzi_prompts_issues
+          - entity: sensor.pitzilabs_firewalla_axiom_pipeline_open_issues
             name: Open Issues
-          - entity: sensor.cpitzi_prompts_pull_requests
+          - entity: sensor.pitzilabs_firewalla_axiom_pipeline_open_pull_requests
             name: Open PRs
 
-      - type: grid
-        columns: 3
-        square: false
-        cards:
-          - type: custom:mushroom-entity-card
-            entity: sensor.cpitzi_prompts_stars
-            name: Stars
-            icon: mdi:star
-          - type: custom:mushroom-entity-card
-            entity: sensor.cpitzi_prompts_forks
-            name: Forks
-            icon: mdi:source-fork
-          - type: custom:mushroom-entity-card
-            entity: sensor.cpitzi_prompts_watchers
-            name: Watchers
-            icon: mdi:eye
+          - type: section
+            label: foundry-platform-demo
+          - entity: sensor.pitzilabs_foundry_platform_demo_latest_commit
+            name: Latest Commit
+          - entity: sensor.pitzilabs_foundry_platform_demo_open_issues
+            name: Open Issues
+          - entity: sensor.pitzilabs_foundry_platform_demo_open_pull_requests
+            name: Open PRs
+
+          - type: section
+            label: homeassistant-config
+          - entity: sensor.pitzilabs_homeassistant_config_latest_commit
+            name: Latest Commit
+          - entity: sensor.pitzilabs_homeassistant_config_open_issues
+            name: Open Issues
+          - entity: sensor.pitzilabs_homeassistant_config_open_pull_requests
+            name: Open PRs
+
+          - type: section
+            label: homelab-observability
+          - entity: sensor.pitzilabs_homelab_observability_latest_commit
+            name: Latest Commit
+          - entity: sensor.pitzilabs_homelab_observability_open_issues
+            name: Open Issues
+          - entity: sensor.pitzilabs_homelab_observability_open_pull_requests
+            name: Open PRs
+
+          - type: section
+            label: ice-cream-book
+          - entity: sensor.pitzilabs_ice_cream_book_latest_commit
+            name: Latest Commit
+          - entity: sensor.pitzilabs_ice_cream_book_open_issues
+            name: Open Issues
+          - entity: sensor.pitzilabs_ice_cream_book_open_pull_requests
+            name: Open PRs
+
+          - type: section
+            label: reference-checker
+          - entity: sensor.pitzilabs_reference_checker_latest_commit
+            name: Latest Commit
+          - entity: sensor.pitzilabs_reference_checker_open_issues
+            name: Open Issues
+          - entity: sensor.pitzilabs_reference_checker_open_pull_requests
+            name: Open PRs
+
+          - type: section
+            label: shared-workflows
+          - entity: sensor.pitzilabs_shared_workflows_latest_commit
+            name: Latest Commit
+          - entity: sensor.pitzilabs_shared_workflows_open_issues
+            name: Open Issues
+          - entity: sensor.pitzilabs_shared_workflows_open_pull_requests
+            name: Open PRs
+
+          - type: section
+            label: workstation-bootstrap
+          - entity: sensor.pitzilabs_workstation_bootstrap_latest_commit
+            name: Latest Commit
+          - entity: sensor.pitzilabs_workstation_bootstrap_open_issues
+            name: Open Issues
+          - entity: sensor.pitzilabs_workstation_bootstrap_open_pull_requests
+            name: Open PRs
 
       - type: markdown
         content: >
-          _More repos (hass, homelab-observability, workstation-bootstrap) coming in a follow-up issue once sensors are configured._
+          _Sensors populate once the HA core `github` integration is configured
+          with the eight PitziLabs/* repos. Until then they read as Unavailable._
 
 
       # ═══════════════════════════════════════════════════════════


### PR DESCRIPTION
## Origin

> Also, remove the prompts github integration but add the PitziLabs repos

Follow-up to the Watchman triage: the `cpitzi/prompts` GitHub cards were dangling references (integration never configured). Swap for the eight PitziLabs org repos and prep the dashboard for when the HA core `github` integration goes live.

## Summary

- `dashboards/homelab-status.yaml` § 7 GitHub: removes the `cpitzi/prompts` entities card + stars/forks/watchers grid + "more repos coming" TODO markdown. Replaces with a single sectioned entities card covering all 8 PitziLabs org repos × {latest_commit, open_issues, open_pull_requests}.
- `dashboards/entity-allowlist.txt`: removes the 6 `cpitzi_prompts_*` allowlist lines, adds 24 `pitzilabs_*` lines (3 × 8 repos), all flagged "pending integration".

### Entity ID convention

HA core `github` integration entity IDs are `sensor.<owner_slug>_<repo_slug>_<metric>`. Hyphens in the repo name become underscores. So `PitziLabs/foundry-platform-demo` → `sensor.pitzilabs_foundry_platform_demo_open_issues` etc.

### Stars / forks / watchers dropped

For an internal-tooling fleet those numbers stay near zero — no signal. Latest commit + open issues + open PRs are the actionable triplet.

### Required follow-up (manual, post-merge)

This PR makes the dashboard *ready* for the integration but does **not** configure the integration itself (it's a UI/PAT config flow, not YAML). After merge:

1. **Settings → Devices & Services → + Add Integration → GitHub**
2. Paste a PAT with `public_repo` + `read:org` (or use the existing `~/repos/.gh-token` fine-grained PAT — its scopes already cover Contents/Issues/PRs/Metadata on PitziLabs/*).
3. Add the 8 PitziLabs repos: `firewalla-axiom-pipeline`, `foundry-platform-demo`, `homeassistant-config`, `homelab-observability`, `ice-cream-book`, `reference-checker`, `shared-workflows`, `workstation-bootstrap`.

Once those land, the dashboard cards resolve and Watchman drops 6 missing entities. Allowlist entries will auto-flag as removable on the next context dump.

## Test plan

- [ ] `YAML Lint` passes
- [ ] `check-config` passes
- [ ] `Tests` (including `dashboard_entities.bats`) passes against the updated allowlist
- [ ] After gitops-sync deploys, GitHub section of Homelab Status dashboard renders 8 sections (cards Unavailable until integration set up)
- [ ] After adding the GitHub integration with all 8 repos, cards populate with live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)