### PR TITLE
Rework GitHub block to HACS github_custom (one sensor + attrs per repo)

### DIFF
--- a/dashboards/entity-allowlist.txt
+++ b/dashboards/entity-allowlist.txt
@@ -36,30 +36,16 @@ sensor.play_room_youtube_today
 sensor.cyberpower_battery_runtime
 
 # --- Pending integration: PitziLabs/* GitHub sensors (homelab-status.yaml) ---
-# Populated by the HA core `github` integration once configured with the eight
-# PitziLabs org repos. Three sensors per repo: latest_commit, open_issues,
-# open_pull_requests. Prune as each repo's sensors land in entities.json.
-sensor.pitzilabs_firewalla_axiom_pipeline_latest_commit
-sensor.pitzilabs_firewalla_axiom_pipeline_open_issues
-sensor.pitzilabs_firewalla_axiom_pipeline_open_pull_requests
-sensor.pitzilabs_foundry_platform_demo_latest_commit
-sensor.pitzilabs_foundry_platform_demo_open_issues
-sensor.pitzilabs_foundry_platform_demo_open_pull_requests
-sensor.pitzilabs_homeassistant_config_latest_commit
-sensor.pitzilabs_homeassistant_config_open_issues
-sensor.pitzilabs_homeassistant_config_open_pull_requests
-sensor.pitzilabs_homelab_observability_latest_commit
-sensor.pitzilabs_homelab_observability_open_issues
-sensor.pitzilabs_homelab_observability_open_pull_requests
-sensor.pitzilabs_ice_cream_book_latest_commit
-sensor.pitzilabs_ice_cream_book_open_issues
-sensor.pitzilabs_ice_cream_book_open_pull_requests
-sensor.pitzilabs_reference_checker_latest_commit
-sensor.pitzilabs_reference_checker_open_issues
-sensor.pitzilabs_reference_checker_open_pull_requests
-sensor.pitzilabs_shared_workflows_latest_commit
-sensor.pitzilabs_shared_workflows_open_issues
-sensor.pitzilabs_shared_workflows_open_pull_requests
-sensor.pitzilabs_workstation_bootstrap_latest_commit
-sensor.pitzilabs_workstation_bootstrap_open_issues
-sensor.pitzilabs_workstation_bootstrap_open_pull_requests
+# Populated by the HACS `github_custom` integration
+# (boralyl/github-custom-component-tutorial) once configured via its UI flow.
+# ONE sensor per repo — state is the latest-commit short SHA; metrics
+# (open_issues, open_pull_requests, stargazers, forks, …) ride as
+# attributes. Prune as each repo's sensor lands in entities.json.
+sensor.pitzilabs_firewalla_axiom_pipeline
+sensor.pitzilabs_foundry_platform_demo
+sensor.pitzilabs_homeassistant_config
+sensor.pitzilabs_homelab_observability
+sensor.pitzilabs_ice_cream_book
+sensor.pitzilabs_reference_checker
+sensor.pitzilabs_shared_workflows
+sensor.pitzilabs_workstation_bootstrap

--- a/dashboards/homelab-status.yaml
+++ b/dashboards/homelab-status.yaml
@@ -489,92 +489,111 @@ views:
       # ═══════════════════════════════════════════════════════════
       # 7. GitHub — PitziLabs fleet
       # ═══════════════════════════════════════════════════════════
-      # Entity IDs follow HA core `github` integration naming:
-      # sensor.<owner>_<repo>_{latest_commit,open_issues,open_pull_requests}.
-      # Repo hyphens become underscores in the entity_id slug.
+      # Powered by the HACS `github_custom` integration
+      # (boralyl/github-custom-component-tutorial). One sensor per repo;
+      # state is the latest-commit short SHA; attributes carry
+      # open_issues, open_pull_requests, stargazers, forks, etc.
+      # Entity_id slug derives from the per-repo `name` field set
+      # during the UI config flow — "pitzilabs <repo>" → sensor.pitzilabs_<repo>.
       - type: markdown
         content: "### 🐙 GitHub — PitziLabs"
 
-      - type: entities
-        title: Fleet activity
-        show_header_toggle: false
-        entities:
-          - type: section
-            label: firewalla-axiom-pipeline
-          - entity: sensor.pitzilabs_firewalla_axiom_pipeline_latest_commit
-            name: Latest Commit
-          - entity: sensor.pitzilabs_firewalla_axiom_pipeline_open_issues
-            name: Open Issues
-          - entity: sensor.pitzilabs_firewalla_axiom_pipeline_open_pull_requests
-            name: Open PRs
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-template-card
+            primary: firewalla-axiom-pipeline
+            secondary: >
+              {% set s = states('sensor.pitzilabs_firewalla_axiom_pipeline') %}
+              {% set i = state_attr('sensor.pitzilabs_firewalla_axiom_pipeline', 'open_issues') | int(0) %}
+              {% set p = state_attr('sensor.pitzilabs_firewalla_axiom_pipeline', 'open_pull_requests') | int(0) %}
+              {{ s }} · {{ i }} issues · {{ p }} PRs
+            icon: mdi:github
+            entity: sensor.pitzilabs_firewalla_axiom_pipeline
+            tap_action: { action: more-info }
 
-          - type: section
-            label: foundry-platform-demo
-          - entity: sensor.pitzilabs_foundry_platform_demo_latest_commit
-            name: Latest Commit
-          - entity: sensor.pitzilabs_foundry_platform_demo_open_issues
-            name: Open Issues
-          - entity: sensor.pitzilabs_foundry_platform_demo_open_pull_requests
-            name: Open PRs
+          - type: custom:mushroom-template-card
+            primary: foundry-platform-demo
+            secondary: >
+              {% set s = states('sensor.pitzilabs_foundry_platform_demo') %}
+              {% set i = state_attr('sensor.pitzilabs_foundry_platform_demo', 'open_issues') | int(0) %}
+              {% set p = state_attr('sensor.pitzilabs_foundry_platform_demo', 'open_pull_requests') | int(0) %}
+              {{ s }} · {{ i }} issues · {{ p }} PRs
+            icon: mdi:github
+            entity: sensor.pitzilabs_foundry_platform_demo
+            tap_action: { action: more-info }
 
-          - type: section
-            label: homeassistant-config
-          - entity: sensor.pitzilabs_homeassistant_config_latest_commit
-            name: Latest Commit
-          - entity: sensor.pitzilabs_homeassistant_config_open_issues
-            name: Open Issues
-          - entity: sensor.pitzilabs_homeassistant_config_open_pull_requests
-            name: Open PRs
+          - type: custom:mushroom-template-card
+            primary: homeassistant-config
+            secondary: >
+              {% set s = states('sensor.pitzilabs_homeassistant_config') %}
+              {% set i = state_attr('sensor.pitzilabs_homeassistant_config', 'open_issues') | int(0) %}
+              {% set p = state_attr('sensor.pitzilabs_homeassistant_config', 'open_pull_requests') | int(0) %}
+              {{ s }} · {{ i }} issues · {{ p }} PRs
+            icon: mdi:github
+            entity: sensor.pitzilabs_homeassistant_config
+            tap_action: { action: more-info }
 
-          - type: section
-            label: homelab-observability
-          - entity: sensor.pitzilabs_homelab_observability_latest_commit
-            name: Latest Commit
-          - entity: sensor.pitzilabs_homelab_observability_open_issues
-            name: Open Issues
-          - entity: sensor.pitzilabs_homelab_observability_open_pull_requests
-            name: Open PRs
+          - type: custom:mushroom-template-card
+            primary: homelab-observability
+            secondary: >
+              {% set s = states('sensor.pitzilabs_homelab_observability') %}
+              {% set i = state_attr('sensor.pitzilabs_homelab_observability', 'open_issues') | int(0) %}
+              {% set p = state_attr('sensor.pitzilabs_homelab_observability', 'open_pull_requests') | int(0) %}
+              {{ s }} · {{ i }} issues · {{ p }} PRs
+            icon: mdi:github
+            entity: sensor.pitzilabs_homelab_observability
+            tap_action: { action: more-info }
 
-          - type: section
-            label: ice-cream-book
-          - entity: sensor.pitzilabs_ice_cream_book_latest_commit
-            name: Latest Commit
-          - entity: sensor.pitzilabs_ice_cream_book_open_issues
-            name: Open Issues
-          - entity: sensor.pitzilabs_ice_cream_book_open_pull_requests
-            name: Open PRs
+          - type: custom:mushroom-template-card
+            primary: ice-cream-book
+            secondary: >
+              {% set s = states('sensor.pitzilabs_ice_cream_book') %}
+              {% set i = state_attr('sensor.pitzilabs_ice_cream_book', 'open_issues') | int(0) %}
+              {% set p = state_attr('sensor.pitzilabs_ice_cream_book', 'open_pull_requests') | int(0) %}
+              {{ s }} · {{ i }} issues · {{ p }} PRs
+            icon: mdi:github
+            entity: sensor.pitzilabs_ice_cream_book
+            tap_action: { action: more-info }
 
-          - type: section
-            label: reference-checker
-          - entity: sensor.pitzilabs_reference_checker_latest_commit
-            name: Latest Commit
-          - entity: sensor.pitzilabs_reference_checker_open_issues
-            name: Open Issues
-          - entity: sensor.pitzilabs_reference_checker_open_pull_requests
-            name: Open PRs
+          - type: custom:mushroom-template-card
+            primary: reference-checker
+            secondary: >
+              {% set s = states('sensor.pitzilabs_reference_checker') %}
+              {% set i = state_attr('sensor.pitzilabs_reference_checker', 'open_issues') | int(0) %}
+              {% set p = state_attr('sensor.pitzilabs_reference_checker', 'open_pull_requests') | int(0) %}
+              {{ s }} · {{ i }} issues · {{ p }} PRs
+            icon: mdi:github
+            entity: sensor.pitzilabs_reference_checker
+            tap_action: { action: more-info }
 
-          - type: section
-            label: shared-workflows
-          - entity: sensor.pitzilabs_shared_workflows_latest_commit
-            name: Latest Commit
-          - entity: sensor.pitzilabs_shared_workflows_open_issues
-            name: Open Issues
-          - entity: sensor.pitzilabs_shared_workflows_open_pull_requests
-            name: Open PRs
+          - type: custom:mushroom-template-card
+            primary: shared-workflows
+            secondary: >
+              {% set s = states('sensor.pitzilabs_shared_workflows') %}
+              {% set i = state_attr('sensor.pitzilabs_shared_workflows', 'open_issues') | int(0) %}
+              {% set p = state_attr('sensor.pitzilabs_shared_workflows', 'open_pull_requests') | int(0) %}
+              {{ s }} · {{ i }} issues · {{ p }} PRs
+            icon: mdi:github
+            entity: sensor.pitzilabs_shared_workflows
+            tap_action: { action: more-info }
 
-          - type: section
-            label: workstation-bootstrap
-          - entity: sensor.pitzilabs_workstation_bootstrap_latest_commit
-            name: Latest Commit
-          - entity: sensor.pitzilabs_workstation_bootstrap_open_issues
-            name: Open Issues
-          - entity: sensor.pitzilabs_workstation_bootstrap_open_pull_requests
-            name: Open PRs
+          - type: custom:mushroom-template-card
+            primary: workstation-bootstrap
+            secondary: >
+              {% set s = states('sensor.pitzilabs_workstation_bootstrap') %}
+              {% set i = state_attr('sensor.pitzilabs_workstation_bootstrap', 'open_issues') | int(0) %}
+              {% set p = state_attr('sensor.pitzilabs_workstation_bootstrap', 'open_pull_requests') | int(0) %}
+              {{ s }} · {{ i }} issues · {{ p }} PRs
+            icon: mdi:github
+            entity: sensor.pitzilabs_workstation_bootstrap
+            tap_action: { action: more-info }
 
       - type: markdown
         content: >
-          _Sensors populate once the HA core `github` integration is configured
-          with the eight PitziLabs/* repos. Until then they read as Unavailable._
+          _Sensors populate once the HACS `github_custom` integration's config
+          flow is completed (paste PAT, add the 8 PitziLabs repo paths)._
 
 
       # ═══════════════════════════════════════════════════════════


### PR DESCRIPTION
## Origin

> Nah, give the other integration a shot

Follow-up to the GitHub-integration triage from the Watchman cleanup conversation. HA core github integration couldn't surface PitziLabs/* repos in its OAuth picker (limits picker to repos the auth'd user created or starred — org-owned repos don't show). Path A from the triage is to swap to the HACS `github_custom` integration (`boralyl/github-custom-component-tutorial`), which uses a PAT + free-form repo path entry.

The HACS install of the integration landed mid-conversation; this PR shapes the dashboard + allowlist to match its different entity model.

## Data model shift

| | HA core `github` | HACS `github_custom` |
|---|---|---|
| Entities per repo | 3 (latest_commit, open_issues, open_pull_requests) | **1** |
| State | (per-sensor) | latest commit short SHA |
| Metrics | separate sensors | **attributes** on the single sensor |
| Repo picker | OAuth → user's own + starred | Text input — any path you can read with the PAT |

## Dashboard layout

§ 7 GitHub: was a single sectioned entities card with 32 rows (8 repos × 1 title + 3 metric rows). Now a 2-column grid of 8 mushroom-template cards — each shows `<sha> · <N> issues · <M> PRs` as the secondary line, with `mdi:github` icon and `tap_action: more-info` so the modal exposes all attributes the integration produces (stargazers, forks, latest_release_*, etc.).

## Allowlist

Drops the 24 `pitzilabs_*_<metric>` rows from PR #331, replaces with 8 single-sensor rows (one per repo). Comment updated to reflect the integration switch.

## Manual steps (post-merge)

1. **HA restart** — the HACS integration was installed mid-conversation; HA needs a restart to load `github_custom` into the platform registry. (One-shot; subsequent updates don't need this.)
2. **Configure via UI** — Settings → Devices & Services → + Add Integration → "Github Custom" → paste a GitHub PAT scoped to PitziLabs/* with read on contents, issues, pull requests, metadata (public repos: `public_repo` is enough; private: also `repo`) → for each of 8 repos enter:
   - **Path**: `PitziLabs/<repo-slug>`
   - **Name**: `pitzilabs <repo-slug>` (the spaces/hyphens become underscores in the entity_id, matching this PR's dashboard refs)
   - Tick "Add another" — uncheck on the last one
3. Entity IDs land as `sensor.pitzilabs_<repo>`. Dashboard cards populate automatically.

## Why no YAML platform config

CI uses `frenck/action-home-assistant@v1`, which validates against a vanilla HA container with no HACS custom_components. A YAML `- platform: github_custom` block would have failed `check-config`. UI-flow-only sidesteps that.

## Test plan

- [ ] `YAML Lint` passes
- [ ] `check-config` passes (no platform: github_custom YAML to break it)
- [ ] `Dashboard Entities` passes against the new 8-row allowlist
- [ ] After HA restart + config flow with 8 repos, all 8 mushroom cards populate with `<sha> · <N> issues · <M> PRs`
- [ ] Tapping a card surfaces more-info with `open_issues`, `open_pull_requests`, `stargazers`, `forks`, `latest_commit_message`, `latest_release_tag` attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)