### PR TITLE
check-dashboard-entities: accept HA's !include / !secret YAML tags

### DIFF
--- a/scripts/check-dashboard-entities.py
+++ b/scripts/check-dashboard-entities.py
@@ -31,6 +31,35 @@ from pathlib import Path
 
 import yaml
 
+
+# HA's YAML loader recognizes custom tags (!include, !secret, etc.) that
+# stock PyYAML rejects. Register no-op constructors so we can parse the
+# document — we only need to collect entity_id strings, not resolve
+# includes or secrets. HA does the real resolution at fetch time, and
+# included child files are walked directly by this script when passed on
+# the command line (so their entity refs get counted via that path, not
+# transitively through the manifest).
+def _ha_tag_scalar(loader, node):
+    """Returns a string placeholder; the real value isn't needed here."""
+    return f"<{node.tag} {loader.construct_scalar(node)}>"
+
+
+def _ha_tag_list(loader, node):
+    return []
+
+
+def _ha_tag_dict(loader, node):
+    return {}
+
+
+for _tag in ("!include", "!secret", "!env_var"):
+    yaml.SafeLoader.add_constructor(_tag, _ha_tag_scalar)
+for _tag in ("!include_dir_list", "!include_dir_merge_list"):
+    yaml.SafeLoader.add_constructor(_tag, _ha_tag_list)
+for _tag in ("!include_dir_named", "!include_dir_merge_named"):
+    yaml.SafeLoader.add_constructor(_tag, _ha_tag_dict)
+
+
 # A valid entity_id: lowercase domain, dot, object_id. Anything with `{`, `}`,
 # whitespace, or uppercase is a template/placeholder and is skipped.
 ENTITY_RE = re.compile(r"^[a-z_]+\.[a-z0-9_]+$")


### PR DESCRIPTION
## Origin

Follow-up to #341 — the Dashboard Entities CI check rejected the new `homelab-status.yaml` manifest because `yaml.safe_load` doesn't know HA's `!include` tag. The fix was committed to the homelab-dashboard-v2 branch as a second commit but auto-merge fired on the first commit before the follow-up made it into the squash, so main shipped without the fix.

Mirrors the same constructor-registration fix already in `kiosk-host/kiosk-preview` from #341.

## Summary

`scripts/check-dashboard-entities.py` now registers no-op constructors for HA's custom YAML tags (`!include`, `!secret`, `!env_var`, and the four `!include_dir_*` variants). The script only collects entity_id strings; resolution of includes / secrets isn't needed for its purpose and HA does the real resolution at fetch time. Local re-run passes against all five top-level dashboards.

## Coverage gap noted (not fixed here)

The workflow globs `dashboards/*.yaml`, which does **not** recurse into the new `dashboards/homelab-views/` lens and detail subdirs. Entity refs inside those children aren't validated. A workflow change to glob recursively would close this, but `.github/workflows/` is out of scope for the local PAT — would need a separate PR with broader perms, or a CI-side `find` invocation. Worth filing as an issue if not done soon.

## Test plan

- [ ] YAML Lint passes
- [ ] Dashboard Entities passes (the previously-failing check)
- [ ] Tests / ESPHome Config / check-config pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)