### PR TITLE
Kiosk: add Chris/Rachel presence chips to meeting card

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -705,12 +705,33 @@ views:
                   --shape-color: transparent;
                 }
 
-          # --- Outdoor weather chips ---
-          # Temperature, humidity, wind, and next sun event from
+          # --- Presence + outdoor weather chips ---
+          # Chris/Rachel home/away (router-layer presence via Firewalla-Local),
+          # then temperature, humidity, wind, and next sun event from
           # weather.forecast_home + sun.sun.
           - type: custom:mushroom-chips-card
             alignment: spaced
             chips:
+              - type: template
+                entity: device_tracker.chris_phone_presence
+                icon: |-
+                  {% if states('device_tracker.chris_phone_presence') == 'home' %}mdi:account-tie
+                  {% else %}mdi:account-off-outline{% endif %}
+                icon_color: |-
+                  {% if states('device_tracker.chris_phone_presence') == 'home' %}green
+                  {% else %}grey{% endif %}
+                content: Chris
+                tap_action: { action: more-info }
+              - type: template
+                entity: device_tracker.rachel_s_s23_presence
+                icon: |-
+                  {% if states('device_tracker.rachel_s_s23_presence') == 'home' %}mdi:account-heart
+                  {% else %}mdi:account-off-outline{% endif %}
+                icon_color: |-
+                  {% if states('device_tracker.rachel_s_s23_presence') == 'home' %}green
+                  {% else %}grey{% endif %}
+                content: Rachel
+                tap_action: { action: more-info }
               - type: template
                 icon: mdi:thermometer
                 icon_color: amber


### PR DESCRIPTION
## Origin

> OK add Chris home and Rachel home tiles to the kiosk somewhere.

Followup to the same session's HACS install of `ccpk1/firewalla-local-ha` and the options-flow configuration that created `device_tracker.chris_phone_presence` and `device_tracker.rachel_s_s23_presence`. The integration's router-layer device trackers are the household's first MAC-based presence source — surfacing them on the kiosk was the first concrete use case for the new entities.

## What changed

`dashboards/kiosk.yaml`: extends the existing 4-chip strip below Rachel's meeting hero to 6 chips, prepending Chris and Rachel presence indicators.

| Chip | Icon (home) | Icon (away) | Color |
|---|---|---|---|
| Chris | `mdi:account-tie` | `mdi:account-off-outline` | green / grey |
| Rachel | `mdi:account-heart` | `mdi:account-off-outline` | green / grey |

Tap action → more-info on the device tracker.

## Why the meeting card

Semantically adjacent to Rachel's "In Meeting / Available" hero already living there. No grid restructuring — the `alignment: spaced` chips card auto-distributes the 6 chips across the same 80px-tall section, no height-allocation changes needed. The sensors cell (2x4 grid) is already full; the alarm hero is a hero, not a chip surface.

## Preview

Captured `kiosk-preview-20260602T184207Z.png` after pushing to live HA — chips render cleanly:

- Chris: green person-tie icon (currently home, MAC d6:a8:20:…)
- Rachel: grey account-off icon (currently `not_home`, MAC 7a:80:2b:…)
- Weather chips (74° / 29% / 9 mph / 8:15 sunset) unchanged

## Test plan

- [x] `kiosk-preview` renders the 6-chip strip at the correct height with no overflow
- [x] Live state encoding is correct (green=home, grey=away) at the moment of capture
- [x] YAML validates locally (`python3 yaml.safe_load` via `kiosk-preview`'s pre-push check)
- [ ] `check-config` workflow passes
- [ ] `claude-review` passes
- [ ] On live merge: walk past the monitor and confirm the chips appear; tap to confirm more-info opens

## Caveats

- All three Firewalla device trackers use **randomized MACs** (locally-administered bit set). Samsung Galaxy phones rotate MACs per network; if presence ever goes stale after a router reboot or SSID change, the fix is phone-side ("Use phone MAC" / disable randomization on home WiFi). Not a dashboard bug.
- The presence chips show the *raw* `home` / `not_home` state via icon+color, not a textual state. Tap → more-info if you want to see the IP / hostname / last_active timestamp attributes.