### PR TITLE
docs(kiosk-preview): tighten protocol for lower-model autonomous runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,40 +195,47 @@ systemd unit, not the dashboard content it points at.
 ## Live Design Loop (kiosk dashboard)
 
 For non-trivial kiosk dashboard work, prefer the **live preview loop**
-over the slower edit→commit→wait-for-gitops cycle:
+over edit→commit→wait-for-gitops:
 
-```
-edit dashboards/kiosk.yaml  →  kiosk-host/kiosk-preview --open
-                                  ↳ 4–8s: push to HA, F5 Chromium,
-                                    wait for stable frame, snapshot
-                                    back to ./kiosk-preview-<UTC>.png
-                                  ↳ discuss the captured frame
-                                  ↳ repeat
-                                  ↳ commit at logical checkpoints (PR
-                                    + auto-merge, one coherent change
-                                    per PR)
-```
+1. Edit `dashboards/kiosk.yaml`.
+2. Run `kiosk-host/kiosk-preview --open`. ~4–8s end-to-end: pushes to
+   HA, F5s Chromium, captures `./kiosk-preview-<UTC>.png`.
+3. Check the PNG against the **snapshot rubric** in
+   `kiosk-host/README.md § Design session protocol` (target rendered,
+   adjacent cells unchanged, layout intact, state encoding correct).
+4. Iterate or commit per the **stop conditions** in the same section.
+5. Commit at logical checkpoints (PR + auto-merge, one coherent
+   change per PR).
 
-The push goes via `ssh -p 22 root@homeassistant.local 'cat > /homeassistant/dashboards/<name>'`
-(HAOS-host SSH, NOT scp — HAOS port 22 has no sftp-server). The
-HA-side gitops-sync resets `/homeassistant/dashboards/` to `origin/main`
-every 5 min, so each preview survives whatever's left in the current
-poll window. That's the discipline: iterate freely in-session, commit
-when a coherent unit is ready, let gitops make it permanent.
+**Sticky constraints:**
+
+- The push goes via `ssh -p 22 root@homeassistant.local 'cat > …'`
+  (HAOS-host SSH, NOT scp — HAOS port 22 has no sftp-server).
+- The HA-side gitops-sync resets `/homeassistant/dashboards/` to
+  `origin/main` every 5 min, so each preview survives only the
+  current poll window. Commit before it closes if you want the
+  change to persist.
 
 **Live-state caveat.** The captured PNG reflects current entity values
-(alarm color, current Sonos art, "Unavailable" labels on cards whose
+(alarm color, current Sonos art, `Unavailable` labels on cards whose
 entities are genuinely down right now). If a frame surprises you, look
 at the entity, not the dashboard.
 
-**When to skip the loop:** trivial copy edits (just commit), additions
-that reference entities not yet in `context/entities.json` (refresh
-context first), or changes to `extra_module_url` JS resources (need
-the optional HA token for `lovelace.reload_resources`).
+**When to skip the loop:**
 
-Full protocol + setup (HAOS SSH key, xdotool on pve2, optional HA
-token) in `kiosk-host/README.md` § "Live preview iteration" and
-§ "Design session protocol".
+- Trivial copy edits — just commit.
+- Cards that reference entities you haven't confirmed exist — verify
+  via `mcp__Local-HA__ha_search_entities` (live, current-to-the-second)
+  first. **Don't refresh `context/entities.json` for this** — the
+  snapshot is for grep, not for validation, and refreshing it takes
+  a full PR cycle.
+- Theme or `extra_module_url` JS resource changes — those need
+  `lovelace.reload_resources`, which requires the optional HA token.
+
+Full protocol (decision table, rubric, stop conditions,
+troubleshooting, non-kiosk dashboard variant) + setup (HAOS SSH key,
+xdotool on pve2, optional HA token) in `kiosk-host/README.md`
+§ "Live preview iteration" and § "Design session protocol".
 
 ---
 

--- a/kiosk-host/README.md
+++ b/kiosk-host/README.md
@@ -145,6 +145,17 @@ kiosk-host/kiosk-preview dashboards/homelab-status.yaml \
 | `--keep` | Suppress the gitops-clobber reminder |
 | `--no-snapshot` | Push + refresh only; no capture (use when you're physically watching the monitor) |
 
+### Decision table: which flags for which file
+
+The flag selection above maps mechanically to the file you're editing:
+
+| You're editing | What you need |
+|---|---|
+| `dashboards/kiosk.yaml` | Nothing — kiosk shows it by default; plain `kiosk-host/kiosk-preview` |
+| Another root manifest (e.g. `dashboards/homelab-status.yaml`) | Pause HA gitops + `kiosk-show --kiosk <URL>` once + `--url <URL>` on the first preview (see *Design session protocol for non-kiosk dashboards*) |
+| A file `!include`d by another dashboard (e.g. `dashboards/homelab-views/*.yaml`) | All of the above **and** `--dashboard-root <root-manifest.yaml>` on every preview (the yaml-mode cache keys off the manifest's mtime, not the child's) |
+| Theme or `extra_module_url` JS resource | Skip the loop — needs `lovelace.reload_resources` which requires the optional HA token (often absent). Commit + wait for gitops instead. |
+
 Under the hood, each call:
 
 1. `python3 yaml.safe_load`s the local file (refuses to push broken YAML).
@@ -192,6 +203,20 @@ Under the hood, each call:
   token at `~/.config/kiosk-preview/ha-token` (mode `0600`). Without
   it the call is skipped and the tool still works for dashboard YAML.
 
+### Troubleshooting
+
+When the loop fails, the symptom usually identifies the stage:
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Errors at *validating YAML* | Local YAML is malformed | Fix locally — the tool refuses to push broken YAML. The error names the line. |
+| Errors at *pushing* | SSH to HAOS port 22 down, or key not authorized | Verify with `ssh -p 22 root@homeassistant.local 'echo ok'`. If it fails, the one-time HAOS `authorized_keys` setup hasn't been done (see *Things to know* above). |
+| Snapshot is a skeleton / loading state | Frame captured before stable; transient HA load fooled the stability heuristic | Re-run `kiosk-preview`. Or capture a fresh frame with `kiosk-host/kiosk-snapshot` (which has no stability check and grabs whatever's currently on the monitor). |
+| Card body shows `Card error: …` | Unknown card type, missing required option, or schema mismatch | Read the error string — it names the field or type. Cross-check the card type via `mcp__Local-HA__ha_read_resource skill://home-assistant-best-practices/references/dashboard-cards.md`. For HACS cards, confirm the card is actually installed via `mcp__Local-HA__ha_hacs_search`. |
+| Card shows `Unavailable` | Entity is genuinely down, OR the entity_id is wrong | `mcp__Local-HA__ha_search_entities` to confirm the entity exists; `ha_get_state` to confirm its current value. **Don't trust `context/entities.json` for this** — it's up to 6h stale. |
+| `curl pve2.local:9999` returns 503 or hangs | `snapshot-server.service` on pve2 is down | `ssh -J root@pve.local root@pve2 'systemctl status snapshot-server.service --no-pager'`; restart if needed. The unit is `PartOf=dashboard-kiosk.service`, so a kiosk restart cycles it too. |
+| F5 doesn't change what's on the monitor | Chromium hung, or `xdotool` not on pve2 | `ssh -J root@pve.local root@pve2 'systemctl restart dashboard-kiosk.service'`; verify `xdotool` is installed (bootstrap apt list). |
+
 ### Design session protocol
 
 For non-trivial kiosk dashboard work (layout changes, theming, new
@@ -202,9 +227,28 @@ edit→commit→wait-5min-for-gitops cycle:
    ```bash
    git checkout main && git pull && git checkout -b kiosk-<topic>
    ```
-2. **Iterate.** Edit `dashboards/kiosk.yaml`, run
-   `kiosk-host/kiosk-preview --open`, look at the PNG, discuss, repeat.
-   Each loop is 4–8s.
+2. **Iterate.** Edit the YAML, run `kiosk-host/kiosk-preview --open`,
+   check the captured PNG against the rubric below, repeat. Each loop
+   is 4–8s.
+
+   **Snapshot rubric** (run after every capture; if any check fails,
+   fix and re-iterate before continuing):
+
+   - **Target card rendered** — not blank, no `Card error: …` string,
+     not stuck on a `Loading…` skeleton.
+   - **Entity states bound** — cards you expected to have data don't
+     show `Unavailable` because of an entity_id typo. Distinguish from
+     entities that are genuinely down by spot-checking
+     `mcp__Local-HA__ha_get_state`.
+   - **Adjacent cards unchanged** — a layout change in one grid cell
+     can ripple. Compare against the previous snapshot side by side
+     and confirm cells you didn't touch are visually identical.
+   - **Layout intact** — no horizontal scrollbars, no card overflowing
+     its grid cell, no cells shrunk to zero height. Look at the cell
+     boundaries, not just the card content.
+   - **State encoding correct** — icons and colors match the entity's
+     current state per the card's `state` blocks (e.g. green hero on a
+     `disarmed` alarm, grey on a presence chip showing `not_home`).
 3. **Checkpoint at logical units.** When a coherent change is ready
    (one card refactored, one theme tweak landed, one alarm-state polish
    complete), commit + PR + arm auto-merge with the usual repo flow.
@@ -215,6 +259,22 @@ edit→commit→wait-5min-for-gitops cycle:
    iterating you have whatever's left in the current poll window. If
    you want a YAML change that survives past the next poll, commit
    and let auto-merge land it.
+
+5. **Stop iterating** when any of these is true:
+
+   - The rubric passes and the change matches the original ask.
+   - **3 consecutive snapshots are visually indistinguishable** —
+     you're polishing past diminishing returns; commit what you have.
+   - **More than ~6 iterations on the same card with no convergence** —
+     likely the wrong card type or a fundamental layout choice. Step
+     back instead of grinding harder; re-read the relevant skill
+     reference (`mcp__Local-HA__ha_read_resource
+     skill://home-assistant-best-practices/references/dashboard-cards.md`)
+     or ask for direction.
+   - **The task as stated is complete** — don't add scope from what
+     the snapshot incidentally surfaces. File a GitHub issue per the
+     repo's "incidentally-observed latent problems" convention if it
+     warrants follow-up.
 
 **Live-state caveats** (look at the captured PNG with these in mind):
 
@@ -253,9 +313,16 @@ the household display:
 1. **Pause the HA-side gitops sync** (otherwise it'll reset
    `/homeassistant/dashboards/` to `origin/main` every 5 min and erase
    any new files you've pushed via kiosk-preview):
+
+   ```yaml
+   # MCP tool call (Local-HA server prefix may differ in cloud sessions):
+   mcp__Local-HA__ha_call_service:
+     domain: automation
+     service: turn_off
+     target:
+       entity_id: automation.gitops_poll_and_deploy
    ```
-   ha_call_service(automation.turn_off, automation.gitops_poll_and_deploy)
-   ```
+
    Or via UI: Settings → Automations → "GitOps: Poll and deploy" → off.
 2. **Redirect pve2's Chromium** to the dashboard you're iterating
    (commandeers the household monitor for the session):
@@ -267,18 +334,27 @@ the household display:
    F5-refresh it — no further `kiosk-show` needed unless the URL
    changes (e.g. navigating to a different view or subview, which
    you can drive in one shot with `kiosk-preview --url <URL>`).
-3. **Iterate.** Same edit → `kiosk-preview` → snapshot → discuss
-   shape as the kiosk dashboard loop. For multi-file dashboards that
-   use `!include`, pass `--dashboard-root <manifest.yaml>` so the
-   yaml-mode dashboard cache (keyed off the manifest's mtime, not
-   the included child's) actually gets busted.
+3. **Iterate.** Same edit → `kiosk-preview` → snapshot → rubric-check
+   shape as the kiosk dashboard loop above (apply the same snapshot
+   rubric and stop conditions). For multi-file dashboards that use
+   `!include`, pass `--dashboard-root <manifest.yaml>` so the yaml-mode
+   dashboard cache (keyed off the manifest's mtime, not the included
+   child's) actually gets busted.
 4. **Restore on the way out** (in this order, after the PR is open
    and ideally merged — otherwise the next gitops poll fetches
    `origin/main` which doesn't yet have your new files and the
    dashboard breaks until merge):
+
+   ```yaml
+   # Re-enable gitops via MCP tool call:
+   mcp__Local-HA__ha_call_service:
+     domain: automation
+     service: turn_on
+     target:
+       entity_id: automation.gitops_poll_and_deploy
+   ```
+
    ```bash
-   # Re-enable gitops
-   ha_call_service(automation.turn_on, automation.gitops_poll_and_deploy)
    # Send the kiosk back to the household dashboard
    ssh -J root@pve.local root@pve2 'kiosk-show --dashboard'
    ```


### PR DESCRIPTION
## Origin

> review the collaborative design iteration loop for clarity and specificity. I intend to try using lower models to go faster

Followup to a session that used the live design loop end-to-end (kiosk presence-tile PR #344). With Opus driving, the loop's narrative protocol works fine — implicit judgment fills the gaps. With a Haiku-class model targeted for routine iteration, the same gaps become failure modes (wrong flags, no self-check rubric, never stopping, Python-pseudocode MCP calls that don't parse).

This PR turns the protocol into a checklist that doesn't depend on the model's judgment.

## What changed

### `kiosk-host/README.md`

| Addition | Why |
|---|---|
| **Decision table: which flags for which file** | The existing flag table explains what each flag does, not when to reach for it. A weaker model can't infer that `dashboards/kiosk.yaml` doesn't need `--dashboard-root` (it's a root manifest, not included). The decision table maps file → flags mechanically. |
| **Troubleshooting subsection** | 7-row symptom → cause → fix table covering each stage of the kiosk-preview pipeline. Previously these recovery paths were embedded in narrative or absent. |
| **Snapshot rubric** (5 items, embedded in step 2 of the protocol) | Replaces "look at the PNG, discuss, repeat" — the "discuss" verb assumed a human in the loop. The rubric (target rendered / states bound / adjacent unchanged / layout intact / state encoding correct) is a checklist the model runs against every capture. |
| **Stop conditions** (new step 5) | 4 explicit conditions (rubric passes + intent matched, 3 indistinguishable snapshots, >6 iterations without convergence, task complete). Prevents lower models from chasing polish indefinitely. |
| **MCP-shape fixes** in the non-kiosk dashboard protocol | The previous `ha_call_service(automation.turn_off, automation.gitops_poll_and_deploy)` is Python-shaped pseudocode; the actual MCP call takes domain/service/target args separately. Now the YAML examples match the tool schema exactly so a lower model can copy-paste. |

### `CLAUDE.md`

- The "Live Design Loop" section is pared from a narrative summary to a 5-step operational sequence, pointing at the README for the rubric / stop conditions / troubleshooting (which are too long to belong in an always-loaded CLAUDE.md).
- The "When to skip" entity-existence advice is fixed: was "refresh `context/entities.json` first" (the expensive path — requires the full ha-context-dump PR cycle); now "verify via `ha_search_entities` first" (the live, current-to-the-second path that takes one MCP call).

## Net effect

- A Haiku-class autonomous run has explicit gates at every decision point that previously required judgment.
- An Opus-class run loses nothing — these were the same checks it was running implicitly. They just exist on paper now.
- Token cost of the new content lives in the README (loaded only when the protocol is consulted), not CLAUDE.md (loaded every session). CLAUDE.md actually gets shorter on the load-bearing operational parts.

## Test plan

- [ ] `claude-review` passes (this is a docs PR; YAML lint / check-config should no-op)
- [ ] Sanity-check by skim: a fresh reader can land at *Design session protocol* and execute steps 1→5 without external knowledge
- [ ] Follow-on: drive a real Haiku session through a small kiosk dashboard change using only this doc and report friction points (separate session — this PR ships the doc; the validation is its own work)

## Out of scope (deliberately)

- Moving the "Under the hood, each call:" pipeline detail behind a `<details>` collapse to reduce noise for a model trying to *invoke* (not extend) the tool — this was suggested in the review but is a separate, isolatable PR.
- Consolidating duplicated "When NOT to use" lists across CLAUDE.md and README — the lists are now slightly different in form (CLAUDE.md is operational, README has the full protocol). If they drift further, fold them in a future pass.