### PR TITLE
Show kiosk dashboard in sidebar

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -68,7 +68,7 @@ lovelace:
       mode: yaml
       title: Kiosk
       icon: mdi:monitor-dashboard
-      show_in_sidebar: false
+      show_in_sidebar: true
       filename: dashboards/kiosk.yaml
     dashboard-command-deck:
       mode: yaml


### PR DESCRIPTION
## Origin

Chris asked why the Kiosk dashboard wasn't showing up in his sidebar.
Inspection turned up `show_in_sidebar: false` on `dashboard-kiosk` in
`configuration.yaml` — the only one of the five YAML dashboards hidden
from the sidebar — and he asked to flip it on so he could reach the
kiosk view from his phone/laptop without typing the URL.

## Summary

- Flip `dashboard-kiosk.show_in_sidebar` from `false` to `true` in
  `configuration.yaml` so the kiosk view appears in the standard HA UI
  sidebar alongside Home, Homelab Status, Command Deck, and Screen Time.
- The pve2 wall-mounted Chromium kiosk is unaffected — it navigates
  directly to `/dashboard-kiosk/home` and never relied on the sidebar.

## Test plan

- [ ] After gitops-sync deploys, refresh HA in the browser
- [ ] Confirm "Kiosk" appears in the left sidebar with the
      `mdi:monitor-dashboard` icon
- [ ] Confirm pve2 wall display still loads the kiosk view as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)