### PR TITLE
Kiosk clock: fix time/date text clipping

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -90,12 +90,12 @@ views:
                vstack-collapses-to-content failure mode we saw with
                flex: 1 1 auto on the grow side. */
             ha-card hui-vertical-stack-card > :first-child {
-              flex: 0 0 190px !important;
-              min-height: 190px;
+              flex: 0 0 215px !important;
+              min-height: 215px;
             }
             ha-card hui-vertical-stack-card > :last-child {
-              flex: 0 0 95px !important;
-              min-height: 95px;
+              flex: 0 0 80px !important;
+              min-height: 80px;
             }
         card:
           type: vertical-stack


### PR DESCRIPTION
## Origin

Chris reported that the kiosk clock was clipping both the time and date text. Inspection found the inner `mod-card` wrapping the `clock-weather-card` declared `height: 215px` while its parent vertical-stack flex allocation capped it at `190px` — the bottom 25px were eaten by `overflow: hidden`. He asked for it to be fixed.

## Summary

- Raise the clock card's flex allocation from `190px` to `215px` to match its declared height.
- Compensate by shrinking the forecast strip's flex allocation from `95px` to `80px`.
- Total remains 295px + 4px gap = 299px, within the 300px grid row.

## Test plan

- [ ] Clock time renders fully without right/bottom clipping
- [ ] Date line (e.g. "Tuesday, Jun 2") renders fully
- [ ] Forecast strip (Tue/Wed/Thu/Fri) still renders in its row
- [ ] Adjacent cells unchanged

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)