### PR TITLE
Kiosk clock: fix date line clipping by expanding top row height

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -48,7 +48,7 @@ views:
       overflow: hidden
       grid-gap: 8px
       grid-template-columns: 1fr 1fr 1.4fr 1fr
-      grid-template-rows: 300px 1fr
+      grid-template-rows: 340px 1fr
       grid-template-areas: |
         "weather weather alarm   meeting"
         "climate sensors lights  media"
@@ -90,8 +90,8 @@ views:
                vstack-collapses-to-content failure mode we saw with
                flex: 1 1 auto on the grow side. */
             ha-card hui-vertical-stack-card > :first-child {
-              flex: 0 0 215px !important;
-              min-height: 215px;
+              flex: 0 0 255px !important;
+              min-height: 255px;
             }
             ha-card hui-vertical-stack-card > :last-child {
               flex: 0 0 80px !important;
@@ -105,8 +105,8 @@ views:
               card_mod:
                 style: |
                   ha-card {
-                    height: 215px !important;
-                    max-height: 215px !important;
+                    height: 255px !important;
+                    max-height: 255px !important;
                     overflow: hidden !important;
                     background: transparent !important;
                     border: none !important;
@@ -114,7 +114,7 @@ views:
                   }
                   ha-card > * {
                     height: 100% !important;
-                    max-height: 215px !important;
+                    max-height: 255px !important;
                     overflow: hidden !important;
                     display: block !important;
                   }


### PR DESCRIPTION
## Origin

Chris reported that after PR #356 the clock time was still visually cut off. A native-resolution crop of the snapshot revealed the date line ("Tuesday, Jun 2") was completely absent — the 215px clock allocation was still too short, pushing the date past the `overflow: hidden` boundary. He asked for a proper fix.

## Summary

- Bump `grid-template-rows` first row from `300px` to `340px`.
- Raise clock card flex allocation from `215px` to `255px` (and matching inner mod-card `height`/`max-height`).
- Forecast strip stays at `80px`; total is 255 + 80 + 4px gap = 339px, fitting cleanly in the 340px row.
- Confirmed via native-resolution crop: time, conditions, date line, and forecast strip all render fully.

## Test plan

- [ ] Native-res crop of clock area shows full time string
- [ ] Date line ("Tuesday, Jun 3" or similar) visible below the time
- [ ] Forecast strip (Tue/Wed/Thu/Fri) still renders
- [ ] Adjacent cells (alarm, meeting) unaffected

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)