### PR TITLE
Kiosk row 1: align alarm + presence cells; add --debug-cells design aid

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -299,7 +299,10 @@ views:
               gap: 8px;
             }
             /* Flex cascade through the vertical-stack so the hero
-               grows and the action row stays a fixed 90px. */
+               grows and the action row stays a fixed 84px. Hero 185 +
+               gap 8 + action 84 = 277, leaving an ~8px bottom margin
+               inside the 285px cell so the action row clears the
+               lights cell below. */
             ha-card hui-vertical-stack-card {
               flex: 1 1 auto;
               min-height: 0;
@@ -308,12 +311,12 @@ views:
               gap: 8px;
             }
             ha-card hui-vertical-stack-card > :first-child {
-              flex: 0 0 190px !important;
-              min-height: 190px;
+              flex: 0 0 185px !important;
+              min-height: 185px;
             }
             ha-card hui-vertical-stack-card > :last-child {
-              flex: 0 0 90px !important;
-              min-height: 90px;
+              flex: 0 0 84px !important;
+              min-height: 84px;
             }
             ha-card > * {
               flex: 1 1 auto;
@@ -329,13 +332,13 @@ views:
             card_mod:
               style: |
                 ha-card {
-                  height: 200px !important;
+                  height: 185px !important;
                   background: transparent !important;
                   border: none !important;
                   box-shadow: none !important;
                 }
                 /* Force the button-card host element to fill the
-                   200px slot — the inner styles.card.height: 100%
+                   185px slot — the inner styles.card.height: 100%
                    only resolves if this host is also 100%. */
                 ha-card > * {
                   height: 100% !important;
@@ -460,7 +463,7 @@ views:
             card_mod:
               style: |
                 ha-card {
-                  height: 90px !important;
+                  height: 84px !important;
                   background: transparent !important;
                   border: none !important;
                   box-shadow: none !important;
@@ -541,8 +544,8 @@ views:
               gap: 6px;
             }
             ha-card hui-vertical-stack-card > :first-child {
-              flex: 0 0 162px !important;
-              min-height: 162px;
+              flex: 0 0 151px !important;
+              min-height: 151px;
             }
             ha-card hui-vertical-stack-card > :nth-child(2) {
               flex: 0 0 120px !important;
@@ -639,7 +642,7 @@ views:
                   label: [{ color: 'var(--kiosk-text-tertiary)' }]
             styles:
               card:
-                - height: '100%'
+                - height: '151px'
                 - border-radius: '10px'
                 - border: 'none'
                 - padding: '12px 24px'

--- a/kiosk-host/README.md
+++ b/kiosk-host/README.md
@@ -135,12 +135,18 @@ kiosk-host/kiosk-preview dashboards/homelab-views/hardware.yaml \
 # `kiosk-show --kiosk <URL>` instead of F5 (~10–15s vs ~3s for F5)
 kiosk-host/kiosk-preview dashboards/homelab-status.yaml \
   --url http://homeassistant.local:8123/dashboard-homelab-status/ups-detail
+
+# Debug overlay: distinct pure-color outline per grid-area cell, so a
+# snapshot can be measured by color (see Design session protocol §
+# "Measuring layout precisely"). Injected on a temp copy — never committed.
+kiosk-host/kiosk-preview --debug-cells --open
 ```
 
 | Flag | When to reach for it |
 |---|---|
 | `--dashboard-root FILE` | The pushed file is `!include`d by another dashboard YAML; pass the manifest path |
 | `--url URL` | Chromium needs to point at a different URL (new dashboard, view, or subview); skips F5 for a `kiosk-show` restart |
+| `--debug-cells` | You need to measure cell geometry precisely — injects a distinct color outline per grid-area cell (temp copy only; never commits borders) |
 | `--open` | xdg-open the captured PNG after capture |
 | `--keep` | Suppress the gitops-clobber reminder |
 | `--no-snapshot` | Push + refresh only; no capture (use when you're physically watching the monitor) |
@@ -275,6 +281,65 @@ edit→commit→wait-5min-for-gitops cycle:
      the snapshot incidentally surfaces. File a GitHub issue per the
      repo's "incidentally-observed latent problems" convention if it
      warrants follow-up.
+
+**Measuring layout precisely — when eyeballing fails.** Brightness
+heuristics and thumbnails lie. Two compounding traps, and the tools that
+beat them. (Every one of these produced a wrong "confirmed" in the
+session that wrote this — take them seriously.)
+
+*The traps.* Kiosk cards are dark-on-dark with no borders, so you cannot
+see where one cell's box ends and the next begins, and a downscaled
+thumbnail blurs every edge into the background. A model that measures
+"where does the content end" by scanning for bright pixels will (a)
+latch onto the nearest bright glyph *across* a cell boundary and
+misattribute it (e.g. read album art two rows down as the presence
+cell), and (b) mistake a top-aligned text label for the bottom of its
+card box, inventing a gap that isn't there. Eyeballing column x-ranges
+instead of computing them from the grid's `fr` units makes a measurement
+window straddle two cells.
+
+*Tool 1 — `kiosk-preview --debug-cells`.* Pushes a temp copy of the YAML
+with a distinct pure-color outline injected per grid-area cell
+(weather=cyan, alarm=magenta, meeting=yellow, …); the local file and the
+committed dashboard never carry borders. Each cell's true box is then one
+`np.where(color)` away, independent of its contents:
+
+```python
+from PIL import Image; import numpy as np
+a = np.asarray(Image.open('kiosk-preview-<ts>.png').convert('RGB')).astype(int)
+R, G, B = a[:,:,0], a[:,:,1], a[:,:,2]
+def box(c):
+    r, g, b = c
+    m = (abs(R-r) < 40) & (abs(G-g) < 40) & (abs(B-b) < 40)
+    ys, xs = np.where(m)
+    return (xs.min(), xs.max(), ys.min(), ys.max())
+print('alarm cell box', box((255, 0, 255)))   # magenta
+```
+
+With the box known, measure content *inside* it — and measure the card
+*box*, not its text. Detect a card's accent border color (e.g. the green
+`--kiosk-accent-disarmed` ≈ `(86,211,100)` left border), not the label
+glyphs; the label is top-aligned, so reading it as the card bottom is how
+you hallucinate a gap. A cell whose content box reaches the colored
+outline is filling its cell; one that stops well short is underfilling;
+one whose content extends *past* the outline is overflowing into its
+neighbor.
+
+*Tool 2 — zoom in, crop at native resolution.* Never judge typography or
+alignment from the downscaled full-frame PNG. Crop the region of interest
+at full 2560-wide resolution and read *that*:
+
+```python
+Image.open('shot.png').crop((1168, 0, 2545, 300)).save('/tmp/z.png')
+```
+
+A clipped clock digit or a 20px gap is obvious at native res and
+invisible in a thumbnail. Crop first, then look.
+
+*Discipline.* Do not say "confirmed" / "flush" / "aligned" from a
+thumbnail or a brightness scan. Either the colored box bounds agree or a
+native-resolution crop shows it plainly. If two readings disagree, the
+measurement is wrong — re-measure, don't rationalize.
 
 **Live-state caveats** (look at the captured PNG with these in mind):
 

--- a/kiosk-host/kiosk-preview
+++ b/kiosk-host/kiosk-preview
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   kiosk-preview [YAML_PATH] [--open] [--keep] [--no-snapshot]
-#                 [--dashboard-root FILE] [--url URL]
+#                 [--dashboard-root FILE] [--url URL] [--debug-cells]
 #   kiosk-preview --help
 #
 # Defaults YAML_PATH to ./dashboards/kiosk.yaml (run from the repo root).
@@ -12,6 +12,16 @@
 # under dashboards/), sends F5 to Chromium on pve2 via xdotool, and
 # curls a fresh snapshot back to ./kiosk-preview-<UTC>.png (--open
 # xdg-opens it).
+#
+#   --debug-cells           Inject a distinct pure-color outline per
+#                           grid-area cell into the pushed YAML (the local
+#                           file is never modified — injection happens on a
+#                           temp copy). Each cell box becomes detectable by
+#                           a single color, so a screenshot can be measured
+#                           with `np.where(color)` instead of guessing box
+#                           edges from dark-on-dark content. A design-debug
+#                           aid — see kiosk-host/README.md § Design session
+#                           protocol. Off by default; never commit borders.
 #
 # Iterating a non-flat dashboard (lens views, drill-down subviews, etc.):
 #   --dashboard-root FILE   Touches FILE on HA after the push, to bust
@@ -81,6 +91,7 @@ keep_after_session=0
 snapshot=1
 dashboard_root=""
 url=""
+debug_cells=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help) usage; exit 0;;
@@ -93,6 +104,7 @@ while [[ $# -gt 0 ]]; do
     --url)
       [[ $# -lt 2 ]] && { err "--url requires an argument"; exit 2; }
       url="$2"; shift 2;;
+    --debug-cells) debug_cells=1; shift;;
     -*) err "unknown flag: $1"; usage >&2; exit 2;;
     *) yaml_path="$1"; shift;;
   esac
@@ -177,6 +189,57 @@ target_base=$(basename "$target_path")
 ts=$(date -u +%Y%m%dT%H%M%SZ)
 total_start=$EPOCHREALTIME
 
+# --- 1b. Debug-cell outline injection (--debug-cells) ----------------------
+# Give each grid-area cell a distinct pure-color outline so a screenshot can
+# be measured by color (np.where) instead of guessing box edges from
+# dark-on-dark content. Injection runs on a temp copy — the local file and
+# the committed dashboard never carry borders. The deployed preview still
+# self-resets on the next gitops poll like any other preview push.
+push_source="$yaml_path"
+debug_tmp=""
+if (( debug_cells == 1 )); then
+  step "injecting debug-cell outlines (temp copy)"
+  debug_tmp=$(mktemp --suffix=.yaml)
+  if python3 - "$yaml_path" "$debug_tmp" <<'PY_EOF'
+import sys, re
+src, dst = sys.argv[1], sys.argv[2]
+lines = open(src).read().split('\n')
+# Deterministic palette: high-saturation, easy to isolate by exact color.
+palette = ['#00ffff', '#ff00ff', '#ffff00', '#ff8000', '#00ff00', '#ff0000',
+           '#8000ff', '#00ff80', '#ff0080', '#80ff00', '#0080ff', '#ff4040']
+grid_re = re.compile(r'grid-area:\s*([A-Za-z0-9_-]+)')
+known, out, i, n = {}, [], 0, 0
+while i < len(lines):
+    out.append(lines[i])
+    if 'view_layout:' in lines[i] and 'grid-area:' in lines[i]:
+        m = grid_re.search(lines[i])
+        area = m.group(1) if m else f'cell{n}'
+        color = known.setdefault(area, palette[len(known) % len(palette)])
+        # Inject the outline right after the cell's first `ha-card {`.
+        j = i + 1
+        while j < len(lines) and j < i + 8:
+            out.append(lines[j])
+            if lines[j].strip() == 'ha-card {':
+                pad = ' ' * (len(lines[j]) - len(lines[j].lstrip()) + 2)
+                out.append(f'{pad}outline: 8px solid {color} !important;')
+                out.append(f'{pad}outline-offset: -8px !important;')
+                n += 1
+                i = j
+                break
+            j += 1
+    i += 1
+open(dst, 'w').write('\n'.join(out))
+sys.stderr.write(f'  injected {n} cell outlines\n')
+PY_EOF
+  then
+    push_source="$debug_tmp"
+    ok "debug-cell outlines injected"
+  else
+    err "debug-cell injection failed; pushing original YAML"
+    rm -f "$debug_tmp"; debug_tmp=""
+  fi
+fi
+
 # --- 2. Push to HA ---------------------------------------------------------
 step "pushing → ${HA_USER}@${HA_HOST}:${target_path}"
 push_start=$EPOCHREALTIME
@@ -187,13 +250,15 @@ push_start=$EPOCHREALTIME
 if ! ssh -p "$HA_SSH_PORT" -o ConnectTimeout=5 -o BatchMode=yes \
         "${HA_USER}@${HA_HOST}" \
         "set -e; mkdir -p '${target_dir}'; tmp='${target_dir}/.${target_base}.preview-tmp'; cat > \"\$tmp\" && mv \"\$tmp\" '${target_path}'" \
-        < "$yaml_path"; then
+        < "$push_source"; then
   err "ssh-stdin push to HA failed. Verify SSH access:"
   err "  ssh -p ${HA_SSH_PORT} ${HA_USER}@${HA_HOST} 'echo ok'"
   err "If you haven't set up HAOS SSH yet, see HA docs:"
   err "  https://developers.home-assistant.io/docs/operating-system/debugging"
+  [[ -n "$debug_tmp" ]] && rm -f "$debug_tmp"
   exit 1
 fi
+[[ -n "$debug_tmp" ]] && rm -f "$debug_tmp"
 push_ms=$(awk "BEGIN { printf \"%.0f\", ($EPOCHREALTIME - $push_start) * 1000 }")
 ok "pushed (${push_ms}ms)"
 


### PR DESCRIPTION
## Origin

After Chris caught Claude repeatedly mis-measuring the kiosk row-1 cells from thumbnails — first a false "perfectly flush" claim, then a wrong reading of the presence cell — he asked Claude to work out *why* it kept getting visually tricked and proposed giving each cell a distinct color border as a design aid Claude could see clearly. He asked to turn the borders into a reusable tool, codify the method so lower models benefit, and fix the two cells the diagnosis surfaced: the alarm cell (too tall, colliding with the lights cell below) and the presence cell (a large empty gap below its content).

## What changed

**Row-1 cell alignment (`dashboards/kiosk.yaml`)**
- **Alarm:** content was hero 200 + action 90 + 8px gap = 298px, overflowing the 285px grid row and crowding the lights cell. Trimmed to 185 + 84 + 8 = 277px so the arm-button strip clears the boundary (verified: arm buttons now end ~279 vs box 284; were spilling to ~307).
- **Presence (meeting):** the hero was a bare button-card whose `height: 100%` collapsed to natural content (~95px), leaving an ~85px gap below the HOME chips. Pinned the hero to 151px so 151 + 6 + 120 = 277px fills the box (verified: presence cards now span to ~286 ≈ box bottom).

**`--debug-cells` design aid (`kiosk-host/kiosk-preview`)**
- New opt-in flag injects a distinct pure-color outline per grid-area cell into a **temp copy** of the YAML at push time. The local file and committed dashboard never carry borders. Cell geometry becomes measurable by color (`np.where`), independent of dark-on-dark content.

**Methodology codification (`kiosk-host/README.md`)**
- Added a "Measuring layout precisely" subsection to the design-session protocol documenting the two traps (dark-on-dark with no borders; top-aligned labels read as card bottoms), the `--debug-cells` overlay, and the "crop at native resolution before judging" rule — written prescriptively for lower models.

## Verification
- Both fixes confirmed with `kiosk-preview --debug-cells` + per-color box detection and native-resolution crops (not thumbnails).
- `check-dashboard-entities.py` passes for all dashboards; `bash -n` clean; no >250-char YAML lines.

## Test plan
- [ ] CI: YAML Lint, check-config, claude-review green
- [ ] Post-merge: confirm row 1 renders with alarm + presence aligned to weather on the live kiosk