### PR TITLE
Kiosk host: point household monitor at /dashboard-kiosk-codesign

### DIFF
--- a/kiosk-host/dashboard-kiosk.sh
+++ b/kiosk-host/dashboard-kiosk.sh
@@ -14,7 +14,11 @@
 set -eu
 
 KIOSK_MODE="kiosk"
-KIOSK_URL="http://homeassistant.local:8123/dashboard-kiosk/home"
+# Staging: household monitor renders the co-design sandbox
+# (/dashboard-kiosk-codesign/home). Iterate against that URL and promote
+# to /dashboard-kiosk/home when satisfied. Promotion is a content copy:
+# `cp dashboards/kiosk-codesign.yaml dashboards/kiosk.yaml` + PR.
+KIOSK_URL="http://homeassistant.local:8123/dashboard-kiosk-codesign/home"
 
 if [ -r /etc/default/dashboard-kiosk ]; then
   # shellcheck disable=SC1091


### PR DESCRIPTION
## Origin

After Chris had Claude create both a UI-managed and a YAML-managed duplicate of the kiosk dashboard, he asked Claude to point the household kiosk display at the codesign version so iteration appears on the monitor as a staging area, with manual promotion to the main kiosk when satisfied.

## What changed

\`kiosk-host/dashboard-kiosk.sh\` — \`KIOSK_URL\` from \`/dashboard-kiosk/home\` to \`/dashboard-kiosk-codesign/home\`. Added a comment explaining the staging role and how to promote.

## Verified before opening

- PR #363 (which registers \`dashboard-kiosk-codesign\`) merged at 2026-06-03T13:28:12Z.
- HA Core has restarted and the codesign URL serves HTTP 200.

## Deploy flow

On merge, pve2's \`dashboard-kiosk-gitops.timer\` (5-min cadence) detects the changed script via \`cmp -s\`, reinstalls \`/usr/local/bin/dashboard-kiosk.sh\`, and restarts \`dashboard-kiosk.service\`. Chromium relaunches at the codesign URL. Brief screen flicker on the household monitor.

## Promotion workflow (for when iteration is satisfactory)

\`\`\`
cp dashboards/kiosk-codesign.yaml dashboards/kiosk.yaml
# restore kiosk.yaml's original header comment if needed
git add dashboards/kiosk.yaml && git commit -m "Promote kiosk-codesign to kiosk" && gh pr create ...
\`\`\`

## Test plan

- [ ] CI: claude-review green (no YAML/check-config gates fire on a shell-script-only diff)
- [ ] Post-merge: within ~5 min, the household monitor renders \`/dashboard-kiosk-codesign/home\` (same visual as before since content is currently identical)