### PR TITLE
Roadmap: capture Firewalla consider_home tuning as presence follow-up

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,6 +13,16 @@ work actually starts.
 - **Roku integration** — Two Rokus unreachable; possible Firewalla Smart
   Protect interference. Diagnose, then decide whether to whitelist or drop.
 
+## Presence
+
+- **Firewalla `consider_home` tuning** — Default window flaps Android
+  device_trackers to `not_home` during routine doze (observed on
+  Rachel-s-S23; see #365). Person aggregation now papers over it for
+  Rachel via the laptop tracker, but bumping the Firewalla integration's
+  `consider_home` to ~900s would also debounce single-source phone
+  trackers (`device_tracker.galaxy_s22_presence`,
+  `device_tracker.chris_phone_presence`).
+
 ## Dashboards
 
 - **Roblox activity detector** — Query Loki for Zeek DNS logs matching


### PR DESCRIPTION
Adds a Presence section to `ROADMAP.md` with one item: bump the Firewalla integration's `consider_home` window so single-source phone device_trackers stop flapping during Android doze.

## Origin

After Chris asked to file and fix an HA presence bug — Rachel was marked `not_home` while sitting on the LAN — the underlying cause was a single doze-prone phone device_tracker with no aggregator. PR #367 (closing #365) shipped the two-pronged fix (Rachel-Laptop as a second source + `person.rachel_morse`). The optional third leg from #365 — widening `consider_home` on the Firewalla integration — was skipped because Rachel's flap is now masked at the person level. Chris asked to capture that follow-up in the roadmap so the other single-source phones (Galaxy-S22, Chris-Phone) aren't forgotten.

## Test plan

- [x] `git diff` shows only the Presence section addition
- [ ] CI (`YAML Lint`) green — markdown-only change