### PR TITLE
Kiosk: recycle Chromium every 6h to defeat V8 heap leak (#308)

### DIFF
--- a/kiosk-host/dashboard-kiosk.service
+++ b/kiosk-host/dashboard-kiosk.service
@@ -6,8 +6,16 @@ Wants=network-online.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/xinit /usr/local/bin/dashboard-kiosk.sh -- :0
-Restart=on-failure
+# Restart=always (not on-failure) so the clean SIGTERM driven by
+# RuntimeMaxSec below also triggers a respawn — on-failure would not.
+Restart=always
 RestartSec=10
+# Recycle every 6h to defeat the Chromium V8 heap leak (#308): the
+# dashboard tab OOMs after ~7h (peak ~5.2 GB), then Chromium falls
+# back to its new-tab UI while the service stays green. 21600s caps
+# uptime under the observed failure point. Costs 4 brief flickers/day
+# the household already tolerates from gitops-driven restarts.
+RuntimeMaxSec=21600
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Origin

Chris asked Claude to fix the silent kiosk-OOM bug from the open-issues triage as autonomously as possible. Claude applied the issue body's own recommended fix.

## What changed

\`kiosk-host/dashboard-kiosk.service\`:

- Added \`RuntimeMaxSec=21600\` (6h ceiling on the kiosk process).
- Changed \`Restart=on-failure\` → \`Restart=always\` so the clean SIGTERM that \`RuntimeMaxSec\` issues actually triggers a respawn (\`on-failure\` would not — it ignores clean exits).
- Kept \`RestartSec=10\`.

## Why this cadence

Failure mode (#308): the dashboard tab OOMs after ~7h (peak 5.2 GB), Chromium drops to its new-tab UI, \`systemctl\` reports green. 21600s caps uptime safely under the observed failure point. The leak diagnosis itself stays open as a separate workstream.

The household sees the same kind of brief flicker as gitops-driven kiosk restarts, just 4× per day at most.

## Validation

- \`systemd-analyze verify\` locally accepts the unit's directives. (The only complaint is about \`/usr/bin/xinit\` not existing on this Ubuntu workstation — pve2 has it. Real verify runs in the pve2-side gitops-pull validator before install.)

## Deploy flow

1. PR merges.
2. pve2's \`dashboard-kiosk-gitops.timer\` (5-min cadence) detects the changed unit, \`systemd-analyze\`s it, reinstalls \`/etc/systemd/system/dashboard-kiosk.service\`, runs \`systemctl daemon-reload\` + \`systemctl restart dashboard-kiosk.service\`.
3. The new 6h ceiling starts counting from that restart.

## Verify post-deploy

\`\`\`
ssh -J root@pve.local root@pve2 'systemctl show dashboard-kiosk.service -p RuntimeMaxUSec -p Restart'
# RuntimeMaxUSec=21600000000
# Restart=always
\`\`\`

Closes #308

## Test plan

- [ ] CI: claude-review green (no YAML/check-config gates fire on a systemd-unit-only diff)
- [ ] Post-merge: \`systemctl show\` on pve2 reports the new directives within 5 min
- [ ] After 6h of uptime, observe a clean dashboard-kiosk.service restart in pve2's journal (no OOM, no fallback to new-tab page)