### PR TITLE
Kiosk: guard round() on None for forecast strip + humidity badges (#326)

### DIFF
--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -156,8 +156,11 @@ views:
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[0] %}
                       {{ (fc.datetime | as_datetime | as_local).strftime('%a') }}
                     secondary: |-
-                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[0] %}
-                      {{ fc.temperature | round }}° / {{ fc.templow | round }}°
+                      {% set forecast = state_attr('sensor.weather_forecast_daily', 'forecast') or [] %}
+                      {% set fc = forecast[0] if forecast|count > 0 else {} %}
+                      {% set t = fc.get('temperature') %}
+                      {% set tl = fc.get('templow') %}
+                      {{ (t | round) if t is not none else "—" }}° / {{ (tl | round) if tl is not none else "—" }}°
                     icon: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[0] %}
                       {% set m = {
@@ -203,8 +206,11 @@ views:
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[1] %}
                       {{ (fc.datetime | as_datetime | as_local).strftime('%a') }}
                     secondary: |-
-                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[1] %}
-                      {{ fc.temperature | round }}° / {{ fc.templow | round }}°
+                      {% set forecast = state_attr('sensor.weather_forecast_daily', 'forecast') or [] %}
+                      {% set fc = forecast[1] if forecast|count > 1 else {} %}
+                      {% set t = fc.get('temperature') %}
+                      {% set tl = fc.get('templow') %}
+                      {{ (t | round) if t is not none else "—" }}° / {{ (tl | round) if tl is not none else "—" }}°
                     icon: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[1] %}
                       {% set m = {
@@ -229,8 +235,11 @@ views:
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[2] %}
                       {{ (fc.datetime | as_datetime | as_local).strftime('%a') }}
                     secondary: |-
-                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[2] %}
-                      {{ fc.temperature | round }}° / {{ fc.templow | round }}°
+                      {% set forecast = state_attr('sensor.weather_forecast_daily', 'forecast') or [] %}
+                      {% set fc = forecast[2] if forecast|count > 2 else {} %}
+                      {% set t = fc.get('temperature') %}
+                      {% set tl = fc.get('templow') %}
+                      {{ (t | round) if t is not none else "—" }}° / {{ (tl | round) if tl is not none else "—" }}°
                     icon: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[2] %}
                       {% set m = {
@@ -255,8 +264,11 @@ views:
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[3] %}
                       {{ (fc.datetime | as_datetime | as_local).strftime('%a') }}
                     secondary: |-
-                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[3] %}
-                      {{ fc.temperature | round }}° / {{ fc.templow | round }}°
+                      {% set forecast = state_attr('sensor.weather_forecast_daily', 'forecast') or [] %}
+                      {% set fc = forecast[3] if forecast|count > 3 else {} %}
+                      {% set t = fc.get('temperature') %}
+                      {% set tl = fc.get('templow') %}
+                      {{ (t | round) if t is not none else "—" }}° / {{ (tl | round) if tl is not none else "—" }}°
                     icon: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[3] %}
                       {% set m = {
@@ -876,7 +888,7 @@ views:
                       - type: template
                         icon: mdi:water-percent
                         icon_color: blue
-                        content: '{{ states("sensor.upstairs_humidity") | round }}%'
+                        content: '{% set h = states("sensor.upstairs_humidity") | float(none) %}{{ (h | round) if h is not none else "—" }}%'
                       - type: template
                         icon: mdi:thermometer
                         icon_color: amber
@@ -998,7 +1010,7 @@ views:
                       - type: template
                         icon: mdi:water-percent
                         icon_color: blue
-                        content: '{{ states("sensor.downstairs_humidity") | round }}%'
+                        content: '{% set h = states("sensor.downstairs_humidity") | float(none) %}{{ (h | round) if h is not none else "—" }}%'
                       - type: template
                         icon: mdi:thermometer
                         icon_color: amber


### PR DESCRIPTION
## Origin

Chris asked Claude to fix the round-on-None log spam after the open-issues triage. The explanation noted both dashboard and log cost, but the household-visible cost is transient (cells show \"Error\" briefly during startup/outages) — log noise (~42 \`TemplateError\` tracebacks/hr in \`home-assistant.log\`) was the dominant motivation, since it buries genuinely useful errors during incident investigation.

## What changed

\`dashboards/kiosk.yaml\` — six bare \`| round\` template calls now use the same \`is not none else \"—\"\` pattern already in the file (lines 839/887/961/1009 for setpoint displays):

- **4 forecast secondary templates** (\`[0]\`..\`[3]\`): pre-fetch the forecast list with \`or []\`, gate the index with \`forecast|count > N\`, pull temp/templow via \`.get()\` so missing keys yield None instead of Undefined.
- **2 humidity badge content templates**: cast the state with \`| float(none)\` so \`\"unknown\"\`/\`\"unavailable\"\` strings map to None before round.

## Verified before opening

Ran \`ha_eval_template\` against the live HA on five scenarios:

| Case | Result |
|---|---|
| Forecast happy path \`[0]\` | \`82° / 63°\` |
| Forecast out-of-bounds index \`[99]\` | \`—° / —°\` |
| Forecast on a non-existent sensor | \`—° / —°\` |
| Humidity happy path | \`50%\` |
| Humidity unknown state | \`—%\` |

All five render cleanly — happy paths produce real numbers, every failure path produces \`—\` with zero template errors.

## Scope notes

- Touched **only** the round() calls. The forecast row's icon / icon_color / primary templates also access \`state_attr(...)[N]\` and may also error during the same startup window, but the issue evidence specifically called out round-on-None and HA's logged stacktraces are round-specific. If any non-round template errors persist after this merge, that's a follow-up worth filing — fix-forward.

## Test plan

- [ ] CI: YAML Lint, check-config, claude-review green
- [ ] Post-merge: scan \`home-assistant.log\` for \`round got invalid input 'None'\` over a 1h window — should report 0 occurrences
- [ ] Visual on the kiosk: cells render real values during happy state, render \`—\` (not error glyphs) during any brief sensor outage

Closes #326