### PR TITLE
Kiosk climate: swap BTUI dial for built-in thermostat card (#354)

### DIFF
--- a/dashboards/kiosk-codesign.yaml
+++ b/dashboards/kiosk-codesign.yaml
@@ -814,19 +814,20 @@ views:
               card:
                 type: vertical-stack
                 cards:
-                  # Active mode (heat / cool / heat_cool): show the BTUI dial
+                  # Active mode (heat / cool / heat_cool): show the dial card.
+                  # Built-in `type: thermostat` works with any climate entity;
+                  # was custom:better-thermostat-ui-card but that card targets
+                  # the Better Thermostat HACS integration and error-bands on
+                  # plain climate entities (#354).
                   - type: conditional
                     conditions:
                       - condition: state
                         entity: climate.upstairs
                         state_not: 'off'
                     card:
-                      type: custom:better-thermostat-ui-card
+                      type: thermostat
                       entity: climate.upstairs
                       name: Upstairs
-                      humidity: sensor.upstairs_humidity
-                      disable_buttons: false
-                      disable_menu: false
                       card_mod:
                         style: |
                           ha-card { background: transparent !important; border: none !important; box-shadow: none !important; }
@@ -937,18 +938,17 @@ views:
                 type: vertical-stack
                 cards:
                   # Active mode (heat / cool / heat_cool): show the BTUI dial
+                  # Active mode (heat / cool / heat_cool): built-in dial.
+                  # See upstairs note above (#354).
                   - type: conditional
                     conditions:
                       - condition: state
                         entity: climate.downstairs
                         state_not: 'off'
                     card:
-                      type: custom:better-thermostat-ui-card
+                      type: thermostat
                       entity: climate.downstairs
                       name: Downstairs
-                      humidity: sensor.downstairs_humidity
-                      disable_buttons: false
-                      disable_menu: false
                       card_mod:
                         style: |
                           ha-card { background: transparent !important; border: none !important; box-shadow: none !important; }

--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -819,19 +819,20 @@ views:
               card:
                 type: vertical-stack
                 cards:
-                  # Active mode (heat / cool / heat_cool): show the BTUI dial
+                  # Active mode (heat / cool / heat_cool): show the dial card.
+                  # Built-in `type: thermostat` works with any climate entity;
+                  # was custom:better-thermostat-ui-card but that card targets
+                  # the Better Thermostat HACS integration and error-bands on
+                  # plain climate entities (#354).
                   - type: conditional
                     conditions:
                       - condition: state
                         entity: climate.upstairs
                         state_not: 'off'
                     card:
-                      type: custom:better-thermostat-ui-card
+                      type: thermostat
                       entity: climate.upstairs
                       name: Upstairs
-                      humidity: sensor.upstairs_humidity
-                      disable_buttons: false
-                      disable_menu: false
                       card_mod:
                         style: |
                           ha-card { background: transparent !important; border: none !important; box-shadow: none !important; }
@@ -942,18 +943,17 @@ views:
                 type: vertical-stack
                 cards:
                   # Active mode (heat / cool / heat_cool): show the BTUI dial
+                  # Active mode (heat / cool / heat_cool): built-in dial.
+                  # See upstairs note above (#354).
                   - type: conditional
                     conditions:
                       - condition: state
                         entity: climate.downstairs
                         state_not: 'off'
                     card:
-                      type: custom:better-thermostat-ui-card
+                      type: thermostat
                       entity: climate.downstairs
                       name: Downstairs
-                      humidity: sensor.downstairs_humidity
-                      disable_buttons: false
-                      disable_menu: false
                       card_mod:
                         style: |
                           ha-card { background: transparent !important; border: none !important; box-shadow: none !important; }


### PR DESCRIPTION
## Origin

Chris asked Claude to continue the open-issues triage and tackle the next P1 (#354) autonomously. Snapshot proved the visual error, card-attribute comparison ruled out config drift between upstairs/downstairs, and the bug landed at the card type itself being mismatched to the entities.

## Diagnosis

\`custom:better-thermostat-ui-card\` targets the Better Thermostat HACS integration. On plain climate entities it renders a card-error band with no entry in the HA error log — silent at the integration layer, loud on the kiosk. \`climate.upstairs\` and \`climate.downstairs\` are not Better-Thermostat-backed, so this card has been broken whenever either thermostat is in an active state. The issue surfaced visually only on the second cell because upstairs was \`off\` and the kiosk's conditional fell through to the standby mushroom card; downstairs was \`cool\` and exercised the active-dial path.

## What changed

Both active-mode conditionals (upstairs + downstairs) now use the built-in \`type: thermostat\` dial card. Applied to:
- \`dashboards/kiosk.yaml\` — canonical
- \`dashboards/kiosk-codesign.yaml\` — staging copy (kept in sync)

Dropped the BTUI-specific keys (\`humidity\`, \`disable_buttons\`, \`disable_menu\`) — they were no-ops for non-BT entities. The humidity badge is already in the chips card below the dial, so no information is lost.

## Verified before opening

Live verification on the household monitor (currently rendering the codesign sandbox per PR #364): downstairs cell now displays "Downstairs / Idle / 78°F / 69°F" cleanly, full frame intact. The F5 path was insufficient to surface the fix — Chromium had BTUI's JS cached. Needed a \`--url\` restart on the kiosk to verify; once gitops deploys this PR, pve2's restart cadence picks up the new card type naturally.

Before/after climate-cell crops in the session transcript.

## Test plan

- [ ] CI: YAML Lint, check-config, claude-review green
- [ ] Post-merge: within ~5 min, the household monitor's climate cell renders the dial for any active thermostat (no red error band)
- [ ] Upstairs path (not visible while \`off\`) — when upstairs flips to active, dial renders the same as downstairs

Closes #354