### PR TITLE
Kiosk camera: switch to camera_view: live for indefinite stream (#355)

### DIFF
--- a/dashboards/kiosk-codesign.yaml
+++ b/dashboards/kiosk-codesign.yaml
@@ -1093,8 +1093,11 @@ views:
                     overflow: hidden;
                     background: var(--kiosk-bg-tile);
                   }
-                  /* Picture-entity fill: stretch the image to the tile. */
-                  ha-card hui-image, ha-card .image {
+                  /* Picture-entity fill: stretch image OR live <video> to the tile.
+                     camera_view: live renders <ha-camera-stream>/<video>,
+                     not <hui-image>, so the video selector matters too. */
+                  ha-card hui-image, ha-card .image,
+                  ha-card ha-camera-stream, ha-card video {
                     height: 100% !important;
                     width: 100% !important;
                     object-fit: cover !important;
@@ -1102,7 +1105,11 @@ views:
               card:
                 type: picture-entity
                 entity: camera.front_door
-                camera_view: auto
+                # `live` uses the camera's HLS stream (session-based) so the
+                # tile keeps painting indefinitely. `auto` was falling back to
+                # a snapshot whose Nest access token rotates every few minutes,
+                # going black between refreshes (#355).
+                camera_view: live
                 show_name: false
                 show_state: false
                 tap_action: { action: more-info }

--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -1098,8 +1098,11 @@ views:
                     overflow: hidden;
                     background: var(--kiosk-bg-tile);
                   }
-                  /* Picture-entity fill: stretch the image to the tile. */
-                  ha-card hui-image, ha-card .image {
+                  /* Picture-entity fill: stretch image OR live <video> to the tile.
+                     camera_view: live renders <ha-camera-stream>/<video>,
+                     not <hui-image>, so the video selector matters too. */
+                  ha-card hui-image, ha-card .image,
+                  ha-card ha-camera-stream, ha-card video {
                     height: 100% !important;
                     width: 100% !important;
                     object-fit: cover !important;
@@ -1107,7 +1110,11 @@ views:
               card:
                 type: picture-entity
                 entity: camera.front_door
-                camera_view: auto
+                # `live` uses the camera's HLS stream (session-based) so the
+                # tile keeps painting indefinitely. `auto` was falling back to
+                # a snapshot whose Nest access token rotates every few minutes,
+                # going black between refreshes (#355).
+                camera_view: live
                 show_name: false
                 show_state: false
                 tap_action: { action: more-info }


### PR DESCRIPTION
## Origin

Chris asked Claude to continue the open-issues triage. Live state check confirmed the camera was streaming with STREAM-capable feature flag, so the diagnosis became "snapshot mode is wrong for a token-rotating Nest camera"; switching to live HLS sidesteps the rotation entirely.

## Diagnosis

\`camera.front_door\` reports state \`streaming\`, brand \`Google Nest\`, \`supported_features=CameraEntityFeature.STREAM\` (2). The card was using \`picture-entity\` with \`camera_view: auto\`, which falls back to the static snapshot endpoint. Nest doorbell entities rotate their \`access_token\` every few minutes, and the cached \`entity_picture\` URL picture-entity references doesn't pick up the fresh token between rotations — so the tile renders black after the first rotation.

## What changed

- \`camera_view: auto\` → \`camera_view: live\` on the camera tile. The live mode uses the HLS stream (session-based, not token-keyed) — the kiosk picks it up once and the \`<video>\` element renders indefinitely.
- Widened the \`card_mod\` CSS to also match \`ha-camera-stream\` / \`video\` so the live view gets the same full-bleed treatment as the snapshot path did; otherwise the live render letterboxed.

Applied to both \`dashboards/kiosk.yaml\` and \`dashboards/kiosk-codesign.yaml\` in one commit since the fix was verified end-to-end on the live household monitor.

## Verified before opening

\`--url\` restart on the live kiosk; camera cell now shows the front yard with the Nest watermark, refreshing in real time, full-bleed within the cell. Full-frame screenshot also confirmed adjacent cells unchanged.

## Test plan

- [ ] CI: YAML Lint, check-config, claude-review green
- [ ] Post-merge: pve2's natural restart cadence (\`RuntimeMaxSec=6h\` from #308, or sooner on a manual restart) picks up the new card config and the household monitor renders the live camera feed continuously

Closes #355