### PR TITLE
Homelab Status data hygiene: grafana_stack _2 swap + cyberpower runtime removal (#333, #334)

### DIFF
--- a/dashboards/entity-allowlist.txt
+++ b/dashboards/entity-allowlist.txt
@@ -29,11 +29,6 @@ sensor.play_room_youtube_today
 media_player.basement_tv
 media_player.office_tv
 
-# --- CyberPower UPS (homelab-status.yaml "UPS" section) ---
-# Integration now online — most sensors resolve in the snapshot and were pruned.
-# Only battery_runtime remains absent (entity not exposed by the integration yet).
-sensor.cyberpower_battery_runtime
-
 # --- Pending integration: PitziLabs/* GitHub sensors (homelab-status.yaml) ---
 # Populated by the HACS `github_custom` integration
 # (boralyl/github-custom-component-tutorial) once configured via its UI flow.

--- a/dashboards/homelab-views/details/grafana-stack.yaml
+++ b/dashboards/homelab-views/details/grafana-stack.yaml
@@ -7,17 +7,20 @@ cards:
   - type: vertical-stack
     cards:
 
-      # Hero
+      # Hero. binary_sensor.grafana_stack_status was orphaned to
+      # `unavailable` when the Proxmox integration re-registered (#333);
+      # sensor.grafana_stack_status_2 is the live string-state replacement
+      # ('running' / 'stopped' / etc).
       - type: custom:mushroom-template-card
         primary: grafana-stack
         secondary: >
-          {% if is_state('binary_sensor.grafana_stack_status', 'on') %}
+          {% if states('sensor.grafana_stack_status_2') == 'running' %}
             LXC 105 on pve3 · Alloy + collectors → Grafana Cloud
-          {% else %}LXC 105 · {{ states('binary_sensor.grafana_stack_status') }}{% endif %}
+          {% else %}LXC 105 · {{ states('sensor.grafana_stack_status_2') }}{% endif %}
         icon: mdi:chart-line
         icon_color: >
-          {% if is_state('binary_sensor.grafana_stack_status', 'on') %}green{% else %}red{% endif %}
-        entity: binary_sensor.grafana_stack_status
+          {% if states('sensor.grafana_stack_status_2') == 'running' %}green{% else %}red{% endif %}
+        entity: sensor.grafana_stack_status_2
         tap_action: { action: none }
 
       # Live state — when the LXC is unavailable, these gauges render as empty
@@ -26,21 +29,21 @@ cards:
         square: false
         cards:
           - type: gauge
-            entity: sensor.grafana_stack_cpu_usage
+            entity: sensor.grafana_stack_cpu_usage_2
             name: CPU
             min: 0
             max: 100
             needle: true
             severity: { green: 0, yellow: 50, red: 80 }
           - type: gauge
-            entity: sensor.grafana_stack_memory_usage_percentage
+            entity: sensor.grafana_stack_memory_usage_percentage_2
             name: Memory
             min: 0
             max: 100
             needle: true
             severity: { green: 0, yellow: 70, red: 85 }
           - type: gauge
-            entity: sensor.grafana_stack_disk_usage
+            entity: sensor.grafana_stack_disk_usage_2
             name: Disk
             min: 0
             max: 100
@@ -53,59 +56,37 @@ cards:
         square: false
         cards:
           - type: custom:mushroom-entity-card
-            entity: sensor.grafana_stack_network_input
+            entity: sensor.grafana_stack_network_input_2
             name: Network in
             icon: mdi:download-network
           - type: custom:mushroom-entity-card
-            entity: sensor.grafana_stack_network_output
+            entity: sensor.grafana_stack_network_output_2
             name: Network out
             icon: mdi:upload-network
           - type: custom:mushroom-template-card
             primary: Uptime
             secondary: >
-              {% set s = states('sensor.grafana_stack_uptime') | int(-1) %}
+              {% set s = states('sensor.grafana_stack_uptime_2') | int(-1) %}
               {% if s < 0 %}—
               {% elif s >= 86400 %}{{ (s // 86400) }}d {{ ((s % 86400) // 3600) }}h
               {% elif s >= 3600 %}{{ (s // 3600) }}h {{ ((s % 3600) // 60) }}m
               {% else %}{{ (s // 60) }}m{% endif %}
             icon: mdi:clock-outline
-            entity: sensor.grafana_stack_uptime
+            entity: sensor.grafana_stack_uptime_2
             tap_action: { action: more-info }
 
-      # Notes + actions
+      # Notes
       - type: markdown
         content: >
           **Role:** Grafana Alloy + receiver collectors, ship logs +
           metrics to Grafana Cloud (`pitzilabs.grafana.net`). Legacy
           local Loki/Prom/Grafana retired 2026-05-27 in the
-          homelab-observability migration. Issue #333 tracks the
-          duplicate `*_2` sensor registration cleanup on this LXC.
+          homelab-observability migration.
 
-      - type: grid
-        columns: 4
-        square: false
-        cards:
-          - type: custom:mushroom-entity-card
-            entity: button.grafana_stack_restart
-            name: Restart LXC
-            icon: mdi:restart
-            tap_action: { action: none }
-            hold_action: { action: call-service, service: button.press, target: { entity_id: button.grafana_stack_restart } }
-          - type: custom:mushroom-entity-card
-            entity: button.grafana_stack_stop
-            name: Stop
-            icon: mdi:stop-circle
-            tap_action: { action: none }
-            hold_action: { action: call-service, service: button.press, target: { entity_id: button.grafana_stack_stop } }
-          - type: custom:mushroom-entity-card
-            entity: button.grafana_stack_start
-            name: Start
-            icon: mdi:play-circle
-            tap_action: { action: none }
-            hold_action: { action: call-service, service: button.press, target: { entity_id: button.grafana_stack_start } }
-          - type: custom:mushroom-entity-card
-            entity: button.grafana_stack_create_snapshot
-            name: Snapshot
-            icon: mdi:camera
-            tap_action: { action: none }
-            hold_action: { action: call-service, service: button.press, target: { entity_id: button.grafana_stack_create_snapshot } }
+
+          **LXC controls (start/stop/restart/snapshot):** absent from
+          this view because the Proxmox VE integration re-registration
+          (see #333) only minted new `_2` sensors — no replacement
+          `button.grafana_stack_*` entities were created, only the
+          orphaned `unavailable` originals. Control the LXC from
+          Proxmox directly until the integration is cleaned up.

--- a/dashboards/homelab-views/details/pve3.yaml
+++ b/dashboards/homelab-views/details/pve3.yaml
@@ -69,14 +69,14 @@ cards:
           - type: custom:mushroom-template-card
             primary: grafana-stack
             secondary: >
-              {% if is_state('binary_sensor.grafana_stack_status', 'on') %}
-                LXC 105 · cpu {{ states('sensor.grafana_stack_cpu_usage') | int(0) }}% ·
-                mem {{ states('sensor.grafana_stack_memory_usage_percentage') | int(0) }}%
-              {% else %}LXC 105 · {{ states('binary_sensor.grafana_stack_status') }}{% endif %}
+              {% if states('sensor.grafana_stack_status_2') == 'running' %}
+                LXC 105 · cpu {{ states('sensor.grafana_stack_cpu_usage_2') | int(0) }}% ·
+                mem {{ states('sensor.grafana_stack_memory_usage_percentage_2') | int(0) }}%
+              {% else %}LXC 105 · {{ states('sensor.grafana_stack_status_2') }}{% endif %}
             icon: mdi:chart-line
             icon_color: >
-              {% if is_state('binary_sensor.grafana_stack_status', 'on') %}green{% else %}red{% endif %}
-            entity: binary_sensor.grafana_stack_status
+              {% if states('sensor.grafana_stack_status_2') == 'running' %}green{% else %}red{% endif %}
+            entity: sensor.grafana_stack_status_2
             tap_action: { action: more-info }
 
       # Backup + boot recency

--- a/dashboards/homelab-views/details/ups.yaml
+++ b/dashboards/homelab-views/details/ups.yaml
@@ -23,9 +23,13 @@ cards:
         entity: sensor.cyberpower_status_data
         tap_action: { action: none }
 
-      # Live state
+      # Live state. Runtime-remaining card removed in #334 — the NUT
+      # integration registers sensor.cyberpower_battery_runtime but
+      # disables it by default for this UPS model (not consistently
+      # reported); re-enabling it just leaves it `unavailable`. Battery
+      # charge + load are sufficient signals for the dashboard.
       - type: grid
-        columns: 3
+        columns: 2
         square: false
         cards:
           - type: gauge
@@ -44,19 +48,6 @@ cards:
             max: 100
             needle: true
             severity: { green: 0, yellow: 50, red: 75 }
-          - type: custom:mushroom-template-card
-            primary: Runtime remaining
-            secondary: >
-              {% set s = states('sensor.cyberpower_battery_runtime') | int(-1) %}
-              {% if s < 0 %}—
-              {% elif s >= 3600 %}{{ (s // 3600) }}h {{ ((s % 3600) // 60) }}m
-              {% else %}{{ (s // 60) }}m{% endif %}
-            icon: mdi:timer-sand
-            icon_color: >
-              {% set s = states('sensor.cyberpower_battery_runtime') | int(0) %}
-              {% if s < 300 %}red{% elif s < 600 %}amber{% else %}green{% endif %}
-            entity: sensor.cyberpower_battery_runtime
-            tap_action: { action: more-info }
 
       # Power lines
       - type: entities
@@ -80,6 +71,3 @@ cards:
           nodes run `upsmon` as secondaries against neptune. NUT
           passwords live at `/root/nut-secrets/` on neptune. HA's NUT
           integration provides these sensors + a power-event automation.
-          `sensor.cyberpower_battery_runtime` is flagged in issue #334
-          (registered but disabled by default — see the dashboard
-          allowlist note).

--- a/dashboards/homelab-views/hardware.yaml
+++ b/dashboards/homelab-views/hardware.yaml
@@ -147,14 +147,14 @@ cards:
           - type: custom:mushroom-template-card
             primary: grafana-stack
             secondary: >
-              {% if is_state('binary_sensor.grafana_stack_status', 'on') %}
+              {% if states('sensor.grafana_stack_status_2') == 'running' %}
                 LXC 105 on pve3 · Alloy + collectors
-              {% else %}LXC 105 · {{ states('binary_sensor.grafana_stack_status') }}{% endif %}
+              {% else %}LXC 105 · {{ states('sensor.grafana_stack_status_2') }}{% endif %}
             icon: mdi:chart-line
             icon_color: >
-              {% if is_state('binary_sensor.grafana_stack_status', 'on') %}green
+              {% if states('sensor.grafana_stack_status_2') == 'running' %}green
               {% else %}red{% endif %}
-            entity: binary_sensor.grafana_stack_status
+            entity: sensor.grafana_stack_status_2
             tap_action: { action: navigate, navigation_path: /dashboard-homelab-status/grafana-stack-detail }
             hold_action: { action: more-info }
 


### PR DESCRIPTION
## Origin

Chris asked Claude to knock out the P2 bundle (Homelab Status data hygiene). Live-state checks reshaped the plan inside #333 — only sensors got \`_2\` variants, not binary_sensors or buttons — and the cyberpower runtime turned out to be integration-disabled, pointing cleanly to the removal branch.

## #333 — grafana_stack (LXC 105) duplicate registration

Path 2 from the issue (update dashboard refs rather than mutate the registry). Lower blast radius, no integration restart.

**Discovered during implementation:** the re-registration only minted \`sensor.*_2\` variants. There is **no** \`binary_sensor.grafana_stack_status_2\` and **no** \`button.grafana_stack_*_2\`. The base \`binary_sensor\` and button entities remain in the registry as \`unavailable\` orphans.

What changed:
- All \`sensor.grafana_stack_*\` refs swapped to \`_2\` in \`hardware.yaml\`, \`details/grafana-stack.yaml\`, \`details/pve3.yaml\`.
- The 3 \`binary_sensor.grafana_stack_status\` status checks switched to \`sensor.grafana_stack_status_2 == 'running'\` (the \`_2\` sensor reports a string state like \`running\` / \`stopped\`).
- The 4-card start/stop/restart/snapshot button grid removed from \`details/grafana-stack.yaml\`. Markdown narrative updated to say the LXC must be controlled from Proxmox directly until the integration is cleaned up.

## #334 — sensor.cyberpower_battery_runtime disabled

\`ha_get_entity\` confirmed \`disabled_by="integration"\` — NUT disabled it by default for this UPS model; re-enabling just leaves it \`unavailable\`. Took the removal branch from the issue's decision tree.

What changed:
- \`details/ups.yaml\`: removed the "Runtime remaining" template card. The "Live state" grid drops from 3 → 2 columns (Battery + Load gauges remain).
- Markdown narrative no longer references #334.
- \`entity-allowlist.txt\`: removed the CyberPower UPS block.

## Verified

\`scripts/check-dashboard-entities.py\` run recursively over \`find dashboards -type f -name '*.yaml'\` (a manual preview of what #343 will eventually do in CI): every homelab-views file reports OK, every entity reference resolves. YAML parses end-to-end.

This drift was invisible to today's CI specifically because \`dashboards/*.yaml\` doesn't recurse into \`homelab-views/\` — one of the reasons #343 exists and is still open.

Closes #333
Closes #334

## Test plan

- [ ] CI: YAML Lint, check-config, claude-review green
- [ ] Post-merge on \`/dashboard-homelab-status\`:
  - hardware lens: grafana-stack tile renders green when LXC is running
  - grafana-stack detail subview: hero green, all gauges populated, no button grid
  - pve3 detail subview: grafana-stack tile renders with live cpu/mem percentages
  - ups detail subview: 2-column gauge grid (Battery + Load); no Runtime card