### PR TITLE
CI: recurse into dashboards/homelab-views/ for entity-reference check (#343)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,12 @@ jobs:
         run: python3 -m pip install --quiet pyyaml
 
       - name: Check dashboard entity references
+        # Recurses into dashboards/homelab-views/ — without `find`, the
+        # shell glob `dashboards/*.yaml` only matches top-level files and
+        # silently skips every fleet entity inside the lens/detail
+        # subview includes (#343). Excludes entity-allowlist.txt by name
+        # since the script expects YAML and the allowlist is plain text.
         run: |
           python3 scripts/check-dashboard-entities.py --strict \
             --allowlist dashboards/entity-allowlist.txt \
-            dashboards/*.yaml
+            $(find dashboards -type f -name '*.yaml' ! -name 'entity-allowlist.txt')


### PR DESCRIPTION
## Origin

Chris asked Claude to try #343 even though the issue body warned the local Claude Code session's fine-grained PAT may lack \`workflows: write\` and the push may bounce. Push went through — local \`gh\` config has the scope.

## Diagnosis

The \`Dashboard Entities\` step in \`tests.yml\` invokes the checker with \`dashboards/*.yaml\` — a shell glob that only matches files at the top level. PR #341 moved every lens + drill-down subview into \`dashboards/homelab-views/\`. The \`!include\`-based manifest \`dashboards/homelab-status.yaml\` reports "0 entity references all resolve" because it has no inline entity refs — they're all in the children that the glob never sees.

## What changed

Single line in \`.github/workflows/tests.yml\`:

\`\`\`diff
-            dashboards/*.yaml
+            \$(find dashboards -type f -name '*.yaml' ! -name 'entity-allowlist.txt')
\`\`\`

Plus a header comment explaining the wrinkle. The script already handles multi-file invocation and HA's \`!include\` tag (PRs #342, #339), so no script-side changes.

## Verified

Ran the new arg list locally — 16 dashboard YAMLs in scope, every entity reference resolves. The recent #333 grafana_stack swap was already cross-checked with this same recursive run.

## Test plan

- [ ] CI: this very check runs against this PR; should now report on \`hardware.yaml\`, \`pve3.yaml\`, \`grafana-stack.yaml\`, \`ups.yaml\`, etc. with non-zero entity counts. \`claude-review\` green.
- [ ] Post-merge: future PRs that touch homelab-views entities will fail CI on missing/typo'd refs instead of silently passing.

Closes #343