### PR TITLE
Smooth office ZEN77 hold-to-dim/brighten ramp

### DIFF
--- a/packages/office_zen77.yaml
+++ b/packages/office_zen77.yaml
@@ -14,8 +14,10 @@
 #   property_key_name: '001'    = up paddle
 #   property_key_name: '002'    = down paddle
 #   value: KeyPressed           = single tap
-#   value: KeyHeldDown          = held past ~1s threshold (fires repeatedly)
-#   value: KeyReleased          = released after hold
+#   value: KeyHeldDown          = held past ~1s threshold (ONE-SHOT — the
+#                                 ramp automations loop internally until the
+#                                 paired KeyReleased fires)
+#   value: KeyReleased          = released after hold (also breaks the ramp)
 #   value: KeyPressed2x..5x     = multi-tap (intentionally unhandled, reserved)
 #
 # Bindings:
@@ -23,11 +25,13 @@
 #               otherwise advance counter (wraps 11 → 1) and apply.
 #               i.e. first tap turns on, subsequent taps cycle scenes.
 #   down tap  → all 6 office lamps off (counter persists, candle loop killed).
-#   up hold   → brighten the current scene by 10%. KeyHeldDown fires
-#               repeatedly while the paddle is held, so each fire steps
-#               input_number.office_brightness up (capped at 100). apply_scene
-#               is called with reset_brightness:false so the helper drives.
-#   down hold → dim the current scene by 10% (floored at 10).
+#   up hold   → ramp the current scene brighter at 5%/~150 ms until the
+#               paddle is released or 100% is reached. KeyHeldDown is a
+#               single Z-Wave event per hold (verified empirically), so the
+#               automation runs a repeat-loop that waits for the matching
+#               KeyReleased to break out. apply_scene is called with
+#               reset_brightness:false so the helper drives the render.
+#   down hold → ramp dimmer the same way; floored at 10%.
 #   To bail out of a colored/flicker scene back to scene 1, use the
 #   Sonoff button's long-press, or tap down (off) then up (on → scene 1).
 #
@@ -131,19 +135,37 @@ automation:
       - condition: state
         entity_id: binary_sensor.office_lights_on
         state: 'on'
+    # mode: restart so a fresh hold cancels any prior ramp instead of
+    # queueing behind it. The repeat-loop steps the helper 5%/~150 ms
+    # until the matching KeyReleased event fires or 100% is reached.
+    mode: restart
     actions:
-      - action: input_number.set_value
-        target:
-          entity_id: input_number.office_brightness
-        data:
-          value: "{{ [(states('input_number.office_brightness') | float(100)) + 10, 100] | min }}"
-      - action: script.office_sonoff_apply_scene
-        data:
-          reset_brightness: false
-    # KeyHeldDown fires repeatedly (~every 500 ms) while held. queued lets
-    # each fire step the helper in order; max:20 caps a runaway hold.
-    mode: queued
-    max: 20
+      - repeat:
+          sequence:
+            - action: input_number.set_value
+              target:
+                entity_id: input_number.office_brightness
+              data:
+                value: "{{ [(states('input_number.office_brightness') | float(0)) + 5, 100] | min }}"
+            - action: script.office_sonoff_apply_scene
+              data:
+                reset_brightness: false
+            - wait_for_trigger:
+                - trigger: event
+                  event_type: zwave_js_value_notification
+                  event_data:
+                    device_id: 51a69e120926a13bba9cfaac7a2937e7
+                    command_class_name: Central Scene
+                    property_key_name: '001'
+                    value: KeyReleased
+              timeout:
+                milliseconds: 150
+              continue_on_timeout: true
+          until:
+            - condition: template
+              value_template: >-
+                {{ wait.completed | default(false)
+                   or (states('input_number.office_brightness') | float(0)) >= 100 }}
 
   - id: zen77_office_down_hold_dim
     alias: 'Office ZEN77: Down hold → dim current scene'
@@ -159,17 +181,34 @@ automation:
       - condition: state
         entity_id: binary_sensor.office_lights_on
         state: 'on'
+    mode: restart
     actions:
-      - action: input_number.set_value
-        target:
-          entity_id: input_number.office_brightness
-        data:
-          value: "{{ [(states('input_number.office_brightness') | float(100)) - 10, 10] | max }}"
-      - action: script.office_sonoff_apply_scene
-        data:
-          reset_brightness: false
-    mode: queued
-    max: 20
+      - repeat:
+          sequence:
+            - action: input_number.set_value
+              target:
+                entity_id: input_number.office_brightness
+              data:
+                value: "{{ [(states('input_number.office_brightness') | float(100)) - 5, 10] | max }}"
+            - action: script.office_sonoff_apply_scene
+              data:
+                reset_brightness: false
+            - wait_for_trigger:
+                - trigger: event
+                  event_type: zwave_js_value_notification
+                  event_data:
+                    device_id: 51a69e120926a13bba9cfaac7a2937e7
+                    command_class_name: Central Scene
+                    property_key_name: '002'
+                    value: KeyReleased
+              timeout:
+                milliseconds: 150
+              continue_on_timeout: true
+          until:
+            - condition: template
+              value_template: >-
+                {{ wait.completed | default(false)
+                   or (states('input_number.office_brightness') | float(100)) <= 10 }}
 
   - id: zen77_office_parameter_apply
     alias: 'Office ZEN77: apply Z-Wave parameters (Scene Control + Smart Switch Mode)'

--- a/packages/sonoff_button_office.yaml
+++ b/packages/sonoff_button_office.yaml
@@ -58,12 +58,14 @@
 # applying. Transitioning into any flicker scene calls script.turn_on so the
 # apply script fires-and-forgets — it never waits on the infinite loop.
 #
-# Live brightness: input_number.office_brightness (10-100, step 10) is the
+# Live brightness: input_number.office_brightness (10-100, step 5) is the
 # brightness applied by every scene. Static scenes read it directly;
 # flicker tick scales its 75-92% random band by `helper / 100`. apply_scene
 # resets the helper to the new scene's default brightness on every tap/cycle
 # (1=100, 2=40, 3=100, 4-11=100) — pass `reset_brightness: false` to render
-# without touching the helper (used by ZEN77 hold-to-dim/brighten).
+# without touching the helper (used by ZEN77 hold-to-dim/brighten). Step 5
+# keeps the ZEN77 hold-ramp visibly smooth; static scene branches add a
+# 0.3 s transition so each ramp step interpolates on the bulbs.
 
 counter:
   office_sonoff_scene:
@@ -79,7 +81,7 @@ input_number:
     name: Office Brightness
     min: 10
     max: 100
-    step: 10
+    step: 5
     unit_of_measurement: '%'
     icon: mdi:brightness-6
 
@@ -138,6 +140,7 @@ script:
                 data:
                   brightness_pct: "{{ states('input_number.office_brightness') | int(100) }}"
                   color_temp_kelvin: 2700
+                  transition: 0.3
           - conditions: "{{ states('counter.office_sonoff_scene') == '2' }}"
             sequence:
               - action: light.turn_on
@@ -146,6 +149,7 @@ script:
                 data:
                   brightness_pct: "{{ states('input_number.office_brightness') | int(40) }}"
                   color_temp_kelvin: 2200
+                  transition: 0.3
           - conditions: "{{ states('counter.office_sonoff_scene') == '3' }}"
             sequence:
               - action: light.turn_on
@@ -154,6 +158,7 @@ script:
                 data:
                   brightness_pct: "{{ states('input_number.office_brightness') | int(100) }}"
                   color_temp_kelvin: 5000
+                  transition: 0.3
           # Scenes 4-11 are all flicker variants; the loop reads its target
           # color from a palette dict keyed on the counter, so we just turn
           # it on for any scene >= 4 and cycling between hues changes


### PR DESCRIPTION
## Origin

Chris noticed the office wall switch (Zooz ZEN77) couldn't smoothly dim or brighten scenes when the paddle was held — each press produced one 10% jump instead of a continuous ramp, so dropping from 40% to 10% required three separate press-hold-release cycles. Diagnosis from the recorder confirmed `KeyHeldDown` is a one-shot Z-Wave event rather than the repeating stream the hold automations assumed, and he approved the fix.

## Summary

- Both `zen77_office_*_hold_*` automations switch from `mode: queued, max: 20` (sized for a stream of events that never arrived) to `mode: restart` with an internal `repeat` loop that waits for the paired `KeyReleased` via `wait_for_trigger` (150 ms timeout, `continue_on_timeout: true`). The loop steps the helper every ~150 ms while held and exits within ~150 ms of release, with an `until:` template guarding the 10% floor / 100% ceiling.
- `input_number.office_brightness` step goes from 10 to 5 so the ramp has enough granularity to read as smooth.
- Static scene branches in `script.office_sonoff_apply_scene` (scenes 1–3) gain `transition: 0.3` so each ramp step interpolates on the bulbs instead of snapping. Flicker scenes (4–11) already ride a `transition: 0.2` inside `office_lamp_tick` and pick up the new helper value on their next tick.
- Header comments in `packages/office_zen77.yaml` corrected to document `KeyHeldDown` as one-shot.

## Evidence

Recorder history (Jun 4 02:31:40–02:31:46) showing three press-and-hold cycles needed to drop the helper 40 → 30 → 20 → 10:

```
02:31:40.567 KeyHeldDown   helper 40 → 30
02:31:43.019 KeyReleased
02:31:44.303 KeyHeldDown   helper 30 → 20
02:31:44.844 KeyReleased
02:31:46.130 KeyHeldDown   helper 20 → 10
02:31:46.547 KeyReleased
```

## Test plan

- [ ] `YAML Lint`, `check-config`, `claude-review` pass
- [ ] Hold up paddle on scene 1 (Bright): smooth ramp from current to 100%, stops on release
- [ ] Hold down paddle on scene 1 (Bright): smooth ramp toward 10% floor, stops on release
- [ ] Hold down paddle on scene 2 (Relax, default 40%): same behavior, floored at 10%
- [ ] Hold up paddle on a flicker scene (e.g. scene 6 Yellow Candle): flicker band brightens visibly within ~one tick (180–400 ms) of helper update
- [ ] Releasing mid-ramp halts within ~150 ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)