### PR TITLE
Add basement water leak detection automation

### DIFF
--- a/automations/basement_water_leak.yaml
+++ b/automations/basement_water_leak.yaml
@@ -1,0 +1,32 @@
+# Fires when either basement water leak sensor reports wet. Critical-channel
+# push to the phone (bypasses Do Not Disturb on Android) plus a persistent
+# in-HA notification. The Samjin sensors live by the water heater and the
+# HVAC condensate ejector pump — both basement floor risks.
+- id: basement_water_leak_detected
+  alias: 'Water leak detected'
+  description: >-
+    Notifies the phone and posts a persistent notification when either
+    basement Samjin leak sensor goes wet. Tag includes the entity_id so
+    the two sensors don't overwrite each other in the notification tray.
+  mode: single
+  triggers:
+    - trigger: state
+      entity_id:
+        - binary_sensor.water_heater_leak
+        - binary_sensor.hvac_pump_leak
+      to: 'on'
+  actions:
+    - action: notify.mobile_app_sm_s926u1
+      data:
+        title: 'Water leak detected'
+        message: '{{ trigger.to_state.name }} reports wet.'
+        data:
+          tag: 'water-leak-{{ trigger.entity_id }}'
+          channel: alarm_stream
+          importance: high
+          priority: high
+          ttl: 0
+    - action: notify.persistent_notification
+      data:
+        title: 'Water leak detected'
+        message: '{{ trigger.to_state.name }} reports wet.'


### PR DESCRIPTION
## Summary

Two Samjin IM6001-WLP01 Zigbee water sensors paired today via ZHA (Connect ZBT-2 coordinator):

- `binary_sensor.water_heater_leak` — by the water heater
- `binary_sensor.hvac_pump_leak` — by the HVAC condensate ejector pump

Both in the `basement` area. Strong link metrics (LQI 152 / 224, RSSI -62 / -44).

New `automations/basement_water_leak.yaml`:

- State trigger on either binary_sensor → `on`
- `notify.mobile_app_sm_s926u1` with `channel: alarm_stream`, `importance/priority: high`, `ttl: 0` (Android Companion bypasses Do Not Disturb)
- `notify.persistent_notification` for in-HA record
- `tag: water-leak-{{ trigger.entity_id }}` so the two sensors don't overwrite each other in the notification tray
- `mode: single` — one alert per state transition

Mirrors the style of `automations/exterior_doors_night.yaml`.

## Caveat — UI automation in place

An identical `automation.water_leak_detected` was created live via the HA MCP earlier in the session for first-touch testing. It still lives in `automations.yaml`. Once this YAML version deploys, you'll have **two automations firing on the same trigger** — fine functionally (the `tag` collapses the duplicate notification) but worth pruning. Delete the UI one via Settings → Automations after the GitOps deploy lands.

## Out of scope for this PR

- Entity renames (`binary_sensor.samjin_water` → `binary_sensor.water_heater_leak`, etc.) live in `.storage/` (gitignored per the three-layer model) and will surface in `context/entities.json` on the next 6h dump.

## Test plan

- [ ] Wait for `ha-config-check` workflow to pass
- [ ] Merge → GitOps deploys within 5 min
- [ ] Wet-finger test the contact pads on either sensor → expect phone push + persistent notification
- [ ] Delete the duplicate UI-created `automation.water_leak_detected` afterward