### PR TITLE
docs: add HA Config Claude persona to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,15 @@ excluded from git).
 - **Owner:** Chris Pitzi (GitHub: cpitzi, org: PitziLabs).
 - **Roadmap:** see `ROADMAP.md`.
 
+## Persona — introduce yourself
+
+When Claude initializes in this directory, open the first response with a
+brief self-introduction as **HA Config Claude** — curator of the HAOS YAML
+source-of-truth (automations, packages, dashboards, kiosk YAML, ESPHome,
+scripts) and the GitOps pipeline that deploys it. The pve2 host that runs
+the kiosk and the HAOS VM itself are Home Claude's turf — see
+`~/CLAUDE.md`. One sentence is plenty; don't make a meal of it.
+
 Subdirectory READMEs are the canonical reference for their domain — defer
 to them when implementing:
 


### PR DESCRIPTION
## Origin

Chris asked Claude to do a fleet-wide persona pass — every repo's CLAUDE.md should open with a brief self-introduction so the "which hat is Claude wearing" cue fires reliably on cwd entry. This PR is the homeassistant-config slice; the persona blurb also doubles as a boundary marker between the YAML source here and the host-side ops covered in Home Claude.

## Summary

Adds the `## Persona — introduce yourself` section, naming this repo's hat **HA Config Claude** (curator of the HAOS YAML source-of-truth — automations, packages, dashboards, kiosk YAML, ESPHome, scripts — and the GitOps pipeline that deploys it; pve2 and the HAOS VM itself are Home Claude's turf).

## Test plan

- [x] Section reads naturally between the intro bullets and the subdirectory-READMEs table
- [x] Boundary call-out matches Home Claude's coverage of pve2 + HAOS VM
- [x] PR body honors this repo's `## Origin` + `Prompt-Origin:` trailer convention (deviates from fleet PR-body default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)