### PR TITLE
Make office candle loop self-extending; revive on hold-path

### DIFF
--- a/packages/sonoff_button_office.yaml
+++ b/packages/sonoff_button_office.yaml
@@ -58,6 +58,14 @@
 # applying. Transitioning into any flicker scene calls script.turn_on so the
 # apply script fires-and-forgets — it never waits on the infinite loop.
 #
+# The driver is also self-extending: HA's `repeat: while:` is capped at 10000
+# iterations per block; at our 180-400 ms tick delays each branch hits that
+# cap after ~30-66 min and exits. Before this was fixed the lamps then froze
+# on the last rendered frame until a paddle tap (or HA restart) re-fired the
+# loop. Now, when the slowest parallel branch exits, the driver re-invokes
+# itself iff counter > 3 — mode:restart cancels the dying instance cleanly,
+# so a flicker scene keeps ticking indefinitely without user intervention.
+#
 # Live brightness: input_number.office_brightness (10-100, step 5) is the
 # brightness applied by every scene. Static scenes read it directly;
 # flicker tick scales its 75-92% random band by `helper / 100`. apply_scene
@@ -162,12 +170,15 @@ script:
           # Scenes 4-11 are all flicker variants; the loop reads its target
           # color from a palette dict keyed on the counter, so we just turn
           # it on for any scene >= 4 and cycling between hues changes
-          # color seamlessly on the next tick. Gated on reset_brightness so
-          # hold-to-dim on a running flicker scene is a no-op (the loop is
-          # already ticking, the helper update reaches it on next iteration).
+          # color seamlessly on the next tick. Gated so hold-to-dim on a
+          # running flicker scene is a no-op (the loop is already ticking,
+          # the helper update reaches it on next iteration) — but if the
+          # loop is OFF (e.g. revived from a dead-loop state or a fresh
+          # HA boot mid-candle-scene) the hold path also restarts it so
+          # the lamps don't stay frozen on the last rendered frame.
           - conditions:
               - "{{ states('counter.office_sonoff_scene') | int(0) >= 4 }}"
-              - "{{ reset_brightness }}"
+              - "{{ reset_brightness or is_state('script.office_sonoff_candle_loop', 'off') }}"
             sequence:
               - action: script.turn_on
                 target:
@@ -343,6 +354,23 @@ script:
                         cascade_offset: 300
                     - delay:
                         milliseconds: "{{ range(180, 400) | random }}"
+      # Self-extend past HA's 10000-iteration cap on `repeat:`. With our
+      # 180-400 ms per-tick delays each branch's while-loop hits the cap
+      # in ~30-66 min and exits silently; before this self-restart the
+      # lamps then froze on the last rendered frame until something else
+      # turned the loop back on (a tap-to-cycle or watchdog). Now, once
+      # all six parallel branches finish, we re-invoke this script if a
+      # flicker scene is still active. mode:restart cleanly cancels the
+      # outgoing run, so the visible gap is sub-second. Gated on counter
+      # so deliberate off / jump-to-static (1-3) terminates cleanly.
+      - if:
+          - condition: numeric_state
+            entity_id: counter.office_sonoff_scene
+            above: 3
+        then:
+          - action: script.turn_on
+            target:
+              entity_id: script.office_sonoff_candle_loop
 
 automation:
   - id: sonoff_button_2_office_cycle


### PR DESCRIPTION
## Origin

Chris asked me to test his office dimmer — he had tried it manually and it "seemed to do nothing." The ZEN77 paddle, Z-Wave events, and the four hold/cycle automations were all healthy and producing traces. What was inert was the rendering chain: the `office_sonoff_candle_loop` driver that paints flicker scenes 4–11 had hit HA's hard 10000-iteration `repeat:` safety cap, terminated, and left the six office lamps frozen on whatever frame they were last rendered. With the loop dead, holding the paddle nudged `input_number.office_brightness` but apply_scene's flicker branch was gated only on `reset_brightness` (the tap path) — so the hold path was a no-op and the dimmer appeared inert.

## What changed

1. `office_sonoff_candle_loop` is now **self-extending**. When the outer `parallel:` block finishes (which it does ~30–66 min after starting, because each branch's `repeat: while:` hits HA's 10000-iteration cap), the script re-invokes itself iff `counter.office_sonoff_scene > 3`. `mode: restart` cancels the dying instance cleanly; the visible gap is sub-second.

2. `office_sonoff_apply_scene`'s flicker branch (scenes 4–11) now also fires when `script.office_sonoff_candle_loop` is off, not just when `reset_brightness` is true. This means the **hold path revives a dead loop** instead of silently updating the helper. Covers HA-restart recovery mid-candle-scene as well.

3. Header comment block updated to describe the self-extension and the dead-loop-revive contract.

## Evidence captured live

- Counter = 4 (Amber Candle), candle-loop state `off` since 2026-06-07T02:38 UTC.
- Six lamps stuck at `rgb_color=[255, 103, 19]`, `last_changed=2026-06-06T20:17:52` (9+ hours frozen).
- System log carrying `homeassistant.components.script.office_sonoff_candle_loop ... terminated because it looped 10000 times` for every parallel branch.
- After `script.turn_on script.office_sonoff_candle_loop` the lamps started flickering again immediately.
- Triggering `automation.office_zen77_down_hold_dim_current_scene` with the loop alive ramped helper 100 → 10 (floored as designed) and lamps `bookcase` 207 → 20, `corner` 212 → 23 — the expected 75–92 % band scaled by helper/100. Confirms the dimmer protocol is correct; only the loop death was masking it.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] CI `check-config` validates against a clean HA instance.
- [ ] After deploy, ZEN77 up/down hold visibly dims/brightens the lamps in real time on the active flicker scene.
- [ ] Flicker scene left alone for >60 min continues flickering (no freeze).
- [ ] Down tap still extinguishes the lamps and terminates the loop cleanly (counter persists, no orphan branches).