### PR TITLE
Mirror kiosk-codesign from production + add CI drift guard

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,19 @@ jobs:
       - name: Run bats suite
         run: bats tests/
 
+  codesign-sync:
+    name: Codesign Sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # dashboards/kiosk-codesign.yaml is a generated mirror of kiosk.yaml.
+      # Fail the build if production moved ahead without the mirror being
+      # regenerated (run scripts/sync-kiosk-codesign.sh and commit). Keeps
+      # the co-design preview from silently drifting behind the live kiosk.
+      - name: Check codesign mirrors production kiosk
+        run: scripts/sync-kiosk-codesign.sh --check
+
   dashboard-entities:
     name: Dashboard Entities
     runs-on: ubuntu-latest

--- a/dashboards/kiosk-codesign.yaml
+++ b/dashboards/kiosk-codesign.yaml
@@ -1,11 +1,19 @@
 # =================================================================
-# KIOSK CO-DESIGN SANDBOX — duplicate of kiosk.yaml for iteration.
-# Edit freely; the household kiosk monitor still points at the
-# canonical /dashboard-kiosk/home, so changes here don't disturb it.
-# Preview with: kiosk-host/kiosk-preview dashboards/kiosk-codesign.yaml \
-#   --url http://homeassistant.local:8123/dashboard-kiosk-codesign/home
-# =================================================================
+# AUTO-GENERATED — DO NOT EDIT BY HAND.
+# Mirror of dashboards/kiosk.yaml, produced by
+# scripts/sync-kiosk-codesign.sh. Edit kiosk.yaml, then run that
+# script to refresh this file. CI (Tests > Codesign Sync) fails if
+# this file drifts from production.
 #
+# Purpose: preview kiosk changes at /dashboard-kiosk-codesign/home
+# without touching the household monitor (/dashboard-kiosk/home).
+# Preview with:
+#   kiosk-host/kiosk-preview dashboards/kiosk-codesign.yaml \
+#     --url http://homeassistant.local:8123/dashboard-kiosk-codesign/home
+#
+# Only the first view's tab title/icon differ from production; all
+# cards, templates, and entity references are identical.
+# =================================================================
 # KIOSK DASHBOARD — V3 (interactive desktop layout)
 # Primary home-state display, scaled for a 2560x1440 monitor driven
 # by mouse + keyboard. Every card supports its native interactions:
@@ -163,8 +171,11 @@ views:
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[0] %}
                       {{ (fc.datetime | as_datetime | as_local).strftime('%a') }}
                     secondary: |-
-                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[0] %}
-                      {{ fc.temperature | round }}° / {{ fc.templow | round }}°
+                      {% set forecast = state_attr('sensor.weather_forecast_daily', 'forecast') or [] %}
+                      {% set fc = forecast[0] if forecast|count > 0 else {} %}
+                      {% set t = fc.get('temperature') %}
+                      {% set tl = fc.get('templow') %}
+                      {{ (t | round) if t is not none else "—" }}° / {{ (tl | round) if tl is not none else "—" }}°
                     icon: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[0] %}
                       {% set m = {
@@ -210,8 +221,11 @@ views:
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[1] %}
                       {{ (fc.datetime | as_datetime | as_local).strftime('%a') }}
                     secondary: |-
-                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[1] %}
-                      {{ fc.temperature | round }}° / {{ fc.templow | round }}°
+                      {% set forecast = state_attr('sensor.weather_forecast_daily', 'forecast') or [] %}
+                      {% set fc = forecast[1] if forecast|count > 1 else {} %}
+                      {% set t = fc.get('temperature') %}
+                      {% set tl = fc.get('templow') %}
+                      {{ (t | round) if t is not none else "—" }}° / {{ (tl | round) if tl is not none else "—" }}°
                     icon: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[1] %}
                       {% set m = {
@@ -236,8 +250,11 @@ views:
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[2] %}
                       {{ (fc.datetime | as_datetime | as_local).strftime('%a') }}
                     secondary: |-
-                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[2] %}
-                      {{ fc.temperature | round }}° / {{ fc.templow | round }}°
+                      {% set forecast = state_attr('sensor.weather_forecast_daily', 'forecast') or [] %}
+                      {% set fc = forecast[2] if forecast|count > 2 else {} %}
+                      {% set t = fc.get('temperature') %}
+                      {% set tl = fc.get('templow') %}
+                      {{ (t | round) if t is not none else "—" }}° / {{ (tl | round) if tl is not none else "—" }}°
                     icon: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[2] %}
                       {% set m = {
@@ -262,8 +279,11 @@ views:
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[3] %}
                       {{ (fc.datetime | as_datetime | as_local).strftime('%a') }}
                     secondary: |-
-                      {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[3] %}
-                      {{ fc.temperature | round }}° / {{ fc.templow | round }}°
+                      {% set forecast = state_attr('sensor.weather_forecast_daily', 'forecast') or [] %}
+                      {% set fc = forecast[3] if forecast|count > 3 else {} %}
+                      {% set t = fc.get('temperature') %}
+                      {% set tl = fc.get('templow') %}
+                      {{ (t | round) if t is not none else "—" }}° / {{ (tl | round) if tl is not none else "—" }}°
                     icon: |-
                       {% set fc = state_attr('sensor.weather_forecast_daily', 'forecast')[3] %}
                       {% set m = {
@@ -884,7 +904,7 @@ views:
                       - type: template
                         icon: mdi:water-percent
                         icon_color: blue
-                        content: '{{ states("sensor.upstairs_humidity") | round }}%'
+                        content: '{% set h = states("sensor.upstairs_humidity") | float(none) %}{{ (h | round) if h is not none else "—" }}%'
                       - type: template
                         icon: mdi:thermometer
                         icon_color: amber
@@ -1005,7 +1025,7 @@ views:
                       - type: template
                         icon: mdi:water-percent
                         icon_color: blue
-                        content: '{{ states("sensor.downstairs_humidity") | round }}%'
+                        content: '{% set h = states("sensor.downstairs_humidity") | float(none) %}{{ (h | round) if h is not none else "—" }}%'
                       - type: template
                         icon: mdi:thermometer
                         icon_color: amber
@@ -1082,7 +1102,10 @@ views:
         card:
           type: vertical-stack
           cards:
-            # --- Front-door camera (Nest) ---
+            # --- Front-door camera (Nest) — snapshot + tap-to-stream hybrid ---
+            # Displays a static snapshot by default (~zero bandwidth).
+            # Tap opens more-info dialog showing live HLS stream for ~30s before dismiss.
+            # This cuts uplink by ~95% vs continuous streaming while preserving on-demand access.
             - type: custom:mod-card
               card_mod:
                 style: |
@@ -1093,11 +1116,7 @@ views:
                     overflow: hidden;
                     background: var(--kiosk-bg-tile);
                   }
-                  /* Picture-entity fill: stretch image OR live <video> to the tile.
-                     camera_view: live renders <ha-camera-stream>/<video>,
-                     not <hui-image>, so the video selector matters too. */
-                  ha-card hui-image, ha-card .image,
-                  ha-card ha-camera-stream, ha-card video {
+                  ha-card hui-image, ha-card .image {
                     height: 100% !important;
                     width: 100% !important;
                     object-fit: cover !important;
@@ -1105,11 +1124,9 @@ views:
               card:
                 type: picture-entity
                 entity: camera.front_door
-                # `live` uses the camera's HLS stream (session-based) so the
-                # tile keeps painting indefinitely. `auto` was falling back to
-                # a snapshot whose Nest access token rotates every few minutes,
-                # going black between refreshes (#355).
-                camera_view: live
+                # snapshot = static image refreshed ~1min (no continuous stream).
+                # Tap action opens more-info dialog which shows live HLS stream.
+                camera_view: snapshot
                 show_name: false
                 show_state: false
                 tap_action: { action: more-info }

--- a/scripts/sync-kiosk-codesign.sh
+++ b/scripts/sync-kiosk-codesign.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# sync-kiosk-codesign.sh — regenerate dashboards/kiosk-codesign.yaml as a
+# mirror of dashboards/kiosk.yaml.
+#
+# The co-design dashboard (/dashboard-kiosk-codesign/home) is a preview copy
+# of the production kiosk (/dashboard-kiosk/home). It used to drift: fixes
+# landed in kiosk.yaml and never got back-ported, so a stale codesign sat
+# behind production (e.g. the Nest cam stuck on camera_view: live after the
+# snapshot fix shipped). This script makes production the single source of
+# truth — codesign is generated, never hand-edited.
+#
+# The only intentional difference is the first view's tab title/icon, swapped
+# to a "Co-design" marker so the preview is visually distinguishable. Every
+# card, template, and entity reference is identical to production.
+#
+# Usage:
+#   sync-kiosk-codesign.sh            Regenerate codesign in place (default).
+#   sync-kiosk-codesign.sh --write    Same as default; explicit.
+#   sync-kiosk-codesign.sh --check    Exit non-zero if codesign has drifted
+#                                     from kiosk.yaml (used by CI). No writes.
+#   sync-kiosk-codesign.sh --help     This message.
+#
+# Paths can be overridden for testing via KIOSK_SRC / KIOSK_DST.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+SRC="${KIOSK_SRC:-${REPO_ROOT}/dashboards/kiosk.yaml}"
+DST="${KIOSK_DST:-${REPO_ROOT}/dashboards/kiosk-codesign.yaml}"
+
+usage() { sed -n '17,24p' "$0" | sed 's/^# \{0,1\}//'; }
+
+# Emit the generated codesign dashboard to stdout: a "do not edit" banner
+# followed by kiosk.yaml with the first view's tab title/icon relabeled.
+# The sed substitutions are anchored to the unique view-header lines; if a
+# future kiosk.yaml renames that view, the content still mirrors correctly,
+# only the cosmetic marker is dropped.
+generate() {
+  cat <<'EOF'
+# =================================================================
+# AUTO-GENERATED — DO NOT EDIT BY HAND.
+# Mirror of dashboards/kiosk.yaml, produced by
+# scripts/sync-kiosk-codesign.sh. Edit kiosk.yaml, then run that
+# script to refresh this file. CI (Tests > Codesign Sync) fails if
+# this file drifts from production.
+#
+# Purpose: preview kiosk changes at /dashboard-kiosk-codesign/home
+# without touching the household monitor (/dashboard-kiosk/home).
+# Preview with:
+#   kiosk-host/kiosk-preview dashboards/kiosk-codesign.yaml \
+#     --url http://homeassistant.local:8123/dashboard-kiosk-codesign/home
+#
+# Only the first view's tab title/icon differ from production; all
+# cards, templates, and entity references are identical.
+EOF
+  sed -e 's|^  - title: Home$|  - title: Co-design|' \
+      -e 's|^    icon: mdi:monitor-dashboard$|    icon: mdi:monitor-edit|' \
+      "$SRC"
+}
+
+mode="write"
+case "${1:-}" in
+  --check) mode="check" ;;
+  --write | "") mode="write" ;;
+  -h | --help) usage; exit 0 ;;
+  *) echo "sync-kiosk-codesign.sh: unknown argument: $1" >&2; exit 2 ;;
+esac
+
+if [[ ! -r "$SRC" ]]; then
+  echo "sync-kiosk-codesign.sh: source not readable: $SRC" >&2
+  exit 2
+fi
+
+if [[ "$mode" == "check" ]]; then
+  if diff -u "$DST" <(generate); then
+    echo "kiosk-codesign.yaml is in sync with kiosk.yaml"
+  else
+    echo "" >&2
+    echo "kiosk-codesign.yaml has drifted from kiosk.yaml." >&2
+    echo "Run: scripts/sync-kiosk-codesign.sh" >&2
+    exit 1
+  fi
+else
+  generate > "$DST"
+  echo "regenerated $(basename "$DST") from $(basename "$SRC")"
+fi

--- a/tests/codesign_sync.bats
+++ b/tests/codesign_sync.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/sync-kiosk-codesign.sh — regenerates kiosk-codesign.yaml as
+# a mirror of kiosk.yaml. Codesign used to drift behind production (fixes landed
+# in kiosk.yaml and were never back-ported), so the suite proves the generator
+# mirrors body content verbatim, relabels only the first view's tab title/icon,
+# and that --check is a real drift guard (passes in sync, fails on drift). Paths
+# are redirected to a temp dir via KIOSK_SRC/KIOSK_DST so the real dashboards are
+# never touched.
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../scripts/sync-kiosk-codesign.sh"
+  export KIOSK_SRC="${BATS_TEST_TMPDIR}/kiosk.yaml"
+  export KIOSK_DST="${BATS_TEST_TMPDIR}/kiosk-codesign.yaml"
+  cat > "$KIOSK_SRC" <<'EOF'
+# kiosk source banner
+views:
+  - title: Home
+    path: home
+    icon: mdi:monitor-dashboard
+    cards:
+      - type: picture-entity
+        entity: camera.front_door
+        camera_view: snapshot
+EOF
+}
+
+@test "writes a mirror with the auto-generated banner" {
+  run bash "$SCRIPT" --write
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"regenerated kiosk-codesign.yaml"* ]]
+  grep -q "AUTO-GENERATED — DO NOT EDIT BY HAND." "$KIOSK_DST"
+}
+
+@test "relabels only the first view's title and icon" {
+  bash "$SCRIPT" --write
+  grep -q "^  - title: Co-design$" "$KIOSK_DST"
+  grep -q "^    icon: mdi:monitor-edit$" "$KIOSK_DST"
+  # production marker values must not survive in the mirror
+  ! grep -q "^  - title: Home$" "$KIOSK_DST"
+  ! grep -q "^    icon: mdi:monitor-dashboard$" "$KIOSK_DST"
+}
+
+@test "mirrors body content verbatim (camera fix carries over)" {
+  bash "$SCRIPT" --write
+  grep -q "camera_view: snapshot" "$KIOSK_DST"
+  grep -q "entity: camera.front_door" "$KIOSK_DST"
+}
+
+@test "--check passes when codesign is in sync" {
+  bash "$SCRIPT" --write
+  run bash "$SCRIPT" --check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"in sync"* ]]
+}
+
+@test "--check fails when production has drifted ahead" {
+  bash "$SCRIPT" --write
+  printf '      - type: gauge\n' >> "$KIOSK_SRC"
+  run bash "$SCRIPT" --check
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"drifted"* ]]
+}
+
+@test "unknown argument is rejected" {
+  run bash "$SCRIPT" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown argument"* ]]
+}


### PR DESCRIPTION
Make the co-design kiosk dashboard a generated mirror of production, and add a CI guard so it can't drift behind the live kiosk again.

## Origin

Chris noticed the household kiosk still showed the Nest cam's *live* stream even though the snapshot fix (`cbdc43f`) had already shipped and deployed. The cause: the pve2 kiosk runner had been left pointed at `/dashboard-kiosk-codesign/home` (the co-design sandbox) instead of the production `/dashboard-kiosk/home`, and `kiosk-codesign.yaml` had silently drifted behind production — it still carried `camera_view: live` (plus stale weather/humidity templates missing production's null-guards). Chris asked to flip the monitor back to production, re-clone codesign from `kiosk.yaml`, and keep codesign mirroring production whenever production gets ahead.

The monitor flip was done out-of-band on pve2 (`kiosk-show --dashboard` — `KIOSK_URL` is mutable runtime state, not in git). This PR handles the repo side.

## What changed

- **`scripts/sync-kiosk-codesign.sh`** — regenerates `dashboards/kiosk-codesign.yaml` as a verbatim mirror of `kiosk.yaml`, relabeling only the first view's tab title/icon to a "Co-design" marker. `--check` mode diffs without writing (for CI); `--write` (default) regenerates in place. Paths overridable via `KIOSK_SRC`/`KIOSK_DST` for testing.
- **`dashboards/kiosk-codesign.yaml`** — regenerated. Now identical to production except the tab marker + generated-file banner. Picks up `camera_view: snapshot` and the null-guarded weather/humidity templates it had been missing.
- **`.github/workflows/tests.yml`** — new `Codesign Sync` job runs `--check`; the build goes red if `kiosk.yaml` advances without the mirror being regenerated and committed.
- **`tests/codesign_sync.bats`** — covers the generator (banner, title/icon relabel, verbatim body) and the drift guard (in-sync passes, drift fails, bad arg rejected).

## Workflow note

Codesign is now generated, not hand-edited. To iterate: edit `kiosk.yaml`, run `scripts/sync-kiosk-codesign.sh`, commit both. The banner at the top of the generated file says as much.

🤖 Generated with [Claude Code](https://claude.com/claude-code)