### PR TITLE
Add front yard lights sunset-to-10pm schedule

### DIFF
--- a/automations/front_yard_lights_schedule.yaml
+++ b/automations/front_yard_lights_schedule.yaml
@@ -1,0 +1,41 @@
+# Front yard lights on a sunset-to-10pm schedule.
+# The three front-of-house lights (front door, front lantern, garage front)
+# turn on at sunset and back off at 10:00 PM. These are the front-yard members
+# of the `light.outdoor` group defined in configuration.yaml; the side and shed
+# lights are intentionally left out so only the front yard follows this schedule.
+- id: front_yard_lights_schedule
+  alias: 'Front yard lights — sunset on, 10 PM off'
+  description: >-
+    Turns the front yard lights (front door, front lantern, garage front) on at
+    sunset and off at 10:00 PM. Requested by Jacob.
+  mode: single
+  triggers:
+    - trigger: sun
+      event: sunset
+      id: 'sunset_on'
+    - trigger: time
+      at: '22:00:00'
+      id: 'ten_pm_off'
+  conditions: []
+  actions:
+    - choose:
+        - conditions:
+            - condition: trigger
+              id: 'sunset_on'
+          sequence:
+            - action: light.turn_on
+              target:
+                entity_id:
+                  - light.front_door
+                  - light.front_lantern
+                  - light.garage_front
+        - conditions:
+            - condition: trigger
+              id: 'ten_pm_off'
+          sequence:
+            - action: light.turn_off
+              target:
+                entity_id:
+                  - light.front_door
+                  - light.front_lantern
+                  - light.garage_front


### PR DESCRIPTION
Adds an automation that turns the front yard lights on at sunset and off at 10:00 PM.

## Origin

Jacob, Chris's nine-year-old son, asked HA Config Claude to set up just the front yard lights to turn on at sunset and turn off at 10 PM. He was specific that the schedule should cover only the front yard, so this change is scoped to the three front-of-house lights and deliberately leaves the side and shed lights alone.

## What changed

New `automations/front_yard_lights_schedule.yaml`:

- **Sunset trigger** → turns on `light.front_door`, `light.front_lantern`, `light.garage_front`
- **10:00 PM time trigger** → turns the same three lights off

The two triggers carry IDs and are routed through a `choose` block — native sun and time triggers, no Jinja templates, `entity_id` targeting throughout, per the `home-assistant-best-practices` skill.

## Scope note

These three are the front-yard members of the `light.outdoor` group in `configuration.yaml`. `light.garage_side` and `light.shed` (also in that group) are excluded so the schedule affects only the front yard, as Jacob asked.

https://claude.ai/code/session_01Ajpb1EeS67FvY47Siv36VP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ajpb1EeS67FvY47Siv36VP)_