### PR TITLE
kiosk-host: add kiosk-serve + decouple snapshot-server from the kiosk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,8 @@ ha-context-dump.log.*
 __pycache__/
 *.pyc
 
-# kiosk-snapshot tool output — throwaway frame grabs from pve2's display
-/kiosk-snapshot-*.png
+# Kiosk frame grabs — throwaway snapshots from pve2's display
+# (kiosk-snapshot, kiosk-preview, kiosk-serve, scrot dumps, comparisons)
+/kiosk-*.png
+/ha-login-*.png
+/screen-time-render.png

--- a/kiosk-host/README.md
+++ b/kiosk-host/README.md
@@ -28,6 +28,8 @@ itself lives in `dashboards/kiosk.yaml`; these files configure the
 | `gitops-pull.timer` | `/etc/systemd/system/dashboard-kiosk-gitops.timer` | `0644` | `root:root` | bootstrap only |
 | `kiosk-snapshot` | (run from your workstation, not deployed) | `0755` | n/a | n/a |
 | `kiosk-preview` | (run from your workstation, not deployed) | `0755` | n/a | n/a |
+| `kiosk-serve` | (run from your workstation, not deployed) | `0755` | n/a | n/a |
+| `pages/*.html` | (pushed on demand to `/opt/claude-kiosk/` by `kiosk-serve`) | n/a | n/a | n/a |
 
 Also on pve2, *not* managed by the loop:
 
@@ -107,6 +109,50 @@ launch (Gdk portal / sandbox crashes have been seen on the workstation).
 Even when Playwright works, prefer `kiosk-snapshot` for kiosk captures —
 Playwright would render a clean, just-authed session, missing the live
 state.
+
+## Serving arbitrary pages (`kiosk-serve`)
+
+`kiosk-serve` is the "put a page Claude generated on the office screen"
+tool — the sibling to `kiosk-preview` (which is specialised to dashboard
+YAML). Give it a local `.html` file (or a directory with an `index.html`)
+and it pushes the content to `/opt/claude-kiosk/` on pve2, serves it with
+a transient `systemd` unit (`claude-kiosk-www`, default port 8088, bound
+so Chromium reaches it at `http://localhost:8088/`), points the kiosk at
+it, and grabs a snapshot so you can confirm what actually rendered —
+Mermaid/WebGL render client-side, so a blind push can lie.
+
+Run it from your workstation (it is not deployed to pve2):
+
+```bash
+# Push a page, serve it, point the kiosk, snapshot → ./kiosk-serve-<UTC>.png
+kiosk-host/kiosk-serve kiosk-host/pages/homelab-architecture.html --open
+
+# Heavy WebGL needs longer to settle before the snapshot
+kiosk-host/kiosk-serve some-page.html --settle 12
+
+# Just re-grab the current frame
+kiosk-host/kiosk-serve --snapshot --open
+
+# Stop the web server and snap back to the household dashboard
+kiosk-host/kiosk-serve --stop
+```
+
+If the kiosk is already on the serve URL, re-serving refreshes with `F5`
+(no Chromium relaunch, no flicker) instead of a full `kiosk-show`
+restart — so iterating on a page is fast. `pages/` holds reusable pages
+worth keeping in git (e.g. `homelab-architecture.html`, a Mermaid diagram
+of the cluster); ad-hoc one-offs can point `kiosk-serve` at any local file.
+
+**Snapshot-server independence.** `kiosk-serve` (and `kiosk-snapshot`, and
+the 6-hourly `ha-context-dump`) depend on `snapshot-server` on pve2
+(`:9999`). That unit is deliberately **not** `PartOf=dashboard-kiosk.service`:
+it scrots X `:0`, which outlives Chromium restarts. It used to be coupled,
+so every `kiosk-show`/`kiosk-serve` URL change (each restarts the kiosk)
+tore it down — and `PartOf` propagates *stop* but not *start*, so nothing
+brought it back until the next drift-triggered gitops run. It stayed dead
+for ~6 days. It is now independent + `enabled` + `Restart=on-failure`, so
+it survives kiosk churn and reboots. As a belt-and-braces measure
+`kiosk-serve` also re-`start`s it before each capture.
 
 ## Live preview iteration (`kiosk-preview`)
 

--- a/kiosk-host/gitops-pull.sh
+++ b/kiosk-host/gitops-pull.sh
@@ -181,11 +181,11 @@ main() {
     systemctl restart "$KIOSK_UNIT"
   fi
 
-  # snapshot-server is PartOf dashboard-kiosk.service, so a kiosk restart
-  # will have already stopped it. Either way, restart on drift to pick up
-  # changes; enable in case it's not enabled yet (idempotent).
-  if [[ "$snap_changed" == true || "$snap_unit_changed" == true \
-        || "$script_changed" == true || "$unit_changed" == true ]]; then
+  # snapshot-server is independent of the kiosk lifecycle (no PartOf), so a
+  # kiosk-only change no longer needs to touch it. Restart only when its own
+  # script or unit drifted; enable --now is idempotent and also heals a host
+  # where it was previously left stopped.
+  if [[ "$snap_changed" == true || "$snap_unit_changed" == true ]]; then
     systemctl enable --now "$SNAP_UNIT" >/dev/null 2>&1 || true
     log INFO "Restarting ${SNAP_UNIT}"
     systemctl restart "$SNAP_UNIT"

--- a/kiosk-host/kiosk-serve
+++ b/kiosk-host/kiosk-serve
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# kiosk-serve — put an arbitrary local HTML page (or directory) on pve2's
+# office monitor, then snapshot the result. The "show me a diagram" sibling
+# to kiosk-preview (which is specialised to dashboard YAML).
+#
+# What it does, in one shot:
+#   1. Pushes a local .html file (or a directory) to /opt/claude-kiosk on pve2.
+#   2. Serves it with a transient systemd unit (claude-kiosk-www) on $PORT,
+#      bound to 0.0.0.0 — Chromium reaches it at http://localhost:$PORT/.
+#   3. Points the kiosk at it. If the kiosk is already on that URL, refreshes
+#      with F5 (fast, no relaunch) instead of a full kiosk-show restart.
+#   4. Ensures the snapshot server is up and grabs ./kiosk-serve-<UTC>.png so
+#      you can SEE what rendered (Mermaid/WebGL/etc. render client-side, so a
+#      blind push can lie — always check the frame).
+#
+# Runs from your workstation (NOT deployed to pve2), same as kiosk-preview.
+# Requires SSH access to pve2 via the pve jump host, and xdotool + scrot on
+# pve2 (already present for kiosk-preview / snapshot-server).
+#
+# Usage:
+#   kiosk-serve PAGE.html            Push, serve, point kiosk, snapshot.
+#   kiosk-serve DIR/                 Serve a directory (must contain index.html).
+#   kiosk-serve PAGE.html --open     ...and xdg-open the snapshot when done.
+#   kiosk-serve --snapshot           Just grab the current frame (no push).
+#   kiosk-serve --dashboard          Snap the kiosk back to the HA dashboard.
+#   kiosk-serve --stop               Snap back AND stop the web server.
+#   kiosk-serve --show               Print kiosk + web-server state.
+#
+# Options:
+#   --port N        Web-server port (default 8088).
+#   --settle SECS   Wait before snapshot (default 7; bump for heavy WebGL).
+#   --no-snapshot   Skip the snapshot step.
+#   --open          xdg-open the captured PNG.
+set -euo pipefail
+
+readonly REMOTE="root@pve2"
+readonly JUMP="root@pve.local"
+SSH=(ssh -J "$JUMP" -o ConnectTimeout=4 -o BatchMode=yes "$REMOTE")
+
+readonly CONTENT_DIR="/opt/claude-kiosk"
+readonly WWW_UNIT="claude-kiosk-www"
+readonly SNAP_UNIT="snapshot-server.service"
+readonly SNAP_PORT=9999
+
+PORT=8088
+SETTLE=7
+DO_SNAPSHOT=1
+DO_OPEN=0
+ACTION=""        # serve | snapshot | dashboard | stop | show
+TARGET=""        # local file or dir for serve
+
+die() { echo "kiosk-serve: $*" >&2; exit 1; }
+
+# ---- arg parse --------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --snapshot)   ACTION=snapshot ;;
+    --dashboard)  ACTION=dashboard ;;
+    --stop)       ACTION=stop ;;
+    --show)       ACTION=show ;;
+    --open)       DO_OPEN=1 ;;
+    --no-snapshot) DO_SNAPSHOT=0 ;;
+    --port)       PORT="${2:?--port needs a value}"; shift ;;
+    --settle)     SETTLE="${2:?--settle needs a value}"; shift ;;
+    -h|--help)    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*)           die "unknown option: $1" ;;
+    *)            TARGET="$1"; ACTION="${ACTION:-serve}" ;;
+  esac
+  shift
+done
+[[ -z "$ACTION" ]] && { sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0; }
+
+readonly URL="http://localhost:${PORT}/"
+
+# ---- helpers ----------------------------------------------------------------
+snapshot() {
+  # snapshot-server is fetched THROUGH the ssh jump (curl on pve2 → stdout),
+  # so it never depends on the workstation routing/mDNS to pve2 directly.
+  # Re-ensure it's running first: kiosk restarts can tear it down on hosts
+  # still running the old PartOf-coupled unit.
+  local out; out="kiosk-serve-$(date -u +%Y%m%dT%H%M%SZ).png"
+  "${SSH[@]}" "systemctl is-active --quiet ${SNAP_UNIT} || systemctl start ${SNAP_UNIT}" 2>/dev/null || true
+  if "${SSH[@]}" "curl -fsS http://localhost:${SNAP_PORT}/" > "$out" 2>/dev/null && [[ -s "$out" ]]; then
+    echo "kiosk-serve: snapshot → ${out} ($(stat -c%s "$out") bytes)"
+    [[ "$DO_OPEN" == 1 ]] && command -v xdg-open >/dev/null && xdg-open "$out" >/dev/null 2>&1 || true
+  else
+    rm -f "$out"
+    echo "kiosk-serve: snapshot failed (is snapshot-server healthy on pve2?)" >&2
+  fi
+}
+
+point_kiosk() {
+  # F5 if already on our URL (fast, no Chromium relaunch); else kiosk-show.
+  local current
+  current=$("${SSH[@]}" "kiosk-show --show 2>/dev/null | sed -n 's/^KIOSK_URL=//p'" || true)
+  if [[ "$current" == "$URL" ]]; then
+    echo "kiosk-serve: already on ${URL} — refreshing (F5)"
+    "${SSH[@]}" "DISPLAY=:0 XAUTHORITY=/root/.Xauthority xdotool key F5" || true
+  else
+    "${SSH[@]}" "kiosk-show --kiosk '${URL}'"
+  fi
+}
+
+# ---- actions ----------------------------------------------------------------
+case "$ACTION" in
+  show)
+    "${SSH[@]}" "kiosk-show --show; echo '--- web server ---'; systemctl is-active ${WWW_UNIT}.service 2>/dev/null || echo 'claude-kiosk-www: inactive'"
+    exit 0
+    ;;
+  dashboard)
+    "${SSH[@]}" "kiosk-show --dashboard"
+    exit 0
+    ;;
+  stop)
+    "${SSH[@]}" "kiosk-show --dashboard; systemctl stop ${WWW_UNIT}.service 2>/dev/null; systemctl reset-failed ${WWW_UNIT}.service 2>/dev/null; rm -rf ${CONTENT_DIR}; echo 'kiosk-serve: stopped web server, snapped back to dashboard'"
+    exit 0
+    ;;
+  snapshot)
+    snapshot
+    exit 0
+    ;;
+  serve)
+    [[ -e "$TARGET" ]] || die "no such file or directory: $TARGET"
+    # Push content.
+    if [[ -d "$TARGET" ]]; then
+      [[ -f "$TARGET/index.html" ]] || die "directory has no index.html: $TARGET"
+      tar -C "$TARGET" -czf - . | "${SSH[@]}" \
+        "rm -rf ${CONTENT_DIR}; mkdir -p ${CONTENT_DIR}; tar -C ${CONTENT_DIR} -xzf -"
+    else
+      [[ "$TARGET" == *.html ]] || echo "kiosk-serve: note — serving '${TARGET##*/}' as index.html" >&2
+      "${SSH[@]}" "mkdir -p ${CONTENT_DIR}; rm -f ${CONTENT_DIR}/index.html; cat > ${CONTENT_DIR}/index.html" < "$TARGET"
+    fi
+    # (Re)start the web server. Restarting it does NOT restart Chromium, so no
+    # flicker; it only re-binds the port and serves the fresh content dir.
+    "${SSH[@]}" "
+      systemctl reset-failed ${WWW_UNIT}.service 2>/dev/null || true
+      systemctl stop ${WWW_UNIT}.service 2>/dev/null || true
+      systemd-run --unit=${WWW_UNIT} --collect \
+        /usr/bin/python3 -m http.server ${PORT} --bind 0.0.0.0 --directory ${CONTENT_DIR} >/dev/null
+      echo 'kiosk-serve: serving ${CONTENT_DIR} on :${PORT}'
+    "
+    point_kiosk
+    if [[ "$DO_SNAPSHOT" == 1 ]]; then
+      sleep "$SETTLE"
+      snapshot
+    fi
+    ;;
+esac

--- a/kiosk-host/pages/homelab-architecture.html
+++ b/kiosk-host/pages/homelab-architecture.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PitziLabs Homelab — Architecture</title>
+<style>
+  :root { color-scheme: dark; }
+  html, body {
+    margin: 0; height: 100%;
+    background: radial-gradient(ellipse at top, #16263f 0%, #0a1120 55%, #060a14 100%);
+    color: #e6edf6;
+    font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    overflow: hidden;
+  }
+  .wrap { height: 100%; display: flex; flex-direction: column; padding: 26px 38px; box-sizing: border-box; }
+  header { display: flex; align-items: baseline; gap: 18px; border-bottom: 2px solid rgba(86,158,255,.25); padding-bottom: 14px; flex: 0 0 auto; }
+  h1 { margin: 0; font-size: 40px; font-weight: 650; letter-spacing: .5px; }
+  h1 .accent { color: #6ab7ff; }
+  .sub { font-size: 19px; color: #93a4ba; font-weight: 400; }
+  .diagram { flex: 1 1 auto; display: flex; align-items: center; justify-content: center; min-height: 0; padding: 14px 0; }
+  /* Force the Mermaid SVG to scale UP to fill the cell (its viewBox keeps
+     aspect ratio); without this it renders at natural size and looks tiny. */
+  .diagram svg { width: 100% !important; height: 100% !important; max-width: none !important; }
+  footer { display: flex; justify-content: space-between; align-items: center; color: #7d8ea4; font-size: 17px; padding-top: 10px; border-top: 1px solid rgba(255,255,255,.06); flex: 0 0 auto; }
+  .pill { background: rgba(106,183,255,.12); border: 1px solid rgba(106,183,255,.3); color: #acd2ff; padding: 3px 12px; border-radius: 999px; font-size: 15px; }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1><span class="accent">PitziLabs</span> Homelab — Architecture</h1>
+      <span class="sub">5-node Proxmox cluster · Firewalla gateway · Grafana Cloud observability</span>
+    </header>
+
+    <div class="diagram">
+      <pre class="mermaid">
+flowchart LR
+  WAN([Comcast WAN]):::wan --> FW["🛡️ Firewalla Gold SE<br/>gateway · DHCP · DNS · DPI<br/>192.168.139.1"]:::fw
+
+  subgraph LAN["LAN · 192.168.139.0/24"]
+    direction TB
+
+    subgraph CL["Proxmox cluster · homelab-cluster · PVE 9.2.2 · 5/5 quorate"]
+      direction TB
+      PVE["pve · .8 — entry node · vmdata ZFS"]:::node
+      PVE2["pve2 · .7 — quorum · KIOSK host"]:::kiosk
+      PVE3["pve3 · .55 — radios pinned here"]:::node
+      PVE4["pve4 · .210 — rebuilt · spare"]:::node
+      PVE5["pve5 · .230 — workstations + obs"]:::node
+    end
+
+    HAOS["VM 100 · Home Assistant OS<br/>📻 Z-Wave · Zigbee · Matter (USB)"]:::guest
+    WS["VM 102 xubuntu-ws<br/>VM 104 fedora-ws"]:::guest
+    LXC["LXC 105 · grafana-stack<br/>Grafana Alloy shipper"]:::obs
+    NAS[("neptune NAS · .6<br/>Ugreen N100 · btrfs RAID1")]:::nas
+    MON["🖥️ Office monitor · 2560×1440<br/>you are looking at it"]:::kiosk
+  end
+
+  FW --> PVE & PVE2 & PVE3 & PVE4 & PVE5
+  PVE3 --> HAOS
+  PVE5 --> WS & LXC
+  PVE2 ==> MON
+  CL -. nightly NFS backups .-> NAS
+
+  subgraph CLOUD["☁️ Grafana Cloud"]
+    direction TB
+    MIMIR["Mimir · metrics"]:::cloud
+    LOKI["Loki · logs"]:::cloud
+  end
+
+  LXC -- remote_write --> MIMIR
+  LXC -- loki.write --> LOKI
+  FW -. Zeek + ACL logs .-> LXC
+
+  classDef wan    fill:#1b2740,stroke:#3f6296,color:#cfe0ff,stroke-width:1px;
+  classDef fw     fill:#3a2330,stroke:#e06b8b,color:#ffd7e2,stroke-width:2px;
+  classDef node   fill:#16233c,stroke:#4f7fc4,color:#dce8fb,stroke-width:1.5px;
+  classDef kiosk  fill:#2a2a14,stroke:#ffcf5c,color:#fff4d0,stroke-width:2.5px;
+  classDef guest  fill:#13283a,stroke:#56b0d6,color:#d5eefb,stroke-width:1px;
+  classDef obs    fill:#172e26,stroke:#56d36a,color:#d4f7dd,stroke-width:1.5px;
+  classDef nas    fill:#241d33,stroke:#a98be0,color:#ecdfff,stroke-width:1.5px;
+  classDef cloud  fill:#10243a,stroke:#6ab7ff,color:#d6ebff,stroke-width:1.5px;
+      </pre>
+    </div>
+
+    <footer>
+      <span>Rendered by <strong style="color:#cdd9e8">Claude</strong> · direct kiosk control via <code>kiosk-serve</code></span>
+      <span class="pill">source of truth: <strong>~/CLAUDE.md</strong> homelab inventory</span>
+    </footer>
+  </div>
+
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'dark',
+    securityLevel: 'loose',
+    flowchart: { curve: 'basis', nodeSpacing: 45, rankSpacing: 70, htmlLabels: true, useMaxWidth: false },
+    themeVariables: { fontSize: '22px', fontFamily: 'Segoe UI, Roboto, sans-serif' }
+  });
+</script>
+</body>
+</html>

--- a/kiosk-host/snapshot-server.service
+++ b/kiosk-host/snapshot-server.service
@@ -2,9 +2,14 @@
 Description=Kiosk Snapshot Server (returns a live scrot on HTTP GET)
 After=dashboard-kiosk.service network-online.target
 Wants=network-online.target
-# Bind to the kiosk session so we stop when the display is restarted —
-# the gitops loop also restarts us explicitly if our script or unit drifts.
-PartOf=dashboard-kiosk.service
+# Deliberately NOT PartOf/BindsTo dashboard-kiosk.service. scrot captures
+# X display :0, which outlives Chromium restarts — so there's no reason to
+# die with the kiosk. The old PartOf coupling meant every `kiosk-show` URL
+# change (which restarts dashboard-kiosk.service) tore this down via stop-
+# propagation, and PartOf does NOT propagate start, so nothing brought it
+# back until the next drift-triggered gitops run. It stayed dead for days.
+# Independent + enabled + Restart=on-failure keeps it alive across kiosk
+# churn (now frequent, via kiosk-serve) and across reboots.
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Origin

Chris wanted to graduate the ad-hoc "Claude takes over the office kiosk" demos into something repeatable — specifically a one-shot way to put a Claude-generated page (such as a homelab architecture diagram) on the screen — and to reinstate the pve2 snapshot server so Claude can *see* what rendered rather than pushing blind. While reinstating the snapshot server, the root cause of its multi-day outage turned out to be a `PartOf=dashboard-kiosk.service` coupling, so this fixes that properly instead of just restarting it.

## What changed

- **`kiosk-serve`** — workstation tool (sibling to `kiosk-preview`, which is specialised to dashboard YAML). Pushes a local `.html` file or directory to `/opt/claude-kiosk/` on pve2, serves it via a transient `claude-kiosk-www` systemd unit (`:8088`, Chromium reaches it at `localhost:8088`), points the kiosk at it, and captures `./kiosk-serve-<UTC>.png`. Refreshes with `F5` when the kiosk is already on the serve URL (no relaunch / flicker). Supports `--snapshot`, `--stop`, `--dashboard`, `--show`, `--port`, `--settle`, `--open`, `--no-snapshot`.
- **`pages/homelab-architecture.html`** — first reusable page: a Mermaid diagram of the cluster (WAN → Firewalla → 5-node Proxmox cluster → HAOS/workstations/Alloy → neptune + Grafana Cloud), sized to fill the 2560×1440 panel.
- **`snapshot-server.service`** — drop `PartOf=dashboard-kiosk.service`. It scrots X `:0`, which outlives Chromium restarts, so it should not die with the kiosk. The coupling meant every `kiosk-show`/`kiosk-serve` URL change (each restarts the kiosk) stopped it, and `PartOf` propagates *stop* but not *start* — nothing brought it back until a drift-triggered gitops run. It had been dead ~6 days. Now independent + `enabled` + `Restart=on-failure`.
- **`gitops-pull.sh`** — only restart `snapshot-server` on its own drift now that a kiosk restart no longer stops it.
- **`.gitignore`** — ignore `kiosk-*` / `ha-login-*` / `screen-time-render` frame grabs (42 were littering the repo root).

## Verification (live, on pve2)

- `kiosk-serve kiosk-host/pages/homelab-architecture.html` → served, F5-refreshed, captured a frame; diagram fills the screen and is readable (caught + fixed a Mermaid `useMaxWidth` scaling bug via the snapshot loop).
- Decouple confirmed by the definitive test: with the new unit deployed, **stopping `dashboard-kiosk.service` leaves `snapshot-server` `active`** (`PartOf`/`ConsistsOf` both clear after `daemon-reload`).

## Deploy note

The pve2 `dashboard-kiosk-gitops.timer` is **paused** right now (it was reverting the manual unit deploy mid-test). It will be re-enabled once this merges, at which point the deployed state already matches `origin/main` (no-op convergence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)