### PR TITLE
Add Kiosk Codesign instrument-panel theme for the codesign sandbox

### DIFF
--- a/dashboards/kiosk-codesign.yaml
+++ b/dashboards/kiosk-codesign.yaml
@@ -11,8 +11,8 @@
 #   kiosk-host/kiosk-preview dashboards/kiosk-codesign.yaml \
 #     --url http://homeassistant.local:8123/dashboard-kiosk-codesign/home
 #
-# Only the first view's tab title/icon differ from production; all
-# cards, templates, and entity references are identical.
+# Only the first view's tab title/icon and theme differ from production;
+# all cards, templates, and entity references are identical.
 # =================================================================
 # KIOSK DASHBOARD — V3 (interactive desktop layout)
 # Primary home-state display, scaled for a 2560x1440 monitor driven
@@ -54,7 +54,7 @@ views:
   - title: Co-design
     path: home
     icon: mdi:monitor-edit
-    theme: Kiosk Polish
+    theme: Kiosk Codesign
     type: custom:grid-layout
     layout:
       height: 100vh

--- a/scripts/sync-kiosk-codesign.sh
+++ b/scripts/sync-kiosk-codesign.sh
@@ -10,9 +10,12 @@
 # snapshot fix shipped). This script makes production the single source of
 # truth — codesign is generated, never hand-edited.
 #
-# The only intentional difference is the first view's tab title/icon, swapped
-# to a "Co-design" marker so the preview is visually distinguishable. Every
-# card, template, and entity reference is identical to production.
+# The intentional differences are cosmetic only: the first view's tab
+# title/icon are swapped to a "Co-design" marker, and its theme is swapped
+# from "Kiosk Polish" to "Kiosk Codesign" so the sandbox renders the
+# instrument-panel design study (themes/kiosk_codesign.yaml) without forking
+# the cards. Every card, template, and entity reference is identical to
+# production.
 #
 # Usage:
 #   sync-kiosk-codesign.sh            Regenerate codesign in place (default).
@@ -52,11 +55,12 @@ generate() {
 #   kiosk-host/kiosk-preview dashboards/kiosk-codesign.yaml \
 #     --url http://homeassistant.local:8123/dashboard-kiosk-codesign/home
 #
-# Only the first view's tab title/icon differ from production; all
-# cards, templates, and entity references are identical.
+# Only the first view's tab title/icon and theme differ from production;
+# all cards, templates, and entity references are identical.
 EOF
   sed -e 's|^  - title: Home$|  - title: Co-design|' \
       -e 's|^    icon: mdi:monitor-dashboard$|    icon: mdi:monitor-edit|' \
+      -e 's|^    theme: Kiosk Polish$|    theme: Kiosk Codesign|' \
       "$SRC"
 }
 

--- a/tests/codesign_sync.bats
+++ b/tests/codesign_sync.bats
@@ -3,8 +3,9 @@
 # Tests for scripts/sync-kiosk-codesign.sh — regenerates kiosk-codesign.yaml as
 # a mirror of kiosk.yaml. Codesign used to drift behind production (fixes landed
 # in kiosk.yaml and were never back-ported), so the suite proves the generator
-# mirrors body content verbatim, relabels only the first view's tab title/icon,
-# and that --check is a real drift guard (passes in sync, fails on drift). Paths
+# mirrors body content verbatim, relabels the first view's tab title/icon and
+# swaps its theme to Kiosk Codesign, and that --check is a real drift guard
+# (passes in sync, fails on drift). Paths
 # are redirected to a temp dir via KIOSK_SRC/KIOSK_DST so the real dashboards are
 # never touched.
 
@@ -18,6 +19,7 @@ views:
   - title: Home
     path: home
     icon: mdi:monitor-dashboard
+    theme: Kiosk Polish
     cards:
       - type: picture-entity
         entity: camera.front_door
@@ -39,6 +41,13 @@ EOF
   # production marker values must not survive in the mirror
   ! grep -q "^  - title: Home$" "$KIOSK_DST"
   ! grep -q "^    icon: mdi:monitor-dashboard$" "$KIOSK_DST"
+}
+
+@test "swaps the sandbox view theme to Kiosk Codesign" {
+  bash "$SCRIPT" --write
+  grep -q "^    theme: Kiosk Codesign$" "$KIOSK_DST"
+  # production theme must not survive in the mirror
+  ! grep -q "^    theme: Kiosk Polish$" "$KIOSK_DST"
 }
 
 @test "mirrors body content verbatim (camera fix carries over)" {

--- a/themes/kiosk_codesign.yaml
+++ b/themes/kiosk_codesign.yaml
@@ -1,0 +1,74 @@
+Kiosk Codesign:
+  # Refined "instrument-panel" variant of Kiosk Polish, applied ONLY to the
+  # co-design sandbox view (/dashboard-kiosk-codesign/home). It deliberately
+  # reuses the same token NAMES as Kiosk Polish so dashboards/kiosk-codesign.yaml
+  # re-skins with zero card edits — the sandbox is a CI-enforced byte-mirror of
+  # production, so the redesign has to live in the theme, not the cards.
+  #
+  # Production (Kiosk Polish, /dashboard-kiosk/home — "the presence monitor")
+  # is untouched.
+  #
+  # Direction (chosen 2026-06-10): refined / instrument-panel —
+  #   1. Deeper, cooler near-black base.
+  #   2. Machined gradient "depth" on card + tile surfaces (vs flat fills).
+  #   3. IBM Plex Sans typography globally (replaces default Roboto) — a
+  #      technical, characterful face that reads like a control surface.
+  #   4. State colors (disarmed/armed/triggered, door green/red, garage amber,
+  #      media blue) kept saturated so the across-the-room glance-read is
+  #      preserved. Only the purely-decorative climate accent is demoted to
+  #      a quiet steel chrome.
+
+  # --- Base palette: deeper, cooler near-black ---
+  kiosk-bg-page: "#0a0c10"
+  # Card/tile backgrounds carry a subtle top-lit gradient for depth. CSS
+  # custom properties can hold gradient values and resolve in `background:`,
+  # so every `background: var(--kiosk-bg-card)` in the dashboard gains depth
+  # with no card edit.
+  kiosk-bg-card: "linear-gradient(160deg, #1b212b 0%, #11151c 100%)"
+  kiosk-bg-tile: "linear-gradient(160deg, #1c2230 0%, #141922 100%)"
+  kiosk-bg-tile-active-media: "linear-gradient(160deg, #16314f 0%, #0f2236 100%)"
+  kiosk-text-primary: "#eef3f8"
+  kiosk-text-secondary: "#9aa6b2"
+  kiosk-text-tertiary: "#6b7682"
+
+  # --- Accents ---
+  # climate: was neon orange (#f0883e). It is only ever a decorative column
+  # border-top, so it's safe to demote to a refined steel chrome that stops
+  # competing with the semantic state palette.
+  kiosk-accent-climate: "#5a7ca6"
+  # sensors / lights / media double as SEMANTIC colors elsewhere in the cards
+  # (green = door-safe, amber = garage-in-transit, blue = media) — keep them.
+  kiosk-accent-sensors: "#56d364"
+  kiosk-accent-lights: "#e3b341"
+  kiosk-accent-media: "#58a6ff"
+  kiosk-accent-disarmed: "#56d364"
+  kiosk-accent-armed: "#e3b341"
+  kiosk-accent-triggered: "#f85149"
+
+  # Mushroom sizing — identical to Polish so the lights column still fits
+  # 2560x1440 without a page scrollbar.
+  mush-icon-size: 32px
+  mush-icon-symbol-size: 0.55em
+  mush-card-primary-font-size: 13px
+  mush-card-secondary-font-size: 12px
+  mush-spacing: 8px
+
+  state-on-color: "#56d364"
+  state-off-color: "#6b7682"
+
+  card-mod-theme: Kiosk Codesign
+  card-mod-root: |
+    @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap');
+    /* Force kiosk grid background through layout-card (as Kiosk Polish does) */
+    home-assistant-main {
+      --primary-background-color: var(--kiosk-bg-page);
+    }
+    /* Global typography swap. font-family is an inherited property, so setting
+       it on <html> cascades across shadow-DOM boundaries into every custom
+       card that doesn't set its own face (clock-weather-card, thermostat,
+       button-card, mushroom). Also set HA's font vars for MDC components. */
+    html {
+      font-family: 'IBM Plex Sans', system-ui, sans-serif;
+      --ha-font-family-body: 'IBM Plex Sans', system-ui, sans-serif;
+      --mdc-typography-font-family: 'IBM Plex Sans', system-ui, sans-serif;
+    }


### PR DESCRIPTION
Re-skins the co-design sandbox (`/dashboard-kiosk-codesign/home`) with a refined "instrument-panel" design study. The production presence monitor (`Kiosk Polish`, `/dashboard-kiosk/home`) is byte-for-byte untouched.

## Origin
Chris had just installed the `frontend-design` plugin to use on Home Assistant dashboard work and asked Claude to point it at the presence monitor — the household kiosk dashboard — as a first test. After a frontend-design-informed critique (default typography, evenly-distributed column accents competing with state colors, flat card fills), Chris chose a "refined / instrument-panel" direction. Because `dashboards/kiosk-codesign.yaml` is a CI-enforced byte-mirror of production, the redesign was implemented as a theme rather than forked cards, so the sandbox can A/B the look with zero card edits.

## What changed
- **`themes/kiosk_codesign.yaml`** (new) — overrides the same `--kiosk-*` tokens the cards already consume: IBM Plex Sans typography (global, via `card-mod-root` `@import` + inherited `font-family`), gradient surface depth on `--kiosk-bg-card`/`--kiosk-bg-tile` (CSS custom properties holding gradient values), a cooler/deeper base, and the purely-decorative `climate` accent demoted from neon orange to a steel chrome.
- **`scripts/sync-kiosk-codesign.sh`** — one `sed` substitution swaps the sandbox view's theme `Kiosk Polish` → `Kiosk Codesign`; comments updated to note the theme is now an intentional difference.
- **`dashboards/kiosk-codesign.yaml`** — regenerated; `--check` passes.

## Scope / safety
- **Production untouched** — only the `/dashboard-kiosk-codesign/home` view changes; `Kiosk Polish` and `kiosk.yaml` are unmodified.
- **State semantics preserved** — disarmed/armed/triggered, door green/red, garage amber, media blue all kept saturated.
- Verified live: pushed to HAOS, `frontend.reload_themes`, rendered before/after at 2560×1440 on the presence monitor.

## Follow-up (not in this PR)
IBM Plex **Mono** on the hero numbers (clock/temps) and a `--kiosk-chrome` token to fully decouple decorative borders from state colors — both require touching production `kiosk.yaml`, so deferred to a separate change.