### PR TITLE
Kiosk: one section per column to eliminate inter-row gaps

### DIFF
--- a/dashboards/kiosk-codesign.yaml
+++ b/dashboards/kiosk-codesign.yaml
@@ -19,44 +19,42 @@
 # 2560x1440 wall monitor, served at /dashboard-kiosk/home.
 #
 # Layout philosophy: NO hard pixel-fit. Uses HA's native `sections`
-# view — cards size to their content, sections reflow responsively
-# across max_columns. There is deliberately no height:100% cascade and
-# no fixed-pixel row math. This replaced the custom:grid-layout +
-# mod-card pixel-fit design on 2026-06-11.
+# view — cards size to their content. This replaced the custom:grid-
+# layout + mod-card pixel-fit design on 2026-06-11.
 #
 # Width fill: max_columns is 5. HA caps each sections column at ~500px
 # and centers the grid, so on the 2560px wall display fewer columns
 # leave wide black bars on each side (3 cols ≈ 530px bars; 5 cols ≈
 # ~38px).
 #
-# Section ORDER is load-bearing. HA's sections view places sections
-# round-robin by order (section i -> column i mod 5) and sizes each
-# grid row to its tallest section. There are exactly TEN sections (two
-# clean rows — an 11th would force a third row that overflows 1440 and
-# clips the bottom), hand-ordered to PAIR a big tile section with a
-# short non-tile section per column so the five columns land within
-# ~200px of each other AND the page never scrolls:
-#   c1 Weather              + Openings (doors/garage/motion)
-#   c2 Upstairs climate     + Hallway/Outdoor lights
-#   c3 Downstairs climate   + Office lights
-#   c4 Security/Presence    + Home Status (env + safety)
-#   c5 Media                + Family/Kitchen lights
-# Because of round-robin, the YAML order is the column-interleave (the
-# first five sections are the top row, the next five the bottom row),
-# NOT the visual top-to-bottom order of a single column. YAML anchors
-# (&climate_block, &mlight) are defined in whichever section appears
-# first in document order and reused by later ones.
+# ONE SECTION PER COLUMN. There are exactly five sections, one per
+# column. This is deliberate: HA's sections view arranges sections in a
+# row-grid and aligns each column's Nth section to a shared row baseline
+# (row height = the tallest section in that row). With multiple sections
+# per column that alignment turns any tall section into an inter-row GAP
+# in every shorter column. With a single section per column there are no
+# shared rows to align, so a column simply stacks its cards top-down and
+# any leftover is a clean margin at the very bottom — no mid-column gaps,
+# whatever the relative heights. Columns are paired (a short non-tile
+# block + a tile block) so they come out within ~150px of each other:
+#   c1 Weather            + Openings (doors/garage/motion)
+#   c2 Security/Presence  + Media (compact now-playing strips)
+#   c3 Upstairs climate   + Hallway/Outdoor lights
+#   c4 Downstairs climate + Office lights
+#   c5 Home Status        + Family/Kitchen lights
+# YAML anchors (&climate_block, &mlight) are defined in whichever
+# section appears first in document order (c3) and reused by c4/c5.
 #
 # Design language (one tile family across the board): button-card,
 # dark tile base, big icon over name over value. State drives icon
 # color + background tint (intensity can scale with magnitude, e.g.
 # light brightness); a LEFT 4px accent = "active/identity" (alarm,
 # presence, a light that's on); a FULL 2px border = "alert" (door/
-# garage open, motion, leak wet, alarm triggered) — reserved for things
-# that demand attention. Color semantics via theme tokens: green =
-# safe/home/closed, red = open/alert, amber = lights/in-transit,
-# blue = media/cool. Climate uses the native thermostat dial; weather
-# the clock-weather-card; Sonos the mini-media-player.
+# garage open, motion, leak wet, alarm triggered). Color semantics via
+# theme tokens: green = safe/home/closed, red = open/alert, amber =
+# lights/in-transit, blue = media/cool. Climate uses the native
+# thermostat dial; weather the clock-weather-card; Sonos the
+# mini-media-player (compact: artwork + name, tap for full controls).
 #
 # The Nest doorbell camera was removed 2026-06-13 — its cloud
 # integration does not serve a still snapshot, so camera_view:snapshot
@@ -84,7 +82,7 @@ views:
     max_columns: 5
     sections:
 
-      # ===== c1 top ===== WEATHER ================================
+      # ================= COLUMN 1: WEATHER + OPENINGS ============
       - type: grid
         cards:
           - type: heading
@@ -98,132 +96,185 @@ views:
             hide_today_section: false
             hide_forecast_section: false
 
-      # ===== c2 top ===== CLIMATE · UPSTAIRS (defines block) =====
-      - type: grid
-        cards:
           - type: heading
-            heading: Upstairs
+            heading: Openings
             heading_style: title
-          - &climate_block
-            type: vertical-stack
+          - type: grid
+            columns: 2
+            square: false
             cards:
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: climate.upstairs
-                    state_not: 'off'
-                card:
-                  type: thermostat
-                  entity: climate.upstairs
-                  name: Upstairs
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: climate.upstairs
-                    state: 'off'
-                card:
-                  type: custom:mushroom-template-card
-                  entity: climate.upstairs
-                  primary: |-
-                    {% set t = state_attr(config.entity, "current_temperature") %}
-                    {{ (t | round(1)) if t is not none else "—" }}°F
-                  secondary: "Upstairs · Standby"
-                  icon: mdi:thermometer
-                  icon_color: blue-grey
-                  fill_container: true
-                  tap_action: { action: more-info }
-              - type: custom:mushroom-chips-card
-                alignment: center
-                chips:
-                  - type: template
-                    icon: mdi:water-percent
-                    icon_color: blue
-                    content: '{% set h = states("sensor.upstairs_humidity") | float(none) %}{{ (h | round) if h is not none else "—" }}%'
-                  - type: template
-                    icon: mdi:thermometer
-                    icon_color: amber
-                    content: |-
-                      {% set t = state_attr("climate.upstairs", "temperature") %}
-                      {% set tl = state_attr("climate.upstairs", "target_temp_low") %}
-                      {% set th = state_attr("climate.upstairs", "target_temp_high") %}
-                      {% if t is not none %}Set {{ t | round }}°
-                      {% elif tl is not none and th is not none %}{{ tl | round }}–{{ th | round }}°
-                      {% else %}—{% endif %}
-                  - type: template
-                    icon: |-
-                      {% set a = state_attr("climate.upstairs", "hvac_action") %}
-                      {% if a == "heating" %}mdi:fire{% elif a == "cooling" %}mdi:snowflake{% elif a == "idle" %}mdi:thermometer-check{% else %}mdi:thermometer-off{% endif %}
-                    icon_color: |-
-                      {% set a = state_attr("climate.upstairs", "hvac_action") %}
-                      {% if a == "heating" %}red{% elif a == "cooling" %}blue{% else %}grey{% endif %}
-                    content: |-
-                      {% set a = state_attr("climate.upstairs", "hvac_action") %}
-                      {{ a | title if a else "Off" }}
-
-      # ===== c3 top ===== CLIMATE · DOWNSTAIRS ===================
-      - type: grid
-        cards:
-          - type: heading
-            heading: Downstairs
-            heading_style: title
-          - <<: *climate_block
+              - &door_sensor
+                type: custom:button-card
+                entity: binary_sensor.main_panel_front_door
+                name: Front
+                show_name: true
+                show_state: true
+                show_icon: true
+                size: 44%
+                tap_action: { action: more-info }
+                state:
+                  - value: 'on'
+                    icon: mdi:door-open
+                    color: 'var(--kiosk-accent-triggered)'
+                    styles:
+                      card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
+                  - value: 'off'
+                    icon: mdi:door-closed
+                    color: 'var(--kiosk-accent-sensors)'
+                    styles:
+                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                  - operator: default
+                    icon: mdi:door
+                    color: 'var(--kiosk-text-tertiary)'
+                    styles:
+                      card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
+                styles:
+                  card:
+                    - background: 'var(--kiosk-bg-tile)'
+                    - border-radius: '8px'
+                    - border: 'none'
+                    - padding: '14px 12px'
+                    - min-height: '180px'
+                  name:
+                    - font-size: '16px'
+                    - font-weight: '500'
+                    - color: 'var(--kiosk-text-secondary)'
+                    - padding-top: '6px'
+                  state:
+                    - font-size: '18px'
+                    - text-transform: 'uppercase'
+                    - font-weight: '600'
+                    - letter-spacing: '0.5px'
+                    - padding-top: '2px'
+              - <<: *door_sensor
+                entity: binary_sensor.main_panel_sliding_door
+                name: Sliding
+                state:
+                  - value: 'on'
+                    icon: mdi:door-sliding-open
+                    color: 'var(--kiosk-accent-triggered)'
+                    styles:
+                      card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
+                  - value: 'off'
+                    icon: mdi:door-sliding
+                    color: 'var(--kiosk-accent-sensors)'
+                    styles:
+                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                  - operator: default
+                    icon: mdi:door-sliding
+                    color: 'var(--kiosk-text-tertiary)'
+                    styles:
+                      card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
+              - <<: *door_sensor
+                entity: binary_sensor.main_panel_garage_door
+                name: Garage Entry
+              - <<: *door_sensor
+                entity: binary_sensor.main_panel_basement_door
+                name: Basement
+              - &garage_cover
+                type: custom:button-card
+                entity: cover.garage_door_1_door
+                name: Garage 1
+                show_name: true
+                show_state: true
+                show_icon: true
+                size: 44%
+                tap_action: { action: more-info }
+                state:
+                  - value: 'closed'
+                    icon: mdi:garage
+                    color: 'var(--kiosk-accent-sensors)'
+                    styles:
+                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                  - value: 'open'
+                    icon: mdi:garage-open-variant
+                    color: 'var(--kiosk-accent-triggered)'
+                    styles:
+                      card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
+                  - operator: regex
+                    value: '^(opening|closing)$'
+                    icon: mdi:garage-alert-variant
+                    color: 'var(--kiosk-accent-lights)'
+                    styles:
+                      card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
+                styles:
+                  card:
+                    - background: 'var(--kiosk-bg-tile)'
+                    - border-radius: '8px'
+                    - border: 'none'
+                    - padding: '14px 12px'
+                    - min-height: '180px'
+                  name:
+                    - font-size: '16px'
+                    - font-weight: '500'
+                    - color: 'var(--kiosk-text-secondary)'
+                    - padding-top: '6px'
+                  state:
+                    - font-size: '18px'
+                    - text-transform: 'uppercase'
+                    - font-weight: '600'
+                    - letter-spacing: '0.5px'
+                    - padding-top: '2px'
+            extra_styles: |
+              @keyframes pulse {
+                0%, 100% { opacity: 1; }
+                50% { opacity: 0.7; }
+              }
+          - type: grid
+            columns: 2
+            square: false
             cards:
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: climate.downstairs
-                    state_not: 'off'
-                card:
-                  type: thermostat
-                  entity: climate.downstairs
-                  name: Downstairs
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: climate.downstairs
-                    state: 'off'
-                card:
-                  type: custom:mushroom-template-card
-                  entity: climate.downstairs
-                  primary: |-
-                    {% set t = state_attr(config.entity, "current_temperature") %}
-                    {{ (t | round(1)) if t is not none else "—" }}°F
-                  secondary: "Downstairs · Standby"
-                  icon: mdi:thermometer
-                  icon_color: blue-grey
-                  fill_container: true
-                  tap_action: { action: more-info }
-              - type: custom:mushroom-chips-card
-                alignment: center
-                chips:
-                  - type: template
-                    icon: mdi:water-percent
-                    icon_color: blue
-                    content: '{% set h = states("sensor.downstairs_humidity") | float(none) %}{{ (h | round) if h is not none else "—" }}%'
-                  - type: template
-                    icon: mdi:thermometer
-                    icon_color: amber
-                    content: |-
-                      {% set t = state_attr("climate.downstairs", "temperature") %}
-                      {% set tl = state_attr("climate.downstairs", "target_temp_low") %}
-                      {% set th = state_attr("climate.downstairs", "target_temp_high") %}
-                      {% if t is not none %}Set {{ t | round }}°
-                      {% elif tl is not none and th is not none %}{{ tl | round }}–{{ th | round }}°
-                      {% else %}—{% endif %}
-                  - type: template
-                    icon: |-
-                      {% set a = state_attr("climate.downstairs", "hvac_action") %}
-                      {% if a == "heating" %}mdi:fire{% elif a == "cooling" %}mdi:snowflake{% elif a == "idle" %}mdi:thermometer-check{% else %}mdi:thermometer-off{% endif %}
-                    icon_color: |-
-                      {% set a = state_attr("climate.downstairs", "hvac_action") %}
-                      {% if a == "heating" %}red{% elif a == "cooling" %}blue{% else %}grey{% endif %}
-                    content: |-
-                      {% set a = state_attr("climate.downstairs", "hvac_action") %}
-                      {{ a | title if a else "Off" }}
+              - <<: *garage_cover
+                entity: cover.garage_door_2_door
+                name: Garage 2
+              - &motion_sensor
+                type: custom:button-card
+                entity: binary_sensor.main_panel_family_room_motion
+                name: Family
+                show_name: true
+                show_state: true
+                show_icon: true
+                size: 44%
+                tap_action: { action: more-info }
+                state:
+                  - value: 'on'
+                    icon: mdi:motion-sensor
+                    color: 'var(--kiosk-accent-triggered)'
+                    styles:
+                      card: [{ background-color: 'rgba(248, 81, 73, 0.20)' }, { animation: 'pulse 1s infinite' }]
+                  - value: 'off'
+                    icon: mdi:motion-sensor-off
+                    color: 'var(--kiosk-accent-sensors)'
+                    styles:
+                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                  - operator: default
+                    icon: mdi:motion-sensor-off
+                    color: 'var(--kiosk-text-tertiary)'
+                    styles:
+                      card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
+                styles:
+                  card:
+                    - background: 'var(--kiosk-bg-tile)'
+                    - border-radius: '8px'
+                    - border: 'none'
+                    - padding: '14px 12px'
+                    - min-height: '180px'
+                  name:
+                    - font-size: '16px'
+                    - font-weight: '500'
+                    - color: 'var(--kiosk-text-secondary)'
+                    - padding-top: '6px'
+                  state:
+                    - font-size: '18px'
+                    - text-transform: 'uppercase'
+                    - font-weight: '600'
+                    - letter-spacing: '0.5px'
+                    - padding-top: '2px'
+              - <<: *motion_sensor
+                entity: binary_sensor.main_panel_office_motion
+                name: Office
 
-      # ===== c4 top ===== SECURITY & PRESENCE ====================
-      # Alarm hero + arm/disarm row, then meeting indicator +
-      # Chris/Rachel presence.
+      # ============ COLUMN 2: SECURITY/PRESENCE + MEDIA =========
       - type: grid
         cards:
           - type: heading
@@ -552,9 +603,6 @@ views:
                       card: [{ background-color: 'var(--kiosk-bg-tile)' }]
                       label: [{ color: 'var(--kiosk-text-tertiary)' }]
 
-      # ===== c5 top ===== MEDIA ==================================
-      - type: grid
-        cards:
           - type: heading
             heading: Media
             heading_style: title
@@ -568,12 +616,12 @@ views:
                 name: Master Bedroom
                 artwork: full-cover-fit
                 info: scroll
-                hide: { source: true, sound_mode: true, shuffle: true, runtime: true, name: false }
+                hide: { source: true, sound_mode: true, shuffle: true, runtime: true, name: false, controls: true, volume: true, power: true, progress: true, icon: true }
                 tap_action: { action: more-info }
                 card_mod:
                   style: |
                     ha-card {
-                      min-height: 120px;
+                      min-height: 88px;
                       border-radius: 6px;
                       {% set members = state_attr(config.entity, 'group_members') or [] %}
                       {% if members | length > 1 and members[0] != config.entity %}
@@ -631,182 +679,69 @@ views:
               state: [{ font-size: '16px' }, { font-weight: '600' }, { text-transform: 'uppercase' }, { justify-self: 'start' }]
               grid: [{ grid-template-areas: '"i n" "i s"' }, { grid-template-columns: 'min-content 1fr' }, { column-gap: '14px' }]
 
-      # ===== c1 bottom ===== OPENINGS (doors/garage/motion) ======
-      # Defines &door_sensor, &garage_cover, &motion_sensor.
+      # ========= COLUMN 3: UPSTAIRS CLIMATE + HALL/OUTDOOR ======
+      # Defines &climate_block (reused by c4) and &mlight (reused c4/c5).
       - type: grid
         cards:
           - type: heading
-            heading: Openings
+            heading: Upstairs
             heading_style: title
-          - type: grid
-            columns: 3
-            square: false
+          - &climate_block
+            type: vertical-stack
             cards:
-              - &door_sensor
-                type: custom:button-card
-                entity: binary_sensor.main_panel_front_door
-                name: Front
-                show_name: true
-                show_state: true
-                show_icon: true
-                size: 46%
-                tap_action: { action: more-info }
-                state:
-                  - value: 'on'
-                    icon: mdi:door-open
-                    color: 'var(--kiosk-accent-triggered)'
-                    styles:
-                      card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
-                  - value: 'off'
-                    icon: mdi:door-closed
-                    color: 'var(--kiosk-accent-sensors)'
-                    styles:
-                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                  - operator: default
-                    icon: mdi:door
-                    color: 'var(--kiosk-text-tertiary)'
-                    styles:
-                      card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
-                styles:
-                  card:
-                    - background: 'var(--kiosk-bg-tile)'
-                    - border-radius: '8px'
-                    - border: 'none'
-                    - padding: '14px 12px'
-                    - min-height: '146px'
-                  name:
-                    - font-size: '16px'
-                    - font-weight: '500'
-                    - color: 'var(--kiosk-text-secondary)'
-                    - padding-top: '6px'
-                  state:
-                    - font-size: '18px'
-                    - text-transform: 'uppercase'
-                    - font-weight: '600'
-                    - letter-spacing: '0.5px'
-                    - padding-top: '2px'
-              - <<: *door_sensor
-                entity: binary_sensor.main_panel_sliding_door
-                name: Sliding
-                state:
-                  - value: 'on'
-                    icon: mdi:door-sliding-open
-                    color: 'var(--kiosk-accent-triggered)'
-                    styles:
-                      card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
-                  - value: 'off'
-                    icon: mdi:door-sliding
-                    color: 'var(--kiosk-accent-sensors)'
-                    styles:
-                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                  - operator: default
-                    icon: mdi:door-sliding
-                    color: 'var(--kiosk-text-tertiary)'
-                    styles:
-                      card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
-              - <<: *door_sensor
-                entity: binary_sensor.main_panel_garage_door
-                name: Garage Entry
-              - <<: *door_sensor
-                entity: binary_sensor.main_panel_basement_door
-                name: Basement
-              - &garage_cover
-                type: custom:button-card
-                entity: cover.garage_door_1_door
-                name: Garage 1
-                show_name: true
-                show_state: true
-                show_icon: true
-                size: 46%
-                tap_action: { action: more-info }
-                state:
-                  - value: 'closed'
-                    icon: mdi:garage
-                    color: 'var(--kiosk-accent-sensors)'
-                    styles:
-                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                  - value: 'open'
-                    icon: mdi:garage-open-variant
-                    color: 'var(--kiosk-accent-triggered)'
-                    styles:
-                      card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
-                  - operator: regex
-                    value: '^(opening|closing)$'
-                    icon: mdi:garage-alert-variant
-                    color: 'var(--kiosk-accent-lights)'
-                    styles:
-                      card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
-                styles:
-                  card:
-                    - background: 'var(--kiosk-bg-tile)'
-                    - border-radius: '8px'
-                    - border: 'none'
-                    - padding: '14px 12px'
-                    - min-height: '146px'
-                  name:
-                    - font-size: '16px'
-                    - font-weight: '500'
-                    - color: 'var(--kiosk-text-secondary)'
-                    - padding-top: '6px'
-                  state:
-                    - font-size: '18px'
-                    - text-transform: 'uppercase'
-                    - font-weight: '600'
-                    - letter-spacing: '0.5px'
-                    - padding-top: '2px'
-              - <<: *garage_cover
-                entity: cover.garage_door_2_door
-                name: Garage 2
-              - &motion_sensor
-                type: custom:button-card
-                entity: binary_sensor.main_panel_family_room_motion
-                name: Family
-                show_name: true
-                show_state: true
-                show_icon: true
-                size: 46%
-                tap_action: { action: more-info }
-                state:
-                  - value: 'on'
-                    icon: mdi:motion-sensor
-                    color: 'var(--kiosk-accent-triggered)'
-                    styles:
-                      card: [{ background-color: 'rgba(248, 81, 73, 0.20)' }, { animation: 'pulse 1s infinite' }]
-                  - value: 'off'
-                    icon: mdi:motion-sensor-off
-                    color: 'var(--kiosk-accent-sensors)'
-                    styles:
-                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                  - operator: default
-                    icon: mdi:motion-sensor-off
-                    color: 'var(--kiosk-text-tertiary)'
-                    styles:
-                      card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
-                styles:
-                  card:
-                    - background: 'var(--kiosk-bg-tile)'
-                    - border-radius: '8px'
-                    - border: 'none'
-                    - padding: '14px 12px'
-                    - min-height: '146px'
-                  name:
-                    - font-size: '16px'
-                    - font-weight: '500'
-                    - color: 'var(--kiosk-text-secondary)'
-                    - padding-top: '6px'
-                  state:
-                    - font-size: '18px'
-                    - text-transform: 'uppercase'
-                    - font-weight: '600'
-                    - letter-spacing: '0.5px'
-                    - padding-top: '2px'
-              - <<: *motion_sensor
-                entity: binary_sensor.main_panel_office_motion
-                name: Office
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: climate.upstairs
+                    state_not: 'off'
+                card:
+                  type: thermostat
+                  entity: climate.upstairs
+                  name: Upstairs
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: climate.upstairs
+                    state: 'off'
+                card:
+                  type: custom:mushroom-template-card
+                  entity: climate.upstairs
+                  primary: |-
+                    {% set t = state_attr(config.entity, "current_temperature") %}
+                    {{ (t | round(1)) if t is not none else "—" }}°F
+                  secondary: "Upstairs · Standby"
+                  icon: mdi:thermometer
+                  icon_color: blue-grey
+                  fill_container: true
+                  tap_action: { action: more-info }
+              - type: custom:mushroom-chips-card
+                alignment: center
+                chips:
+                  - type: template
+                    icon: mdi:water-percent
+                    icon_color: blue
+                    content: '{% set h = states("sensor.upstairs_humidity") | float(none) %}{{ (h | round) if h is not none else "—" }}%'
+                  - type: template
+                    icon: mdi:thermometer
+                    icon_color: amber
+                    content: |-
+                      {% set t = state_attr("climate.upstairs", "temperature") %}
+                      {% set tl = state_attr("climate.upstairs", "target_temp_low") %}
+                      {% set th = state_attr("climate.upstairs", "target_temp_high") %}
+                      {% if t is not none %}Set {{ t | round }}°
+                      {% elif tl is not none and th is not none %}{{ tl | round }}–{{ th | round }}°
+                      {% else %}—{% endif %}
+                  - type: template
+                    icon: |-
+                      {% set a = state_attr("climate.upstairs", "hvac_action") %}
+                      {% if a == "heating" %}mdi:fire{% elif a == "cooling" %}mdi:snowflake{% elif a == "idle" %}mdi:thermometer-check{% else %}mdi:thermometer-off{% endif %}
+                    icon_color: |-
+                      {% set a = state_attr("climate.upstairs", "hvac_action") %}
+                      {% if a == "heating" %}red{% elif a == "cooling" %}blue{% else %}grey{% endif %}
+                    content: |-
+                      {% set a = state_attr("climate.upstairs", "hvac_action") %}
+                      {{ a | title if a else "Off" }}
 
-      # ===== c2 bottom ===== HALLWAY & OUTDOOR LIGHTS (defines &mlight)
-      - type: grid
-        cards:
           - type: heading
             heading: Hallways & Outdoor
             heading_style: title
@@ -824,7 +759,7 @@ views:
                 show_name: true
                 show_state: true
                 show_icon: true
-                size: 48%
+                size: 44%
                 tap_action: { action: toggle }
                 hold_action: { action: more-info }
                 state_display: |
@@ -877,7 +812,7 @@ views:
             heading: Outdoor
             heading_style: subtitle
           - type: grid
-            columns: 3
+            columns: 2
             square: false
             cards:
               - <<: *mlight
@@ -896,9 +831,67 @@ views:
                 entity: light.shed
                 name: Shed
 
-      # ===== c3 bottom ===== OFFICE LIGHTS =======================
+      # ========= COLUMN 4: DOWNSTAIRS CLIMATE + OFFICE ==========
       - type: grid
         cards:
+          - type: heading
+            heading: Downstairs
+            heading_style: title
+          - <<: *climate_block
+            cards:
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: climate.downstairs
+                    state_not: 'off'
+                card:
+                  type: thermostat
+                  entity: climate.downstairs
+                  name: Downstairs
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: climate.downstairs
+                    state: 'off'
+                card:
+                  type: custom:mushroom-template-card
+                  entity: climate.downstairs
+                  primary: |-
+                    {% set t = state_attr(config.entity, "current_temperature") %}
+                    {{ (t | round(1)) if t is not none else "—" }}°F
+                  secondary: "Downstairs · Standby"
+                  icon: mdi:thermometer
+                  icon_color: blue-grey
+                  fill_container: true
+                  tap_action: { action: more-info }
+              - type: custom:mushroom-chips-card
+                alignment: center
+                chips:
+                  - type: template
+                    icon: mdi:water-percent
+                    icon_color: blue
+                    content: '{% set h = states("sensor.downstairs_humidity") | float(none) %}{{ (h | round) if h is not none else "—" }}%'
+                  - type: template
+                    icon: mdi:thermometer
+                    icon_color: amber
+                    content: |-
+                      {% set t = state_attr("climate.downstairs", "temperature") %}
+                      {% set tl = state_attr("climate.downstairs", "target_temp_low") %}
+                      {% set th = state_attr("climate.downstairs", "target_temp_high") %}
+                      {% if t is not none %}Set {{ t | round }}°
+                      {% elif tl is not none and th is not none %}{{ tl | round }}–{{ th | round }}°
+                      {% else %}—{% endif %}
+                  - type: template
+                    icon: |-
+                      {% set a = state_attr("climate.downstairs", "hvac_action") %}
+                      {% if a == "heating" %}mdi:fire{% elif a == "cooling" %}mdi:snowflake{% elif a == "idle" %}mdi:thermometer-check{% else %}mdi:thermometer-off{% endif %}
+                    icon_color: |-
+                      {% set a = state_attr("climate.downstairs", "hvac_action") %}
+                      {% if a == "heating" %}red{% elif a == "cooling" %}blue{% else %}grey{% endif %}
+                    content: |-
+                      {% set a = state_attr("climate.downstairs", "hvac_action") %}
+                      {{ a | title if a else "Off" }}
+
           - type: heading
             heading: Office
             heading_style: title
@@ -925,10 +918,8 @@ views:
                 entity: light.desk_lamp_2_2
                 name: Desk 2
 
-      # ===== c4 bottom ===== HOME STATUS (defines &status_tile) ==
-      # Environment + safety indicators in the shared tile language:
-      # leak detectors (green dry / red wet), UPS, floor temps
-      # (warm/cool tinted), humidity.
+      # ========= COLUMN 5: HOME STATUS + FAMILY/KITCHEN =========
+      # Defines &status_tile.
       - type: grid
         cards:
           - type: heading
@@ -1066,9 +1057,6 @@ views:
                     styles:
                       card: [{ background-color: 'rgba(88, 166, 255, 0.10)' }]
 
-      # ===== c5 bottom ===== FAMILY & KITCHEN LIGHTS =============
-      - type: grid
-        cards:
           - type: heading
             heading: Lights
             heading_style: title

--- a/dashboards/kiosk.yaml
+++ b/dashboards/kiosk.yaml
@@ -4,44 +4,42 @@
 # 2560x1440 wall monitor, served at /dashboard-kiosk/home.
 #
 # Layout philosophy: NO hard pixel-fit. Uses HA's native `sections`
-# view — cards size to their content, sections reflow responsively
-# across max_columns. There is deliberately no height:100% cascade and
-# no fixed-pixel row math. This replaced the custom:grid-layout +
-# mod-card pixel-fit design on 2026-06-11.
+# view — cards size to their content. This replaced the custom:grid-
+# layout + mod-card pixel-fit design on 2026-06-11.
 #
 # Width fill: max_columns is 5. HA caps each sections column at ~500px
 # and centers the grid, so on the 2560px wall display fewer columns
 # leave wide black bars on each side (3 cols ≈ 530px bars; 5 cols ≈
 # ~38px).
 #
-# Section ORDER is load-bearing. HA's sections view places sections
-# round-robin by order (section i -> column i mod 5) and sizes each
-# grid row to its tallest section. There are exactly TEN sections (two
-# clean rows — an 11th would force a third row that overflows 1440 and
-# clips the bottom), hand-ordered to PAIR a big tile section with a
-# short non-tile section per column so the five columns land within
-# ~200px of each other AND the page never scrolls:
-#   c1 Weather              + Openings (doors/garage/motion)
-#   c2 Upstairs climate     + Hallway/Outdoor lights
-#   c3 Downstairs climate   + Office lights
-#   c4 Security/Presence    + Home Status (env + safety)
-#   c5 Media                + Family/Kitchen lights
-# Because of round-robin, the YAML order is the column-interleave (the
-# first five sections are the top row, the next five the bottom row),
-# NOT the visual top-to-bottom order of a single column. YAML anchors
-# (&climate_block, &mlight) are defined in whichever section appears
-# first in document order and reused by later ones.
+# ONE SECTION PER COLUMN. There are exactly five sections, one per
+# column. This is deliberate: HA's sections view arranges sections in a
+# row-grid and aligns each column's Nth section to a shared row baseline
+# (row height = the tallest section in that row). With multiple sections
+# per column that alignment turns any tall section into an inter-row GAP
+# in every shorter column. With a single section per column there are no
+# shared rows to align, so a column simply stacks its cards top-down and
+# any leftover is a clean margin at the very bottom — no mid-column gaps,
+# whatever the relative heights. Columns are paired (a short non-tile
+# block + a tile block) so they come out within ~150px of each other:
+#   c1 Weather            + Openings (doors/garage/motion)
+#   c2 Security/Presence  + Media (compact now-playing strips)
+#   c3 Upstairs climate   + Hallway/Outdoor lights
+#   c4 Downstairs climate + Office lights
+#   c5 Home Status        + Family/Kitchen lights
+# YAML anchors (&climate_block, &mlight) are defined in whichever
+# section appears first in document order (c3) and reused by c4/c5.
 #
 # Design language (one tile family across the board): button-card,
 # dark tile base, big icon over name over value. State drives icon
 # color + background tint (intensity can scale with magnitude, e.g.
 # light brightness); a LEFT 4px accent = "active/identity" (alarm,
 # presence, a light that's on); a FULL 2px border = "alert" (door/
-# garage open, motion, leak wet, alarm triggered) — reserved for things
-# that demand attention. Color semantics via theme tokens: green =
-# safe/home/closed, red = open/alert, amber = lights/in-transit,
-# blue = media/cool. Climate uses the native thermostat dial; weather
-# the clock-weather-card; Sonos the mini-media-player.
+# garage open, motion, leak wet, alarm triggered). Color semantics via
+# theme tokens: green = safe/home/closed, red = open/alert, amber =
+# lights/in-transit, blue = media/cool. Climate uses the native
+# thermostat dial; weather the clock-weather-card; Sonos the
+# mini-media-player (compact: artwork + name, tap for full controls).
 #
 # The Nest doorbell camera was removed 2026-06-13 — its cloud
 # integration does not serve a still snapshot, so camera_view:snapshot
@@ -69,7 +67,7 @@ views:
     max_columns: 5
     sections:
 
-      # ===== c1 top ===== WEATHER ================================
+      # ================= COLUMN 1: WEATHER + OPENINGS ============
       - type: grid
         cards:
           - type: heading
@@ -83,132 +81,185 @@ views:
             hide_today_section: false
             hide_forecast_section: false
 
-      # ===== c2 top ===== CLIMATE · UPSTAIRS (defines block) =====
-      - type: grid
-        cards:
           - type: heading
-            heading: Upstairs
+            heading: Openings
             heading_style: title
-          - &climate_block
-            type: vertical-stack
+          - type: grid
+            columns: 2
+            square: false
             cards:
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: climate.upstairs
-                    state_not: 'off'
-                card:
-                  type: thermostat
-                  entity: climate.upstairs
-                  name: Upstairs
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: climate.upstairs
-                    state: 'off'
-                card:
-                  type: custom:mushroom-template-card
-                  entity: climate.upstairs
-                  primary: |-
-                    {% set t = state_attr(config.entity, "current_temperature") %}
-                    {{ (t | round(1)) if t is not none else "—" }}°F
-                  secondary: "Upstairs · Standby"
-                  icon: mdi:thermometer
-                  icon_color: blue-grey
-                  fill_container: true
-                  tap_action: { action: more-info }
-              - type: custom:mushroom-chips-card
-                alignment: center
-                chips:
-                  - type: template
-                    icon: mdi:water-percent
-                    icon_color: blue
-                    content: '{% set h = states("sensor.upstairs_humidity") | float(none) %}{{ (h | round) if h is not none else "—" }}%'
-                  - type: template
-                    icon: mdi:thermometer
-                    icon_color: amber
-                    content: |-
-                      {% set t = state_attr("climate.upstairs", "temperature") %}
-                      {% set tl = state_attr("climate.upstairs", "target_temp_low") %}
-                      {% set th = state_attr("climate.upstairs", "target_temp_high") %}
-                      {% if t is not none %}Set {{ t | round }}°
-                      {% elif tl is not none and th is not none %}{{ tl | round }}–{{ th | round }}°
-                      {% else %}—{% endif %}
-                  - type: template
-                    icon: |-
-                      {% set a = state_attr("climate.upstairs", "hvac_action") %}
-                      {% if a == "heating" %}mdi:fire{% elif a == "cooling" %}mdi:snowflake{% elif a == "idle" %}mdi:thermometer-check{% else %}mdi:thermometer-off{% endif %}
-                    icon_color: |-
-                      {% set a = state_attr("climate.upstairs", "hvac_action") %}
-                      {% if a == "heating" %}red{% elif a == "cooling" %}blue{% else %}grey{% endif %}
-                    content: |-
-                      {% set a = state_attr("climate.upstairs", "hvac_action") %}
-                      {{ a | title if a else "Off" }}
-
-      # ===== c3 top ===== CLIMATE · DOWNSTAIRS ===================
-      - type: grid
-        cards:
-          - type: heading
-            heading: Downstairs
-            heading_style: title
-          - <<: *climate_block
+              - &door_sensor
+                type: custom:button-card
+                entity: binary_sensor.main_panel_front_door
+                name: Front
+                show_name: true
+                show_state: true
+                show_icon: true
+                size: 44%
+                tap_action: { action: more-info }
+                state:
+                  - value: 'on'
+                    icon: mdi:door-open
+                    color: 'var(--kiosk-accent-triggered)'
+                    styles:
+                      card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
+                  - value: 'off'
+                    icon: mdi:door-closed
+                    color: 'var(--kiosk-accent-sensors)'
+                    styles:
+                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                  - operator: default
+                    icon: mdi:door
+                    color: 'var(--kiosk-text-tertiary)'
+                    styles:
+                      card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
+                styles:
+                  card:
+                    - background: 'var(--kiosk-bg-tile)'
+                    - border-radius: '8px'
+                    - border: 'none'
+                    - padding: '14px 12px'
+                    - min-height: '180px'
+                  name:
+                    - font-size: '16px'
+                    - font-weight: '500'
+                    - color: 'var(--kiosk-text-secondary)'
+                    - padding-top: '6px'
+                  state:
+                    - font-size: '18px'
+                    - text-transform: 'uppercase'
+                    - font-weight: '600'
+                    - letter-spacing: '0.5px'
+                    - padding-top: '2px'
+              - <<: *door_sensor
+                entity: binary_sensor.main_panel_sliding_door
+                name: Sliding
+                state:
+                  - value: 'on'
+                    icon: mdi:door-sliding-open
+                    color: 'var(--kiosk-accent-triggered)'
+                    styles:
+                      card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
+                  - value: 'off'
+                    icon: mdi:door-sliding
+                    color: 'var(--kiosk-accent-sensors)'
+                    styles:
+                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                  - operator: default
+                    icon: mdi:door-sliding
+                    color: 'var(--kiosk-text-tertiary)'
+                    styles:
+                      card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
+              - <<: *door_sensor
+                entity: binary_sensor.main_panel_garage_door
+                name: Garage Entry
+              - <<: *door_sensor
+                entity: binary_sensor.main_panel_basement_door
+                name: Basement
+              - &garage_cover
+                type: custom:button-card
+                entity: cover.garage_door_1_door
+                name: Garage 1
+                show_name: true
+                show_state: true
+                show_icon: true
+                size: 44%
+                tap_action: { action: more-info }
+                state:
+                  - value: 'closed'
+                    icon: mdi:garage
+                    color: 'var(--kiosk-accent-sensors)'
+                    styles:
+                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                  - value: 'open'
+                    icon: mdi:garage-open-variant
+                    color: 'var(--kiosk-accent-triggered)'
+                    styles:
+                      card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
+                  - operator: regex
+                    value: '^(opening|closing)$'
+                    icon: mdi:garage-alert-variant
+                    color: 'var(--kiosk-accent-lights)'
+                    styles:
+                      card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
+                styles:
+                  card:
+                    - background: 'var(--kiosk-bg-tile)'
+                    - border-radius: '8px'
+                    - border: 'none'
+                    - padding: '14px 12px'
+                    - min-height: '180px'
+                  name:
+                    - font-size: '16px'
+                    - font-weight: '500'
+                    - color: 'var(--kiosk-text-secondary)'
+                    - padding-top: '6px'
+                  state:
+                    - font-size: '18px'
+                    - text-transform: 'uppercase'
+                    - font-weight: '600'
+                    - letter-spacing: '0.5px'
+                    - padding-top: '2px'
+            extra_styles: |
+              @keyframes pulse {
+                0%, 100% { opacity: 1; }
+                50% { opacity: 0.7; }
+              }
+          - type: grid
+            columns: 2
+            square: false
             cards:
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: climate.downstairs
-                    state_not: 'off'
-                card:
-                  type: thermostat
-                  entity: climate.downstairs
-                  name: Downstairs
-              - type: conditional
-                conditions:
-                  - condition: state
-                    entity: climate.downstairs
-                    state: 'off'
-                card:
-                  type: custom:mushroom-template-card
-                  entity: climate.downstairs
-                  primary: |-
-                    {% set t = state_attr(config.entity, "current_temperature") %}
-                    {{ (t | round(1)) if t is not none else "—" }}°F
-                  secondary: "Downstairs · Standby"
-                  icon: mdi:thermometer
-                  icon_color: blue-grey
-                  fill_container: true
-                  tap_action: { action: more-info }
-              - type: custom:mushroom-chips-card
-                alignment: center
-                chips:
-                  - type: template
-                    icon: mdi:water-percent
-                    icon_color: blue
-                    content: '{% set h = states("sensor.downstairs_humidity") | float(none) %}{{ (h | round) if h is not none else "—" }}%'
-                  - type: template
-                    icon: mdi:thermometer
-                    icon_color: amber
-                    content: |-
-                      {% set t = state_attr("climate.downstairs", "temperature") %}
-                      {% set tl = state_attr("climate.downstairs", "target_temp_low") %}
-                      {% set th = state_attr("climate.downstairs", "target_temp_high") %}
-                      {% if t is not none %}Set {{ t | round }}°
-                      {% elif tl is not none and th is not none %}{{ tl | round }}–{{ th | round }}°
-                      {% else %}—{% endif %}
-                  - type: template
-                    icon: |-
-                      {% set a = state_attr("climate.downstairs", "hvac_action") %}
-                      {% if a == "heating" %}mdi:fire{% elif a == "cooling" %}mdi:snowflake{% elif a == "idle" %}mdi:thermometer-check{% else %}mdi:thermometer-off{% endif %}
-                    icon_color: |-
-                      {% set a = state_attr("climate.downstairs", "hvac_action") %}
-                      {% if a == "heating" %}red{% elif a == "cooling" %}blue{% else %}grey{% endif %}
-                    content: |-
-                      {% set a = state_attr("climate.downstairs", "hvac_action") %}
-                      {{ a | title if a else "Off" }}
+              - <<: *garage_cover
+                entity: cover.garage_door_2_door
+                name: Garage 2
+              - &motion_sensor
+                type: custom:button-card
+                entity: binary_sensor.main_panel_family_room_motion
+                name: Family
+                show_name: true
+                show_state: true
+                show_icon: true
+                size: 44%
+                tap_action: { action: more-info }
+                state:
+                  - value: 'on'
+                    icon: mdi:motion-sensor
+                    color: 'var(--kiosk-accent-triggered)'
+                    styles:
+                      card: [{ background-color: 'rgba(248, 81, 73, 0.20)' }, { animation: 'pulse 1s infinite' }]
+                  - value: 'off'
+                    icon: mdi:motion-sensor-off
+                    color: 'var(--kiosk-accent-sensors)'
+                    styles:
+                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
+                  - operator: default
+                    icon: mdi:motion-sensor-off
+                    color: 'var(--kiosk-text-tertiary)'
+                    styles:
+                      card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
+                styles:
+                  card:
+                    - background: 'var(--kiosk-bg-tile)'
+                    - border-radius: '8px'
+                    - border: 'none'
+                    - padding: '14px 12px'
+                    - min-height: '180px'
+                  name:
+                    - font-size: '16px'
+                    - font-weight: '500'
+                    - color: 'var(--kiosk-text-secondary)'
+                    - padding-top: '6px'
+                  state:
+                    - font-size: '18px'
+                    - text-transform: 'uppercase'
+                    - font-weight: '600'
+                    - letter-spacing: '0.5px'
+                    - padding-top: '2px'
+              - <<: *motion_sensor
+                entity: binary_sensor.main_panel_office_motion
+                name: Office
 
-      # ===== c4 top ===== SECURITY & PRESENCE ====================
-      # Alarm hero + arm/disarm row, then meeting indicator +
-      # Chris/Rachel presence.
+      # ============ COLUMN 2: SECURITY/PRESENCE + MEDIA =========
       - type: grid
         cards:
           - type: heading
@@ -537,9 +588,6 @@ views:
                       card: [{ background-color: 'var(--kiosk-bg-tile)' }]
                       label: [{ color: 'var(--kiosk-text-tertiary)' }]
 
-      # ===== c5 top ===== MEDIA ==================================
-      - type: grid
-        cards:
           - type: heading
             heading: Media
             heading_style: title
@@ -553,12 +601,12 @@ views:
                 name: Master Bedroom
                 artwork: full-cover-fit
                 info: scroll
-                hide: { source: true, sound_mode: true, shuffle: true, runtime: true, name: false }
+                hide: { source: true, sound_mode: true, shuffle: true, runtime: true, name: false, controls: true, volume: true, power: true, progress: true, icon: true }
                 tap_action: { action: more-info }
                 card_mod:
                   style: |
                     ha-card {
-                      min-height: 120px;
+                      min-height: 88px;
                       border-radius: 6px;
                       {% set members = state_attr(config.entity, 'group_members') or [] %}
                       {% if members | length > 1 and members[0] != config.entity %}
@@ -616,182 +664,69 @@ views:
               state: [{ font-size: '16px' }, { font-weight: '600' }, { text-transform: 'uppercase' }, { justify-self: 'start' }]
               grid: [{ grid-template-areas: '"i n" "i s"' }, { grid-template-columns: 'min-content 1fr' }, { column-gap: '14px' }]
 
-      # ===== c1 bottom ===== OPENINGS (doors/garage/motion) ======
-      # Defines &door_sensor, &garage_cover, &motion_sensor.
+      # ========= COLUMN 3: UPSTAIRS CLIMATE + HALL/OUTDOOR ======
+      # Defines &climate_block (reused by c4) and &mlight (reused c4/c5).
       - type: grid
         cards:
           - type: heading
-            heading: Openings
+            heading: Upstairs
             heading_style: title
-          - type: grid
-            columns: 3
-            square: false
+          - &climate_block
+            type: vertical-stack
             cards:
-              - &door_sensor
-                type: custom:button-card
-                entity: binary_sensor.main_panel_front_door
-                name: Front
-                show_name: true
-                show_state: true
-                show_icon: true
-                size: 46%
-                tap_action: { action: more-info }
-                state:
-                  - value: 'on'
-                    icon: mdi:door-open
-                    color: 'var(--kiosk-accent-triggered)'
-                    styles:
-                      card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
-                  - value: 'off'
-                    icon: mdi:door-closed
-                    color: 'var(--kiosk-accent-sensors)'
-                    styles:
-                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                  - operator: default
-                    icon: mdi:door
-                    color: 'var(--kiosk-text-tertiary)'
-                    styles:
-                      card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
-                styles:
-                  card:
-                    - background: 'var(--kiosk-bg-tile)'
-                    - border-radius: '8px'
-                    - border: 'none'
-                    - padding: '14px 12px'
-                    - min-height: '146px'
-                  name:
-                    - font-size: '16px'
-                    - font-weight: '500'
-                    - color: 'var(--kiosk-text-secondary)'
-                    - padding-top: '6px'
-                  state:
-                    - font-size: '18px'
-                    - text-transform: 'uppercase'
-                    - font-weight: '600'
-                    - letter-spacing: '0.5px'
-                    - padding-top: '2px'
-              - <<: *door_sensor
-                entity: binary_sensor.main_panel_sliding_door
-                name: Sliding
-                state:
-                  - value: 'on'
-                    icon: mdi:door-sliding-open
-                    color: 'var(--kiosk-accent-triggered)'
-                    styles:
-                      card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
-                  - value: 'off'
-                    icon: mdi:door-sliding
-                    color: 'var(--kiosk-accent-sensors)'
-                    styles:
-                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                  - operator: default
-                    icon: mdi:door-sliding
-                    color: 'var(--kiosk-text-tertiary)'
-                    styles:
-                      card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
-              - <<: *door_sensor
-                entity: binary_sensor.main_panel_garage_door
-                name: Garage Entry
-              - <<: *door_sensor
-                entity: binary_sensor.main_panel_basement_door
-                name: Basement
-              - &garage_cover
-                type: custom:button-card
-                entity: cover.garage_door_1_door
-                name: Garage 1
-                show_name: true
-                show_state: true
-                show_icon: true
-                size: 46%
-                tap_action: { action: more-info }
-                state:
-                  - value: 'closed'
-                    icon: mdi:garage
-                    color: 'var(--kiosk-accent-sensors)'
-                    styles:
-                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                  - value: 'open'
-                    icon: mdi:garage-open-variant
-                    color: 'var(--kiosk-accent-triggered)'
-                    styles:
-                      card: [{ background-color: 'rgba(248, 81, 73, 0.18)' }, { border: '2px solid var(--kiosk-accent-triggered)' }]
-                  - operator: regex
-                    value: '^(opening|closing)$'
-                    icon: mdi:garage-alert-variant
-                    color: 'var(--kiosk-accent-lights)'
-                    styles:
-                      card: [{ background-color: 'rgba(227, 179, 65, 0.18)' }, { animation: 'pulse 1s infinite' }]
-                styles:
-                  card:
-                    - background: 'var(--kiosk-bg-tile)'
-                    - border-radius: '8px'
-                    - border: 'none'
-                    - padding: '14px 12px'
-                    - min-height: '146px'
-                  name:
-                    - font-size: '16px'
-                    - font-weight: '500'
-                    - color: 'var(--kiosk-text-secondary)'
-                    - padding-top: '6px'
-                  state:
-                    - font-size: '18px'
-                    - text-transform: 'uppercase'
-                    - font-weight: '600'
-                    - letter-spacing: '0.5px'
-                    - padding-top: '2px'
-              - <<: *garage_cover
-                entity: cover.garage_door_2_door
-                name: Garage 2
-              - &motion_sensor
-                type: custom:button-card
-                entity: binary_sensor.main_panel_family_room_motion
-                name: Family
-                show_name: true
-                show_state: true
-                show_icon: true
-                size: 46%
-                tap_action: { action: more-info }
-                state:
-                  - value: 'on'
-                    icon: mdi:motion-sensor
-                    color: 'var(--kiosk-accent-triggered)'
-                    styles:
-                      card: [{ background-color: 'rgba(248, 81, 73, 0.20)' }, { animation: 'pulse 1s infinite' }]
-                  - value: 'off'
-                    icon: mdi:motion-sensor-off
-                    color: 'var(--kiosk-accent-sensors)'
-                    styles:
-                      card: [{ background-color: 'rgba(86, 211, 100, 0.10)' }]
-                  - operator: default
-                    icon: mdi:motion-sensor-off
-                    color: 'var(--kiosk-text-tertiary)'
-                    styles:
-                      card: [{ background-color: 'rgba(227, 179, 65, 0.10)' }]
-                styles:
-                  card:
-                    - background: 'var(--kiosk-bg-tile)'
-                    - border-radius: '8px'
-                    - border: 'none'
-                    - padding: '14px 12px'
-                    - min-height: '146px'
-                  name:
-                    - font-size: '16px'
-                    - font-weight: '500'
-                    - color: 'var(--kiosk-text-secondary)'
-                    - padding-top: '6px'
-                  state:
-                    - font-size: '18px'
-                    - text-transform: 'uppercase'
-                    - font-weight: '600'
-                    - letter-spacing: '0.5px'
-                    - padding-top: '2px'
-              - <<: *motion_sensor
-                entity: binary_sensor.main_panel_office_motion
-                name: Office
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: climate.upstairs
+                    state_not: 'off'
+                card:
+                  type: thermostat
+                  entity: climate.upstairs
+                  name: Upstairs
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: climate.upstairs
+                    state: 'off'
+                card:
+                  type: custom:mushroom-template-card
+                  entity: climate.upstairs
+                  primary: |-
+                    {% set t = state_attr(config.entity, "current_temperature") %}
+                    {{ (t | round(1)) if t is not none else "—" }}°F
+                  secondary: "Upstairs · Standby"
+                  icon: mdi:thermometer
+                  icon_color: blue-grey
+                  fill_container: true
+                  tap_action: { action: more-info }
+              - type: custom:mushroom-chips-card
+                alignment: center
+                chips:
+                  - type: template
+                    icon: mdi:water-percent
+                    icon_color: blue
+                    content: '{% set h = states("sensor.upstairs_humidity") | float(none) %}{{ (h | round) if h is not none else "—" }}%'
+                  - type: template
+                    icon: mdi:thermometer
+                    icon_color: amber
+                    content: |-
+                      {% set t = state_attr("climate.upstairs", "temperature") %}
+                      {% set tl = state_attr("climate.upstairs", "target_temp_low") %}
+                      {% set th = state_attr("climate.upstairs", "target_temp_high") %}
+                      {% if t is not none %}Set {{ t | round }}°
+                      {% elif tl is not none and th is not none %}{{ tl | round }}–{{ th | round }}°
+                      {% else %}—{% endif %}
+                  - type: template
+                    icon: |-
+                      {% set a = state_attr("climate.upstairs", "hvac_action") %}
+                      {% if a == "heating" %}mdi:fire{% elif a == "cooling" %}mdi:snowflake{% elif a == "idle" %}mdi:thermometer-check{% else %}mdi:thermometer-off{% endif %}
+                    icon_color: |-
+                      {% set a = state_attr("climate.upstairs", "hvac_action") %}
+                      {% if a == "heating" %}red{% elif a == "cooling" %}blue{% else %}grey{% endif %}
+                    content: |-
+                      {% set a = state_attr("climate.upstairs", "hvac_action") %}
+                      {{ a | title if a else "Off" }}
 
-      # ===== c2 bottom ===== HALLWAY & OUTDOOR LIGHTS (defines &mlight)
-      - type: grid
-        cards:
           - type: heading
             heading: Hallways & Outdoor
             heading_style: title
@@ -809,7 +744,7 @@ views:
                 show_name: true
                 show_state: true
                 show_icon: true
-                size: 48%
+                size: 44%
                 tap_action: { action: toggle }
                 hold_action: { action: more-info }
                 state_display: |
@@ -862,7 +797,7 @@ views:
             heading: Outdoor
             heading_style: subtitle
           - type: grid
-            columns: 3
+            columns: 2
             square: false
             cards:
               - <<: *mlight
@@ -881,9 +816,67 @@ views:
                 entity: light.shed
                 name: Shed
 
-      # ===== c3 bottom ===== OFFICE LIGHTS =======================
+      # ========= COLUMN 4: DOWNSTAIRS CLIMATE + OFFICE ==========
       - type: grid
         cards:
+          - type: heading
+            heading: Downstairs
+            heading_style: title
+          - <<: *climate_block
+            cards:
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: climate.downstairs
+                    state_not: 'off'
+                card:
+                  type: thermostat
+                  entity: climate.downstairs
+                  name: Downstairs
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: climate.downstairs
+                    state: 'off'
+                card:
+                  type: custom:mushroom-template-card
+                  entity: climate.downstairs
+                  primary: |-
+                    {% set t = state_attr(config.entity, "current_temperature") %}
+                    {{ (t | round(1)) if t is not none else "—" }}°F
+                  secondary: "Downstairs · Standby"
+                  icon: mdi:thermometer
+                  icon_color: blue-grey
+                  fill_container: true
+                  tap_action: { action: more-info }
+              - type: custom:mushroom-chips-card
+                alignment: center
+                chips:
+                  - type: template
+                    icon: mdi:water-percent
+                    icon_color: blue
+                    content: '{% set h = states("sensor.downstairs_humidity") | float(none) %}{{ (h | round) if h is not none else "—" }}%'
+                  - type: template
+                    icon: mdi:thermometer
+                    icon_color: amber
+                    content: |-
+                      {% set t = state_attr("climate.downstairs", "temperature") %}
+                      {% set tl = state_attr("climate.downstairs", "target_temp_low") %}
+                      {% set th = state_attr("climate.downstairs", "target_temp_high") %}
+                      {% if t is not none %}Set {{ t | round }}°
+                      {% elif tl is not none and th is not none %}{{ tl | round }}–{{ th | round }}°
+                      {% else %}—{% endif %}
+                  - type: template
+                    icon: |-
+                      {% set a = state_attr("climate.downstairs", "hvac_action") %}
+                      {% if a == "heating" %}mdi:fire{% elif a == "cooling" %}mdi:snowflake{% elif a == "idle" %}mdi:thermometer-check{% else %}mdi:thermometer-off{% endif %}
+                    icon_color: |-
+                      {% set a = state_attr("climate.downstairs", "hvac_action") %}
+                      {% if a == "heating" %}red{% elif a == "cooling" %}blue{% else %}grey{% endif %}
+                    content: |-
+                      {% set a = state_attr("climate.downstairs", "hvac_action") %}
+                      {{ a | title if a else "Off" }}
+
           - type: heading
             heading: Office
             heading_style: title
@@ -910,10 +903,8 @@ views:
                 entity: light.desk_lamp_2_2
                 name: Desk 2
 
-      # ===== c4 bottom ===== HOME STATUS (defines &status_tile) ==
-      # Environment + safety indicators in the shared tile language:
-      # leak detectors (green dry / red wet), UPS, floor temps
-      # (warm/cool tinted), humidity.
+      # ========= COLUMN 5: HOME STATUS + FAMILY/KITCHEN =========
+      # Defines &status_tile.
       - type: grid
         cards:
           - type: heading
@@ -1051,9 +1042,6 @@ views:
                     styles:
                       card: [{ background-color: 'rgba(88, 166, 255, 0.10)' }]
 
-      # ===== c5 bottom ===== FAMILY & KITCHEN LIGHTS =============
-      - type: grid
-        cards:
           - type: heading
             heading: Lights
             heading_style: title


### PR DESCRIPTION
## Origin

Continuing the live kiosk codesign loop, Chris pinpointed that the **Media card was tall and causing the dead space between rows**. He was right: HA's `sections` view arranges sections in a row-grid and aligns each column's Nth section to a shared baseline (row height = the tallest section in that row), so whichever top-row section is tallest — the five-Sonos Media block, and after it Security/Presence — turned into a gap in every shorter column. We first compacted Media, but since shrinking one tall section just promoted the next-tallest to the same problem, Chris chose the structural fix.

## What changed

- **One section per column (5 sections total).** Each column is now a single top-down stack, so there are no shared rows for HA to align — inter-row gaps can't form regardless of relative section heights; any leftover is a clean bottom margin.
  - c1 Weather + Openings (doors/garage/motion)
  - c2 Security/Presence + Media
  - c3 Upstairs climate + Hallway/Outdoor lights
  - c4 Downstairs climate + Office lights
  - c5 Home Status + Family/Kitchen lights
- **Compact media tiles:** `mini-media-player` now shows artwork + name only (volume/transport/progress hidden); tap still opens full controls. Idle players collapse to slim strips.
- Trimmed opening/light tile icon sizes for fit.
- Regenerated `dashboards/kiosk-codesign.yaml` via `scripts/sync-kiosk-codesign.sh` (CI Codesign Sync check passes).

## Verification

Iterated with `kiosk-host/kiosk-preview` and measured per-column: **no mid-column gaps** remain (the previous ~325–415px inter-row gaps are gone); each column stacks tightly and fills top-to-bottom. Side bars 32/43px. YAML validated; codesign mirror confirmed in sync. (Note: captured at night with house lights off, so light tiles render grey rather than amber — live state, not the design.)

## Follow-ups (not in scope)

- c2 (Security/Presence + compact Media) is the shortest column; now that the structure no longer propagates section height, Media could be made richer/taller to fill it without re-introducing gaps.
- A persistent ~43px (1.03×) of view padding sits below the fold; harmless, not clipping card content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)