### PR TITLE
Office scenes: add Blue + Red Desk flicker, purge yellow/green/purple candles

### DIFF
--- a/packages/office_zen77.yaml
+++ b/packages/office_zen77.yaml
@@ -22,7 +22,7 @@
 #
 # Bindings:
 #   up tap    → if lights off, reset counter to 1 and apply scene 1;
-#               otherwise advance counter (wraps 11 → 1) and apply.
+#               otherwise advance counter (wraps 9 → 1) and apply.
 #               i.e. first tap turns on, subsequent taps cycle scenes.
 #   down tap  → all 6 office lamps off (counter persists, candle loop killed).
 #   up hold   → ramp the current scene brighter at 5%/~150 ms until the
@@ -79,7 +79,7 @@ automation:
           - if:
               - condition: state
                 entity_id: counter.office_sonoff_scene
-                state: '11'
+                state: '9'
             then:
               - action: counter.set_value
                 target:

--- a/packages/sonoff_button_office.yaml
+++ b/packages/sonoff_button_office.yaml
@@ -9,7 +9,7 @@
 #
 # Bindings:
 #   single press → if lights are off, reset counter to 1 and apply scene 1;
-#                  otherwise advance the counter (wraps 11 → 1) and apply.
+#                  otherwise advance the counter (wraps 9 → 1) and apply.
 #                  i.e. first click turns on, subsequent clicks cycle scenes.
 #   double press → all office lights off (counter persists)
 #   long press   → jump straight to scene 1 (Bright), reset counter to 1.
@@ -21,16 +21,18 @@
 # same scene index. Single source of truth.
 #
 # Static scenes (1-3) apply uniform values to all six lamps simultaneously.
-# Flicker scenes (4-11) all share one parallel driver loop in
+# Flicker scenes (4-9) all share one parallel driver loop in
 # `script.office_sonoff_candle_loop`. The loop dispatches per-lamp ticks
 # every 180-400 ms to `script.office_lamp_tick`, which renders the current
 # scene's frame for that lamp. Brightness always flickers in a tight 75-92%
 # band with a 0.2 s transition; what differs per scene is how the color is
 # computed:
 #
-#   - Candle scenes (4-9): fixed hue per scene, looked up from a palette dict.
-#   - Rainbow Sync (10): hue derived from wall-clock time, same on all lamps.
-#   - Rainbow Cascade (11): hue derived from wall-clock time + a per-lamp
+#   - Candle scenes (4-6): fixed hue per scene, looked up from a palette dict.
+#   - Blue + Red Desk (7): per-lamp color — the two desk lamps flicker red,
+#     every other lamp flickers blue. Same brightness band as the candles.
+#   - Rainbow Sync (8): hue derived from wall-clock time, same on all lamps.
+#   - Rainbow Cascade (9): hue derived from wall-clock time + a per-lamp
 #     60° cascade offset, so the rainbow ripples across the room.
 #
 # Each per-lamp branch also waits a random 0-300 ms startup phase so the
@@ -42,16 +44,17 @@
 #   3  Focus             — all 6, 100% / 5000K  (bright, cool)
 #   4  Amber Candle      — flicker rgb(255, 100, 15)
 #   5  Red Candle        — flicker rgb(255,  20,  5)
-#   6  Yellow Candle     — flicker rgb(255, 220, 30)
-#   7  Green Candle      — flicker rgb(40,  220, 60)
-#   8  Blue Candle       — flicker rgb(30,   80, 255)
-#   9  Purple Candle     — flicker rgb(180,  30, 255)
-#   10 Rainbow Sync      — flicker; hue cycles every 30 s, all lamps in unison
-#   11 Rainbow Cascade   — flicker; hue cycles every 30 s, each lamp offset 60°
+#   6  Blue Candle       — flicker rgb(30,   80, 255)
+#   7  Blue + Red Desk   — flicker; desk lamps rgb(255, 20, 5), rest rgb(30, 80, 255)
+#   8  Rainbow Sync      — flicker; hue cycles every 30 s, all lamps in unison
+#   9  Rainbow Cascade   — flicker; hue cycles every 30 s, each lamp offset 60°
 #
 # The static Red and Blue scenes from earlier iterations were retired — the
 # candle/rainbow variants cover colored lighting and clicking past two extra
-# steady-color scenes to reach the more useful effects was friction.
+# steady-color scenes to reach the more useful effects was friction. The
+# Yellow, Green, and Purple candles were purged 2026-06-14 (never rested on
+# in 10 days of dwell-time history — pure click-past friction); the Blue +
+# Red Desk scene was added the same day, slotted next to the Blue candle.
 #
 # The flicker driver (mode: restart) exits when counter.office_sonoff_scene
 # drops to 3 or below. Every static scene calls script.turn_off on it before
@@ -70,7 +73,7 @@
 # brightness applied by every scene. Static scenes read it directly;
 # flicker tick scales its 75-92% random band by `helper / 100`. apply_scene
 # resets the helper to the new scene's default brightness on every tap/cycle
-# (1=100, 2=40, 3=100, 4-11=100) — pass `reset_brightness: false` to render
+# (1=100, 2=40, 3=100, 4-9=100) — pass `reset_brightness: false` to render
 # without touching the helper (used by ZEN77 hold-to-dim/brighten). Step 5
 # keeps the ZEN77 hold-ramp visibly smooth; static scene branches add a
 # 0.3 s transition so each ramp step interpolates on the bulbs.
@@ -79,7 +82,7 @@ counter:
   office_sonoff_scene:
     name: Office Sonoff Scene
     minimum: 1
-    maximum: 11
+    maximum: 9
     initial: 1
     step: 1
     restore: true
@@ -167,7 +170,7 @@ script:
                   brightness_pct: "{{ states('input_number.office_brightness') | int(100) }}"
                   color_temp_kelvin: 5000
                   transition: 0.3
-          # Scenes 4-11 are all flicker variants; the loop reads its target
+          # Scenes 4-9 are all flicker variants; the loop reads its target
           # color from a palette dict keyed on the counter, so we just turn
           # it on for any scene >= 4 and cycling between hues changes
           # color seamlessly on the next tick. Gated so hold-to-dim on a
@@ -205,9 +208,9 @@ script:
       brightness: "{{ ((range(75, 93) | random) * (states('input_number.office_brightness') | int(100)) / 100) | int }}"
     sequence:
       - choose:
-          # Scene 10 — Rainbow Sync: all lamps share the same hue, driven by
+          # Scene 8 — Rainbow Sync: all lamps share the same hue, driven by
           # wall-clock time. 12 deg/sec → full cycle every 30 s.
-          - conditions: "{{ scene == 10 }}"
+          - conditions: "{{ scene == 8 }}"
             sequence:
               - action: light.turn_on
                 target:
@@ -218,9 +221,9 @@ script:
                     - 100
                   brightness_pct: "{{ brightness }}"
                   transition: 0.2
-          # Scene 11 — Rainbow Cascade: each lamp offset by `cascade_offset` so
+          # Scene 9 — Rainbow Cascade: each lamp offset by `cascade_offset` so
           # the rainbow ripples across the room rather than moving in unison.
-          - conditions: "{{ scene == 11 }}"
+          - conditions: "{{ scene == 9 }}"
             sequence:
               - action: light.turn_on
                 target:
@@ -231,8 +234,25 @@ script:
                     - 100
                   brightness_pct: "{{ brightness }}"
                   transition: 0.2
+          # Scene 7 — Blue + Red Desk: a per-lamp variant of the Blue candle.
+          # The two desk lamps flicker the Red-candle hue rgb(255, 20, 5);
+          # every other lamp flickers the Blue-candle hue rgb(30, 80, 255).
+          # Same 75-92% brightness band as the candles, so it reads as one
+          # cohesive flicker scene that happens to have a red desk.
+          - conditions: "{{ scene == 7 }}"
+            sequence:
+              - action: light.turn_on
+                target:
+                  entity_id: "{{ target_entity }}"
+                data:
+                  rgb_color: >-
+                    {{ [255, 20, 5]
+                       if target_entity in ['light.desk_lamp_2', 'light.desk_lamp_2_2']
+                       else [30, 80, 255] }}
+                  brightness_pct: "{{ brightness }}"
+                  transition: 0.2
         default:
-          # Scenes 4-9 — fixed-hue candles, color from palette dict.
+          # Scenes 4-6 — fixed-hue candles, color from palette dict.
           - action: light.turn_on
             target:
               entity_id: "{{ target_entity }}"
@@ -241,10 +261,7 @@ script:
                 {% set palette = {
                   '4': [255, 100, 15],
                   '5': [255, 20,  5],
-                  '6': [255, 220, 30],
-                  '7': [40,  220, 60],
-                  '8': [30,   80, 255],
-                  '9': [180,  30, 255]
+                  '6': [30,   80, 255]
                 } %}
                 {{ palette[states('counter.office_sonoff_scene')] | default([255, 100, 15]) }}
               brightness_pct: "{{ brightness }}"
@@ -398,7 +415,7 @@ automation:
           - if:
               - condition: state
                 entity_id: counter.office_sonoff_scene
-                state: '11'
+                state: '9'
             then:
               - action: counter.set_value
                 target:


### PR DESCRIPTION
## Origin

Chris asked for a new office lighting scene identical to the existing **Blue candle flicker**, but with the **desk lamps flickering red** instead of blue while the rest of the room stays blue. He also wanted the scene cycle enumerated and the lesser-used scenes purged. When shown 10 days of dwell-time usage data on `counter.office_sonoff_scene`, he chose to drop the never-rested Yellow, Green, and Purple candles while **keeping both Rainbow scenes**.

## What changed

**New scene — `7 Blue + Red Desk`** (a per-lamp variant of the Blue candle):
- The two desk lamps (`light.desk_lamp_2`, `light.desk_lamp_2_2`) flicker the Red-candle hue `rgb(255, 20, 5)`.
- Every other office lamp (bookcase, door, table, corner) flickers the Blue-candle hue `rgb(30, 80, 255)`.
- Shares the candles' 75–92% brightness band, so it reads as one cohesive flicker scene with a red desk.
- Implemented as a `scene == 7` branch in `script.office_lamp_tick` that picks color per `target_entity` — the first scene to differentiate color by lamp.

**Purge — Yellow, Green, Purple candles.** 10 days of counter dwell-time history showed these three were never rested on, only clicked past (pure cycle friction). Rainbow Sync/Cascade kept per Chris's choice.

**Renumbered the cycle contiguously** (was 1–11, now 1–9):

| # | Scene |
|---|-------|
| 1 | Bright (static) |
| 2 | Relax (static) |
| 3 | Focus (static) |
| 4 | Amber Candle |
| 5 | Red Candle |
| 6 | Blue Candle |
| 7 | **Blue + Red Desk** (new) |
| 8 | Rainbow Sync |
| 9 | Rainbow Cascade |

Mechanical bits of the renumber:
- `counter.office_sonoff_scene` maximum `11 → 9`.
- Wrap-around literal `state: '11' → '9'` in **both** the Sonoff button and ZEN77 paddle cycle automations (shared counter).
- Candle palette dict trimmed to `4/5/6`.
- Catalog/comment blocks refreshed in both packages.

## Verification

- Desk-lamp entity IDs confirmed live (`light.desk_lamp_2` = "Desk Lamp", `light.desk_lamp_2_2` = "Desk Lamp 2") — the only two `light.desk*` entities.
- Grep confirms no orphaned references to old scene numbers (10/11) or purged colors anywhere in the repo; no dashboard references the catalog; the meeting indicator is scene-number-agnostic.
- Both packages parse as YAML; the candle-loop boundary (`above: 3`) and brightness-reset logic (`scene 2 → 40`) are unaffected.
- Live counter is at 5, well within the new max of 9 — no stranding on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)