### PR TITLE
Fix review prompt: Home Assistant config, not bash/Terraform

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,13 +23,20 @@ jobs:
     with:
       allowed_bots: "*"
       review_prompt: |
-        This repository contains bash bootstrap scripts for Linux workstations
-        and Terraform infrastructure code. Focus your review on:
+        This repository is a Home Assistant configuration: YAML automations,
+        scripts, scenes, and Lovelace dashboards, plus bash gitops/kiosk
+        deploy scripts (`scripts/gitops-sync.sh`, `kiosk-host/`) that pull to
+        production via systemd timers. Focus your review on:
 
-        1. **Bash correctness** — quoting bugs, unset variable references,
-           broken conditionals, incorrect exit codes, non-portable syntax
-        2. **Idempotency** — will re-running the script break anything?
-        3. **Security** — hardcoded credentials, secrets in output, unsafe
-           permissions, curl|bash pitfalls
-        4. **Terraform** — if HCL files changed: dependency graph issues,
-           resources requiring multiple applies, missing variable validation
+        1. **HA YAML validity** — automations, scripts, scenes, and templates:
+           trigger / condition / action shape, Jinja2 template errors, and the
+           right automation mode (e.g. not `single` for motion lights).
+        2. **entity_id discipline** — prefer entity_id over device_id; flag
+           entity renames that would break consumers (dashboards, automations).
+        3. **Bash correctness & safety** of the gitops/kiosk scripts —
+           quoting, unset vars, and the flock / main-branch-guard /
+           log-rotation / reinstall-only-on-drift invariants.
+        4. **Secrets** — nothing sensitive committed; `!secret` references
+           intact, no tokens in YAML or logs.
+        5. **Prompt-Origin convention** — PRs carry the `Prompt-Origin`
+           trailer and the `## Origin` section per this repo's CLAUDE.md.


### PR DESCRIPTION
## Origin

Chris asked Repo Claude to align a newly created repo with the fleet, which
surfaced that several repos' automated-review workflows carry a copy-pasted
review prompt describing bash bootstrap scripts + Terraform — content those
repos do not contain. He asked for the fleet's review prompts to be audited and
the mismatches fixed.

## What changed

Replaces the boilerplate `review_prompt` in `claude-code-review.yml` with one
written for this repo: HA YAML validity, entity_id discipline, gitops/kiosk
bash safety, secret hygiene, and the Prompt-Origin convention. No behavior
change beyond the review rubric.

Prompt-Origin: Chris, via Repo Claude — "audit all 8 review prompts and fix the mismatches"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
