### PR TITLE
Trim Origin/Prompt-Origin restatement to a pointer (now fleet-wide)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,60 +281,19 @@ Use bug/dashboard/automation/etc. labels as appropriate. A future
 session will pick up the issue, do the actual diagnosis, and open the
 PR that closes it. Origin: kiosk OOM observation 2026-05-31, issue #308.
 
-### Every PR opens with an `## Origin` section
+### `## Origin` section + `Prompt-Origin:` trailer — now fleet-wide
 
-Immediately after the one-line summary. This section discloses how the
-change came about and serves as the durable record of what was asked
-for, written in **third-person past-tense narrative** referring to the
-requester by name.
+This convention originated in this repo and is **now a fleet-wide rule**:
+every PR opens with an `## Origin` section and every commit carries a matching
+`Prompt-Origin:` trailer (a third-person past-tense narrative of what was
+asked for, requester named, no verbatim prompt dump). The canonical format
+and full guidance live in `shared-workflows/CLAUDE.md` → "Fleet PR-workflow
+(canonical source)" — follow it; this file no longer restates the details.
 
-Treat the prompts you receive as raw material, not as the artifact
-itself — the PR archive is read months later by reviewers (and future
-Chris) who weren't in the session, and a terse verbatim "make X work"
-reads as noise out of context. A 2–4 sentence narrative translates the
-moment into a durable record.
-
-- **Lead with the requester and what they wanted**, e.g. "Chris wanted
-  the kiosk to surface Chris-Phone and Rachel-S23 presence so the
-  household monitor reflects who's home."
-- **Include the substantive constraints** they specified (e.g.
-  "…somewhere unobtrusive, no layout disruption") and any trade-offs
-  they flagged or accepted.
-- **Don't quote the prompt verbatim**, even when it's short. The
-  directness reads as informal in PR archives — translate to
-  narrative.
-- **For longer or multi-turn sessions**, same 2–4 sentence narrative.
-  Link the transcript if one's available, but summarize the *intent*
-  in your own words rather than dumping the back-and-forth.
-- **Don't speculate about context you weren't given.** Narrate only
-  what was actually communicated. If you're uncertain about intent,
-  say so plainly — don't invent a justification.
-
-### Every commit carries a `Prompt-Origin:` trailer
-
-Mirroring the PR's Origin section in compressed form. Same
-third-person past-tense narrative — one or two sentences, no verbatim
-quoting.
-
-Example:
-
-```
-Reconfigure Sonoff button 2 for office lighting control
-
-Single-click toggles on, double-click off, hold cycles scenes.
-New scenes: full-red, full-blue, flickering-candle, white-bright, white-relax.
-
-Prompt-Origin: |
-  Chris asked for Sonoff button 2 to be rewired for office lighting:
-  single-click on, double-click off, hold cycles a new scene set
-  covering full-brightness red and blue, a flickering candle, and a
-  range of white temperatures from bright to relax.
-Authored-By: Claude Code
-Co-Authored-By: Chris Pitzi <chris@...>
-```
-
-The PR description is the human-readable record; the commit trailer is
-the durable, `git log`-greppable one. Both should agree.
+The one HA-specific emphasis worth keeping: because this repo dispatches
+changes **without issues** (see above), the `## Origin` section is the *only*
+durable record of intent here — so it carries more weight than in repos where
+a linked issue also captures the ask. Don't skip it.
 
 ---
 


### PR DESCRIPTION
## Origin

Chris asked to propagate this repo's `## Origin` + `Prompt-Origin:` convention
to the whole fleet and align on it. With the convention now promoted to a
fleet-wide rule (defined canonically in shared-workflows/CLAUDE.md), its full
restatement here is redundant — and two copies of the same guidance would
drift. He wanted the fleet aligned on a single source of truth.

## What changed

`CLAUDE.md` — the two detailed subsections ("Every PR opens with an `## Origin`
section" and "Every commit carries a `Prompt-Origin:` trailer") are replaced
with a short pointer to the canonical fleet rule. The one genuinely
HA-specific note is kept: because this repo dispatches changes *without
issues*, the `## Origin` section is the only durable record of intent here, so
it carries extra weight.

No behavior change — the convention still applies (more strongly than ever,
now that CI enforces it); this just stops maintaining a second copy of the
rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
