### PR TITLE
Operationalize dashboard import as a reusable ad-hoc CLI

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,20 +34,53 @@ GitOps auto-deploy script. Called every 5 minutes by the `gitops_sync_poll` auto
 
 Polling from inside HA (rather than pushing from a GitHub Actions webhook) avoids exposing the HA instance to inbound internet traffic and sidesteps NAT traversal entirely. The tradeoff is a maximum 5-minute latency on deploys — acceptable for a home automation context. The Supervisor API validation step (`/core/check`) runs the same config validator as a normal HA startup, so a bad merge is caught before the service is disrupted.
 
-## `import-home-to-storage.sh`
+## `import-dashboard-to-storage.sh`
 
-One-shot helper that copies the git-managed `dashboards/home.yaml` into a
-storage-mode (UI-managed) Lovelace dashboard at `url_path: home-ui`. After it
-runs, the next `ha-context-dump.sh` snapshot picks the dashboard up in
+Ad-hoc helper that copies a git-managed YAML dashboard into a storage-mode
+(UI-managed) Lovelace dashboard, so you can hand-tweak it in the HA UI while
+still starting from the repo's "official" dashboard paradigm. After it runs,
+the next `ha-context-dump.sh` snapshot picks the dashboard up in
 `context/dashboards-storage.json`, which makes it visible to assistants
 working against `context/`.
+
+The import is a structurally lossless round-trip — `yaml.safe_load` →
+`lovelace/config/save` persists the exact parsed config — so the UI copy
+matches the source view-for-view. (Only holds for self-contained dashboards;
+HA custom tags like `!include`/`!secret` would break `safe_load`.)
 
 Must run inside the HA Core container (Python 3, `aiohttp`, and `PyYAML` are
 part of Core's runtime; the SSH add-on's Alpine shell has none of them):
 
 ```bash
-docker exec homeassistant /config/scripts/import-home-to-storage.sh
+# default: seed dashboards/home.yaml -> "Home (UI Edit)" at /home-ui-edit
+docker exec homeassistant /config/scripts/import-dashboard-to-storage.sh
+
+# any dashboard, by name (resolved to /config/dashboards/<name>.yaml)
+docker exec homeassistant /config/scripts/import-dashboard-to-storage.sh kiosk
+
+# full control over the storage dashboard's url_path / title / icon
+docker exec homeassistant /config/scripts/import-dashboard-to-storage.sh \
+    home home-ui-edit "Home (UI Edit)" mdi:home-edit
 ```
+
+From the workstation in one shot (the HAOS host has `docker`, the SSH add-on
+does not — note port 22 + `docker exec`, not `ha`):
+
+```bash
+ssh -p 22 root@homeassistant.local \
+  "docker exec homeassistant /config/scripts/import-dashboard-to-storage.sh <name>"
+```
+
+### Positional arguments
+
+Each falls back to its env var, then to a value derived from the source name:
+
+| # | Arg | Env | Default |
+|---|-----|-----|---------|
+| 1 | `<source>` | `SOURCE_YAML` | `home` — a bare **name** resolves to `/config/dashboards/<name>.yaml`; an explicit path passes through |
+| 2 | `<url_path>` | `URL_PATH` | `<name>-ui-edit` |
+| 3 | `<title>` | `TITLE` | `"<Name> (UI Edit)"` |
+| 4 | `<icon>` | `ICON` | `mdi:view-dashboard-edit` |
 
 ### Authentication
 
@@ -71,18 +104,24 @@ in `secrets.yaml` → `SUPERVISOR_TOKEN` (last-resort fallback that will
 almost certainly fail). For a one-shot run without modifying `secrets.yaml`:
 
 ```bash
-docker exec -e HA_TOKEN='<paste-token-here>' homeassistant /config/scripts/import-home-to-storage.sh
+docker exec -e HA_TOKEN='<paste-token-here>' homeassistant /config/scripts/import-dashboard-to-storage.sh
 ```
 
 ### Overrides and behavior
 
-Env vars: `SOURCE_YAML`, `URL_PATH`, `TITLE`, `ICON`, `HA_WS_URL`,
-`SECRETS_YAML`, `HA_TOKEN`. Idempotent — re-running overwrites the saved
-config but does not duplicate the registry entry. The git-managed
-`dashboards/home.yaml` and its `lovelace.dashboards` registration in
-`configuration.yaml` are left in place; both dashboards coexist
-(`/dashboard-home/home` from YAML, `/home-ui` from storage) until cutover
-is decided.
+Beyond the positional args above, `HA_WS_URL` and `SECRETS_YAML` are
+env-overridable. **Idempotent** — re-running overwrites the saved config but
+does not duplicate the registry entry; this is a **reseed-from-source**
+operation, so any hand-edits made in the UI copy are clobbered on the next
+import. That's the intended flow: edit the official YAML, reseed, hand-tweak;
+or hand-tweak, then port the changes back into the YAML as the durable
+source-of-truth.
+
+The git-managed source dashboard and its `lovelace.dashboards` registration
+in `configuration.yaml` are left in place — the YAML and storage copies
+coexist (e.g. `/dashboard-home/home` from YAML, `/home-ui-edit` from
+storage). The storage copy is gitignored `.storage/` runtime state and will
+**drift** from the YAML once you edit it; git remains the source of truth.
 
 ## `validate-ha-version.sh` / `validate-context-branch.sh`
 

--- a/scripts/assign-playroom-areas.sh
+++ b/scripts/assign-playroom-areas.sh
@@ -21,7 +21,7 @@
 # `input_button.assign_playroom_areas` helper in
 # packages/playroom_area_fix.yaml.
 #
-# Token resolution mirrors scripts/import-home-to-storage.sh:
+# Token resolution mirrors scripts/import-dashboard-to-storage.sh:
 #   1. HA_TOKEN env var (one-shot override)
 #   2. ha_token from /config/secrets.yaml (preferred; see
 #      scripts/README.md > "Script auth conventions" for why values are

--- a/scripts/import-dashboard-to-storage.sh
+++ b/scripts/import-dashboard-to-storage.sh
@@ -1,12 +1,30 @@
 #!/usr/bin/env bash
-# One-shot: import dashboards/home.yaml as a UI-managed (storage-mode)
-# Lovelace dashboard at url_path /home-ui, so that ha-context-dump.sh
-# captures it under context/dashboards-storage.json.
+# Ad-hoc: import a git-managed YAML dashboard into a UI-managed (storage-mode)
+# Lovelace dashboard, so it can be hand-tweaked in the HA UI while still
+# starting from the repo's "official" dashboard paradigm. After it runs the
+# next ha-context-dump.sh snapshot captures the result in
+# context/dashboards-storage.json.
 #
-# Run inside the HA Core container (Python 3, aiohttp, and PyYAML are
-# part of Core's runtime):
+# Run inside the HA Core container (Python 3, aiohttp, and PyYAML are part of
+# Core's runtime; the SSH add-on's Alpine shell has none of them):
 #
-#   docker exec homeassistant /config/scripts/import-home-to-storage.sh
+#   # default: seed dashboards/home.yaml -> "Home (UI Edit)" at /home-ui-edit
+#   docker exec homeassistant /config/scripts/import-dashboard-to-storage.sh
+#
+#   # any dashboard, by name (resolved to /config/dashboards/<name>.yaml):
+#   docker exec homeassistant /config/scripts/import-dashboard-to-storage.sh kiosk
+#
+#   # full control over the storage dashboard's url_path / title / icon:
+#   docker exec homeassistant /config/scripts/import-dashboard-to-storage.sh \
+#       home home-ui-edit "Home (UI Edit)" mdi:home-edit
+#
+# Positional args (each falls back to its env var, then to a derived default):
+#   1  <source>    dashboard NAME (-> /config/dashboards/<name>.yaml) or an
+#                  explicit path. Env: SOURCE_YAML. Default: home
+#   2  <url_path>  storage dashboard url_path. Env: URL_PATH.
+#                  Default: <name>-ui-edit
+#   3  <title>     sidebar title. Env: TITLE. Default: "<Name> (UI Edit)"
+#   4  <icon>      mdi icon. Env: ICON. Default: mdi:view-dashboard-edit
 #
 # Token resolution order (first non-empty wins):
 #   1. HA_TOKEN env var (one-shot override)
@@ -19,20 +37,34 @@
 # A leading "Bearer " prefix is stripped automatically so the value can
 # be stored in the same form rest_command consumers expect.
 #
-# Idempotent: re-running overwrites the saved config but does not
-# duplicate the dashboard registry entry.
+# Idempotent: re-running overwrites the saved config but does not duplicate
+# the dashboard registry entry. NOTE: re-importing OVERWRITES any hand-edits
+# made in the UI copy — it is a reseed-from-source operation, by design.
 
 set -euo pipefail
 
-readonly SOURCE_YAML="${SOURCE_YAML:-/config/dashboards/home.yaml}"
-readonly URL_PATH="${URL_PATH:-home-ui}"
-readonly TITLE="${TITLE:-Home (UI)}"
-readonly ICON="${ICON:-mdi:home-variant}"
+# --- resolve source (arg 1 > $SOURCE_YAML > "home"); bare names expand to
+#     /config/dashboards/<name>.yaml, explicit paths pass through unchanged ---
+src_in="${1:-${SOURCE_YAML:-home}}"
+if [[ "$src_in" == */* || "$src_in" == *.yaml ]]; then
+    SOURCE_YAML="$src_in"
+else
+    SOURCE_YAML="/config/dashboards/${src_in}.yaml"
+fi
+
+# url_path / title / icon: arg > env > (empty, derived in Python from the
+# source basename so the title-casing isn't at the mercy of busybox sed)
+URL_PATH="${2:-${URL_PATH:-}}"
+TITLE="${3:-${TITLE:-}}"
+ICON="${4:-${ICON:-}}"
+
 readonly HA_WS_URL="${HA_WS_URL:-ws://127.0.0.1:8123/api/websocket}"
 readonly SECRETS_YAML="${SECRETS_YAML:-/config/secrets.yaml}"
 
 if [[ ! -f "$SOURCE_YAML" ]]; then
     echo "error: source dashboard not found: $SOURCE_YAML" >&2
+    echo "       available dashboards:" >&2
+    ls -1 /config/dashboards/*.yaml 2>/dev/null | sed 's#.*/#         #; s#\.yaml$##' >&2 || true
     exit 1
 fi
 
@@ -96,6 +128,15 @@ WS_URL = os.environ["_IMPORT_WS_URL"]
 TOKEN = os.environ["_IMPORT_TOKEN"]
 TOKEN_SOURCE = os.environ["_IMPORT_TOKEN_SOURCE"]
 SECRETS_YAML = os.environ["_IMPORT_SECRETS_YAML"]
+
+# Derive any defaults left empty by the caller from the source basename, e.g.
+# /config/dashboards/home.yaml -> name "home" -> url_path "home-ui-edit",
+# title "Home (UI Edit)".
+name = os.path.splitext(os.path.basename(SOURCE_YAML))[0]
+pretty = name.replace("-", " ").replace("_", " ").title()
+URL_PATH = URL_PATH or f"{name}-ui-edit"
+TITLE = TITLE or f"{pretty} (UI Edit)"
+ICON = ICON or "mdi:view-dashboard-edit"
 
 
 with open(SOURCE_YAML) as fh:

--- a/secrets.yaml.example
+++ b/secrets.yaml.example
@@ -6,7 +6,7 @@ wifi_ssid: "CHANGE_ME"
 wifi_password: "CHANGE_ME"
 github_pat: "CHANGE_ME"
 # Home Assistant long-lived access token (Profile -> Security -> Long-Lived Access Tokens).
-# Used by scripts/import-home-to-storage.sh to authenticate against Core's websocket API.
+# Used by scripts/import-dashboard-to-storage.sh to authenticate against Core's websocket API.
 # Stored as the full Authorization header value, matching the github_pat convention.
 ha_token: "Bearer CHANGE_ME"
 trusted_network: "CHANGE_ME"  # Local subnet in CIDR notation, e.g. 10.0.0.0/24


### PR DESCRIPTION
## Summary

Turns the one-shot, home-only YAML→storage-mode dashboard importer into a reusable, arg-driven CLI so any official YAML dashboard can be seeded into a hand-editable UI copy on demand.

- Renames `scripts/import-home-to-storage.sh` → `scripts/import-dashboard-to-storage.sh`.
- Adds positional args `<source> <url_path> <title> <icon>`, each falling back to its env var, then to a value derived from the source basename:
  - `home` → `/config/dashboards/home.yaml`, url_path `home-ui-edit`, title `"Home (UI Edit)"`, icon `mdi:view-dashboard-edit`.
  - A bare **name** resolves to `/config/dashboards/<name>.yaml`; an explicit path passes through unchanged.
- Defaults are computed in the embedded Python (not `sed`) so title-casing is portable inside the Alpine/busybox Core container.
- Unknown source name prints the list of available dashboards.
- Token resolution and the lossless `yaml.safe_load` → `lovelace/config/save` round-trip are unchanged.
- README section rewritten (new name, arg table, **reseed-overwrites-UI-edits** + **storage drifts from git** caveats); fixes the two stray references to the old name (`assign-playroom-areas.sh` comment, `secrets.yaml.example` comment).

No automation/CI executes this script — it's a manual `docker exec` one-shot — so the rename is safe.

## Origin

Chris wanted the dashboard import operationalized "at least enough to have it available ad-hoc," so he can seed UI-editable copies from the repo's official YAML dashboards and tweak them by hand while still working from the canonical paradigm. He specifically asked to import the YAML-managed 'Home' into a UI-managed 'Home (UI Edit)' — that was done live against the running instance (registered `home-ui-edit`, 1 view saved). This PR generalizes the previously home-only script so any dashboard can be seeded the same way.

## Usage

```bash
# default: home.yaml -> "Home (UI Edit)" at /home-ui-edit
docker exec homeassistant /config/scripts/import-dashboard-to-storage.sh

# any dashboard by name
docker exec homeassistant /config/scripts/import-dashboard-to-storage.sh kiosk

# from the workstation
ssh -p 22 root@homeassistant.local \
  "docker exec homeassistant /config/scripts/import-dashboard-to-storage.sh <name>"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)