### PR TITLE
Add in-HA button to seed UI-editable dashboards from YAML

### DIFF
--- a/packages/dashboard_import.yaml
+++ b/packages/dashboard_import.yaml
@@ -1,0 +1,62 @@
+# Button to (re)seed a UI-managed (storage-mode) Lovelace dashboard from its
+# git-managed YAML source, via scripts/import-dashboard-to-storage.sh.
+#
+# Workflow: pick a dashboard in input_select.dashboard_to_seed, press
+# input_button.seed_ui_dashboard. The automation calls
+# shell_command.import_dashboard_to_storage with the selected name; the script
+# creates/overwrites "<Name> (UI Edit)" at url_path /<name>-ui-edit and reports
+# the outcome via a persistent notification.
+#
+# This is the in-HA front end for the CLI documented in scripts/README.md
+# (§ import-dashboard-to-storage.sh) — same script, same auth (ha_token from
+# secrets.yaml), runs inside Core via shell_command rather than docker exec.
+#
+# IMPORTANT: re-seeding OVERWRITES any hand-edits in the UI copy — it reseeds
+# from the official YAML by design. The intended loop is: edit the official
+# YAML → reseed → hand-tweak; or hand-tweak in the UI, then port the change
+# back into the YAML as the durable source-of-truth. The storage copy is
+# gitignored .storage/ runtime state and drifts from git once you edit it.
+#
+# Options must match a dashboard file at /config/dashboards/<name>.yaml.
+
+input_select:
+  dashboard_to_seed:
+    name: "Dashboard to seed (UI Edit)"
+    icon: mdi:view-dashboard-edit
+    options:
+      - home
+      - home-codesign
+      - homelab-status
+      - screen-time
+
+input_button:
+  seed_ui_dashboard:
+    name: "Seed UI-editable dashboard"
+    icon: mdi:database-import
+
+automation:
+  - id: seed_ui_dashboard_trigger
+    alias: "Dashboard Import: seed UI copy on button press"
+    mode: single
+    triggers:
+      - trigger: state
+        entity_id: input_button.seed_ui_dashboard
+    actions:
+      - variables:
+          selected: "{{ states('input_select.dashboard_to_seed') }}"
+      - action: shell_command.import_dashboard_to_storage
+        data:
+          source: "{{ selected }}"
+        response_variable: result
+      - action: persistent_notification.create
+        data:
+          title: "Dashboard import"
+          notification_id: seed_ui_dashboard_done
+          message: >-
+            {% if result.returncode == 0 %}
+            ✅ Seeded '{{ selected }}' → UI Edit copy. Open
+            /{{ selected }}-ui-edit to hand-tweak it (re-seeding overwrites edits).
+            {% else %}
+            ❌ Import of '{{ selected }}' failed (code {{ result.returncode }}).
+            stderr: {{ result.stderr }}
+            {% endif %}

--- a/shell_commands.yaml
+++ b/shell_commands.yaml
@@ -1,2 +1,3 @@
 gitops_sync: "bash /config/scripts/gitops-sync.sh"
 assign_playroom_areas: "bash /config/scripts/assign-playroom-areas.sh"
+import_dashboard_to_storage: "bash /config/scripts/import-dashboard-to-storage.sh {{ source }}"


### PR DESCRIPTION
## Summary

Adds an in-HA front end for `scripts/import-dashboard-to-storage.sh` (added in #437) so a YAML dashboard can be reseeded into a hand-editable storage-mode copy from inside Home Assistant — no terminal / `docker exec`.

**`packages/dashboard_import.yaml`:**
- `input_select.dashboard_to_seed` — pick which dashboard to seed (`home`, `home-codesign`, `homelab-status`, `screen-time`).
- `input_button.seed_ui_dashboard` — press to reseed the selected one.
- A `mode: single` automation: on button press → `shell_command.import_dashboard_to_storage` with the selected name (via `response_variable`) → `persistent_notification` reporting success (with the `/<name>-ui-edit` URL) or stderr on failure.

**`shell_commands.yaml`:** registers `import_dashboard_to_storage`, templated on the selected dashboard name. The script runs inside Core and authenticates with `ha_token` from `secrets.yaml`, identical to the CLI path.

Mirrors the reviewed button pattern in `packages/playroom_area_fix.yaml` (state trigger on an `input_button` → `shell_command` with `response_variable` → `persistent_notification`). Per the HA best-practices skill, `input_select`/`input_button` are the correct helpers for "user selection" / "manual trigger," and `mode: single` is correct for a one-shot manual action. Helpers live in a YAML package (not `.storage/`) because this is infra tooling that must survive a rebuild — same justification as the playroom button.

**Re-seeding overwrites UI hand-edits by design** — it reseeds from the official YAML. The intended loop (edit YAML → reseed → tweak; or tweak → port back to YAML) is documented in the package header and `scripts/README.md`.

The `input_select` options were corrected to match the post-#435 dashboard set (`kiosk.yaml` was retired; `home-codesign.yaml` is its successor).

## Origin

After the YAML→storage-mode dashboard import was generalized into a reusable CLI in #437, Chris asked for "a button!" — he wanted to reseed UI-editable copies of the official YAML dashboards from inside HA rather than via `docker exec`, so he can hand-tweak dashboards while still starting from the canonical paradigm. This wires the existing script to an `input_select` + `input_button` + automation, following the repo's established button-package pattern.

## How to use

1. Open the **Dashboard to seed (UI Edit)** dropdown, pick a dashboard.
2. Press **Seed UI-editable dashboard**.
3. A notification confirms; open `/<name>-ui-edit` (e.g. `/home-ui-edit`) to hand-edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)