### PR TITLE
Ignore legacy kiosk-*.png display frame grabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,8 +58,10 @@ __pycache__/
 *.pyc
 
 # Display frame grabs — throwaway snapshots from pve2's display
-# (home-snapshot, home-preview, home-serve, scrot dumps, comparisons)
+# (home-snapshot, home-preview, home-serve, scrot dumps, comparisons;
+# kiosk-* is the pre-#435 legacy prefix for the same artifacts)
 /home-preview-*.png
 /home-snapshot-*.png
+/kiosk-*.png
 /ha-login-*.png
 /screen-time-render.png


### PR DESCRIPTION
## Summary

Adds a `/kiosk-*.png` rule to `.gitignore` to tombstone the pre-rename display-frame-grab artifacts.

The `home-host` preview/snapshot tools capture throwaway PNGs into the repo root. #435 added ignore rules for the current `home-preview-*.png` / `home-snapshot-*.png` names, but the pre-rename `kiosk-*.png` artifacts were never covered — so ~68 of them had accumulated untracked in the root. This rule sits in the same "Display frame grabs" section and prevents the legacy prefix from being committed by accident. The ~68 stray files themselves were already removed from the working tree (untracked, so no repo change for the deletion).

## Origin

Chris asked to clean up the PNG clutter in the repo root left over from past kiosk dashboard preview/design sessions. The strays were deleted locally; this PR guards against the legacy `kiosk-*.png` naming returning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)