### PR TITLE
Prune resolved allowlist entries + drop dead Roku refs from screen-time

### DIFF
--- a/dashboards/entity-allowlist.txt
+++ b/dashboards/entity-allowlist.txt
@@ -28,26 +28,3 @@ sensor.play_room_youtube_today
 # Basement and Office TVs via some integration not yet active in HA.
 media_player.basement_tv
 media_player.office_tv
-
-# --- Pending integration: PitziLabs/* GitHub sensors (homelab-status.yaml) ---
-# Populated by the HACS `github_custom` integration
-# (boralyl/github-custom-component-tutorial) once configured via its UI flow.
-# ONE sensor per repo — state is the latest-commit short SHA; metrics
-# (open_issues, open_pull_requests, stargazers, forks, …) ride as
-# attributes. Prune as each repo's sensor lands in entities.json.
-sensor.pitzilabs_firewalla_axiom_pipeline
-sensor.pitzilabs_foundry_platform_demo
-sensor.pitzilabs_homeassistant_config
-sensor.pitzilabs_homelab_observability
-sensor.pitzilabs_ice_cream_book
-sensor.pitzilabs_reference_checker
-sensor.pitzilabs_shared_workflows
-sensor.pitzilabs_workstation_bootstrap
-
-# --- Pending snapshot: room light groups (configuration.yaml, #440/#442) ---
-# YAML `light: - platform: group` entities for the whole-room dimmer controls.
-# They carry unique_id, so they WILL land in context/entities.json after this
-# deploys and the next context dump runs — prune these three then.
-light.family_room
-light.kitchen
-light.office_lights

--- a/dashboards/screen-time.yaml
+++ b/dashboards/screen-time.yaml
@@ -17,15 +17,6 @@ views:
     path: today
     icon: mdi:television-clock
     cards:
-      # --- 3-day app activity timeline ---
-      - type: history-graph
-        title: TV App Activity — Last 3 Days
-        hours_to_show: 72
-        refresh_interval: 60
-        entities:
-          - entity: sensor.play_room_tv_active_app
-            name: Play Room
-
       # --- Play Room today's totals ---
       - type: entities
         title: Play Room TV — Today
@@ -46,12 +37,3 @@ views:
             name: Disney Plus
             icon: mdi:movie-open-star
         state_color: false
-
-      # --- Current state at the bottom for live awareness ---
-      - type: glance
-        title: Right Now
-        entities:
-          - entity: media_player.play_room_tv
-            name: Play Room
-        state_color: true
-        show_state: true


### PR DESCRIPTION
## Summary

Two coupled cleanups that turn the **Dashboard Entities** gate green after the dashboard-overhaul context snapshot landed (#456):

1. **Prune `entity-allowlist.txt`** — the strict checker flagged **11** allowlisted entities as now present in `context/entities.json` and removable: the three room light groups from #449 (`light.family_room`, `light.kitchen`, `light.office_lights`) and the eight `sensor.pitzilabs_*` GitHub sensors. Removed all 11; the allowlist now holds only genuinely unregistered/pending entries.
2. **`screen-time.yaml`** — remove the two cards that referenced the now-removed Roku entities: the `history-graph` (`sensor.play_room_tv_active_app`) and the "Right Now" `glance` (`media_player.play_room_tv`). The Roku integration was removed earlier this session; **#443 only cleaned the home dashboard's Play Room TV card**, so `screen-time.yaml`'s references became dangling and were the only Dashboard Entities *failure* once #456's fresh snapshot dropped those entities.

Verified locally: `check-dashboard-entities.py --strict` exits **0** — `screen-time.yaml: OK (5 references all resolve)`, no remaining "can be removed" notes.

## Origin

Chris asked to prune the `entity-allowlist.txt` entries for the new light groups once the context-snapshot PR (#456) merged. Doing so surfaced that #456 had also turned the Dashboard Entities gate **red** — via `screen-time.yaml`'s stale Roku references that #443 missed — so this bundles the required CI fix with the requested prune.

## Heads-up (follow-up decision)

The Play Room TV **device is gone**, so the Screen Time dashboard's remaining "Today" totals card is now sourceless (its `play_room_*_today` history_stats feed off the removed Roku app sensor). The whole dashboard is effectively dead. **Full removal** (the `screen-time.yaml` file, its `dashboard-screen-time` registration in `configuration.yaml`, the 5 `play_room_*_today` history_stats helpers, and their allowlist entries) is left as a separate decision — flagging rather than doing unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)