### PR TITLE
docs: neutralize PR summary voice (drop Origin/Prompt-Origin)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,5 +38,6 @@ jobs:
            log-rotation / reinstall-only-on-drift invariants.
         4. **Secrets** — nothing sensitive committed; `!secret` references
            intact, no tokens in YAML or logs.
-        5. **Prompt-Origin convention** — PRs carry the `Prompt-Origin`
-           trailer and the `## Origin` section per this repo's CLAUDE.md.
+        5. **PR summary voice** — the PR body carries a neutral, objective
+           summary of the who/what/why (no `## Origin` section, no
+           `Prompt-Origin` trailer) per this repo's CLAUDE.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,19 +244,18 @@ Use bug/dashboard/automation/etc. labels as appropriate. A future
 session will pick up the issue, do the actual diagnosis, and open the
 PR that closes it. Origin: home dashboard OOM observation 2026-05-31, issue #308.
 
-### `## Origin` section + `Prompt-Origin:` trailer — now fleet-wide
+### PR summary voice — fleet-wide
 
-This convention originated in this repo and is **now a fleet-wide rule**:
-every PR opens with an `## Origin` section and every commit carries a matching
-`Prompt-Origin:` trailer (a third-person past-tense narrative of what was
-asked for, requester named, no verbatim prompt dump). The canonical format
-and full guidance live in `shared-workflows/CLAUDE.md` → "Fleet PR-workflow
-(canonical source)" — follow it; this file no longer restates the details.
+The fleet convention is a **neutral, objective, action-oriented PR summary**
+that carries the who/what/why woven in — not a separate `## Origin` section,
+and no `Prompt-Origin:` commit trailer. The canonical format and full guidance
+live in `shared-workflows/CLAUDE.md` → "Fleet PR-workflow (canonical source)" —
+follow it; this file no longer restates the details.
 
 The one HA-specific emphasis worth keeping: because this repo dispatches
-changes **without issues** (see above), the `## Origin` section is the *only*
-durable record of intent here — so it carries more weight than in repos where
-a linked issue also captures the ask. Don't skip it.
+changes **without issues** (see above), the PR summary is the *only* durable
+record of intent here — so the who/what/why carries more weight than in repos
+where a linked issue also captures the ask. Don't skip it.
 
 ---
 


### PR DESCRIPTION
## Summary

Aligns this repo with the fleet-wide PR-voice change (canonical: PitziLabs/shared-workflows#11): the PR-workflow restatement and the `claude-code-review.yml` CI reviewer item now describe a neutral, objective, action-oriented PR summary that carries the who/what/why woven in — dropping the `## Origin` section and the `Prompt-Origin:` commit trailer. The HA-specific emphasis is preserved: because changes here dispatch without issues, the PR summary is the only durable record of intent, so the who/what/why still can't be skipped.

Part of a fleet-wide sweep replacing the third-person "Origin" narrative with a professional summary voice; companion changes land in shared-workflows (canonical), the repos-root CLAUDE.md mirror, and the bullpen PR template. Follows the new convention itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)