### PR TITLE
Repoint reusable-workflow refs to the lentago org

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,7 @@
 # ============================================================================
 # Claude Code — Automated PR Review
 # ============================================================================
-# Thin wrapper around PitziLabs/shared-workflows/claude-review.yml.
+# Thin wrapper around lentago/shared-workflows/claude-review.yml.
 # Pinned to Haiku. Accepts bot-authored PRs (allowed_bots: "*").
 # ============================================================================
 
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-    uses: PitziLabs/shared-workflows/.github/workflows/claude-review.yml@main
+    uses: lentago/shared-workflows/.github/workflows/claude-review.yml@main
     secrets: inherit
     with:
       allowed_bots: "*"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,7 @@
 # ============================================================================
 # Claude Code — Interactive @claude Responder
 # ============================================================================
-# Thin wrapper around PitziLabs/shared-workflows/claude-responder.yml.
+# Thin wrapper around lentago/shared-workflows/claude-responder.yml.
 # ============================================================================
 
 name: Claude Code
@@ -26,7 +26,7 @@ jobs:
       issues: write
       id-token: write
       actions: read
-    uses: PitziLabs/shared-workflows/.github/workflows/claude-responder.yml@main
+    uses: lentago/shared-workflows/.github/workflows/claude-responder.yml@main
     secrets: inherit
     with:
       allowed_tools: '"Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch"'


### PR DESCRIPTION
Repoints the reusable-workflow references from the retired `PitziLabs` org to `lentago`, following the organization rename to Lentago Labs. GitHub Actions does not reliably resolve `uses:` through organization-transfer redirects, so the references must name the new org path explicitly. Workflow behavior is unchanged.