### PR TITLE
fix(alarm): drop the dead basement-kitchen door from House Openings

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -231,7 +231,6 @@ template:
           {{ is_state('binary_sensor.main_panel_front_door', 'on')
              or is_state('binary_sensor.main_panel_sliding_door', 'on')
              or is_state('binary_sensor.main_panel_garage_door', 'on')
-             or is_state('binary_sensor.basement_kitchen_door', 'on')
              or is_state('cover.garage_door_1_door', 'open')
              or is_state('cover.garage_door_2_door', 'open') }}
         attributes:
@@ -245,9 +244,6 @@ template:
             {% endif %}
             {% if is_state('binary_sensor.main_panel_garage_door', 'on') %}
               {% set names.open = names.open + ['Garage Entry'] %}
-            {% endif %}
-            {% if is_state('binary_sensor.basement_kitchen_door', 'on') %}
-              {% set names.open = names.open + ['Basement'] %}
             {% endif %}
             {% if is_state('cover.garage_door_1_door', 'open') %}
               {% set names.open = names.open + ['Garage 1'] %}


### PR DESCRIPTION
`binary_sensor.basement_kitchen_door` (a ZHA contact sensor) has been dead since 2026-06-01 — battery and device both gone, confirmed unrecoverable. Two references to it lingered in the `House Openings` template sensor in `configuration.yaml`: the perimeter-openings OR-chain and the `open_list` name builder. A permanently-`unavailable` entity in the OR-chain is silently falsy, so the basement door was quietly excluded from alarm escalation while still cluttering the config and flagging in Watchman.

This removes both references. The remaining openings (front, sliding, garage entry, garage covers) are unchanged, so the alarm-escalation behavior for live sensors is unaffected.

The physical device is being purged from the ZHA network registry separately (that step is a Home Assistant UI action — the config-entry device-removal API ZHA exposes isn't reachable via the MCP tooling).

Part of #332.