### PR TITLE
feat(dashboard): show live light color on Home light cards

### DIFF
--- a/dashboards/home-codesign.yaml
+++ b/dashboards/home-codesign.yaml
@@ -831,6 +831,7 @@ views:
             type: custom:mushroom-light-card
             entity: light.outdoor
             show_brightness_control: true
+            use_light_color: true
             tap_action:
               action: toggle
             hold_action:
@@ -844,6 +845,7 @@ views:
                 entity: light.front_door
                 name: Front
                 show_brightness_control: true
+                use_light_color: true
                 tap_action:
                   action: toggle
                 hold_action:

--- a/dashboards/home.yaml
+++ b/dashboards/home.yaml
@@ -817,6 +817,7 @@ views:
             type: custom:mushroom-light-card
             entity: light.outdoor
             show_brightness_control: true
+            use_light_color: true
             tap_action:
               action: toggle
             hold_action:
@@ -830,6 +831,7 @@ views:
                 entity: light.front_door
                 name: Front
                 show_brightness_control: true
+                use_light_color: true
                 tap_action:
                   action: toggle
                 hold_action:


### PR DESCRIPTION
Adds `use_light_color: true` to the two mushroom-light-card YAML anchors (`&room_ctrl` and `&mlight`) in `dashboards/home.yaml`, so every light tile on the Home dashboard — room master controls and per-light tiles alike — renders its icon and brightness slider in the light's current color instead of the static on-state accent. Lights without color support fall back to Mushroom's default on-state coloring, so switch-backed and brightness-only lights are unaffected.

Requested so the Home dashboard reflects each light's actual color setting at a glance. The change is made once per anchor and inherited by all merged tiles; `dashboards/home-codesign.yaml` is regenerated via `scripts/sync-home-codesign.sh` in the same commit to keep the co-design mirror in sync (CI-enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)