### PR TITLE
chore(readme): add Ask DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Home Assistant Configuration — Lentago Labs
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/lentago/homeassistant-config)
+
 **Authorship:** The YAML configuration, ESPHome firmware, automations, dashboards, scripts, and documentation in this repo are co-written with [Claude](https://claude.ai) (Anthropic). I direct the work and review the output; Claude writes the code. I'm an infrastructure operator, not a software engineer — please don't read this repo as a portfolio of coding ability.
 
 Git-controlled Home Assistant deployment running on Proxmox. Every configuration file is YAML-driven, version-controlled, and deployed through a structured AI-augmented development workflow.


### PR DESCRIPTION
Adds the **Ask DeepWiki** badge to the README, linking to this repo's auto-generated, queryable documentation wiki at https://deepwiki.com/lentago/homeassistant-config.

Part of the 2026-07-02 org-wide adoption of DeepWiki as the LLM-queryable documentation layer for all public Lentago Labs repos (all 16 are indexed; badges roll out to the 13 active repos only). Badge sits directly under the title; no other README content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)