### PR TITLE
Rebrand sweep: PitziLabs → Lentago Labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,10 +306,10 @@ or self-registering — none take a `configuration.yaml` block.
 
 This repository is one piece of a broader infrastructure portfolio at [github.com/lentago](https://github.com/lentago):
 
-- **[solidago](https://github.com/lentago/solidago)** (formerly foundry-platform-demo) — Terraform-managed three-tier AWS environment (VPC, ECS Fargate, RDS, ElastiCache, CI/CD)
-- **[firewalla-axiom-pipeline](https://github.com/lentago/firewalla-axiom-pipeline)** — Fluent Bit log pipeline shipping Firewalla network telemetry to Axiom
-- **[homelab-observability](https://github.com/lentago/homelab-observability)** — Grafana Cloud + Alloy observability for the Firewalla home network
-- **[workstation-bootstrap](https://github.com/lentago/workstation-bootstrap)** — Idempotent workstation provisioning for ChromeOS, Xubuntu, and Fedora
+- **[solidago](https://github.com/lentago/solidago)** — Terraform-managed three-tier AWS environment (VPC, ECS Fargate, RDS, ElastiCache, CI/CD)
+- **[betula](https://github.com/lentago/betula)** — Fluent Bit log pipeline shipping Firewalla network telemetry to Axiom
+- **[drosera](https://github.com/lentago/drosera)** — Grafana Cloud + Alloy observability for the Firewalla home network
+- **[kalmia](https://github.com/lentago/kalmia)** — Idempotent workstation provisioning for ChromeOS, Xubuntu, and Fedora
 
 ## License
 


### PR DESCRIPTION
Part of the fleet-wide PitziLabs → Lentago Labs rebrand sweep (living docs only; branch + PR per repo, review before merge).

## Changed
- `README.md` — portfolio cross-links: dropped the `(formerly foundry-platform-demo)` breadcrumb on solidago; `firewalla-axiom-pipeline` → `betula`; `homelab-observability` → `drosera`; `workstation-bootstrap` → `kalmia`.

## Found but deliberately NOT changed (guard rails)
- `context/entities.json` / `context/devices.json` — these are **exports of live HA state**. The `*_pitzilabs_*` storage entities mirror the Neptune NAS SMB share, which is still literally named `PitziLabs`, and the `sensor.pitzilabs_<repo>` GitHub sensors track pre-rename repo names. Editing the export would make it lie about the live system. If wanted, renaming those HA entities/sensors (and the share) is its own change with automation-consumer checks — happy to file an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
