### PR TITLE
Stop office/playroom flicker loops on an external off command

### DIFF
--- a/packages/hue_tap_dial_playroom.yaml
+++ b/packages/hue_tap_dial_playroom.yaml
@@ -43,6 +43,12 @@
 #   writes colour, never brightness, so the dial still dims the room while it
 #   runs. Same pattern as `script.office_sonoff_candle_loop`.
 #
+#   Off from outside this package (Alexa, dashboard, companion app, Assist)
+#   does not go through Button 4, so it never stops the loop — a plain
+#   light.turn_off is overwritten on the next pass and the bulbs stay lit.
+#   The `playroom_color_loop_external_off_guard` automation at the bottom of
+#   this file closes that gap.
+#
 # ZHA event signatures (PhilipsRDM002 quirk, zha-device-handlers):
 #   Buttons fire on cluster 0xFC00 (64512) with commands of the form
 #   `button_N_short_release` / `button_N_long_release` where N is 1-4.
@@ -532,3 +538,54 @@ automation:
           delta: "{{ -25 if trigger.event.data.args[0] == 1 else 25 }}"
     mode: queued
     max: 10
+
+  - id: playroom_color_loop_external_off_guard
+    alias: 'Playroom: external off stops the color loop'
+    description: >-
+      Makes "turn off the playroom lights" work from outside the tap dial.
+      Button 4 short calls script.turn_off on the color loop before turning the
+      bulbs off; Alexa, the dashboard, the companion app and Assist all call
+      plain light.turn_off, which the loop overwrites on its next pass (2.5 s
+      later) because it writes light.turn_on with hs_color — enough to re-light
+      a bulb that was just turned off. This guard watches for a bulb going off
+      while the loop is running, kills the loop, and re-issues the off.
+
+      Only the software loop (Button 1 long) needs this. The Hue native
+      colorloop effect (Button 4 long) runs on the bulbs themselves, so HA
+      sends nothing and an external off already works there.
+    triggers:
+      - trigger: state
+        entity_id:
+          - light.playroom_1
+          - light.playroom_2
+          - light.playroom_3
+          - light.playroom_4
+        from: 'on'
+        to: 'off'
+    conditions:
+      # The loop only ever writes colour, never brightness and never off, so an
+      # on→off transition while it runs came from outside the loop.
+      - condition: state
+        entity_id: script.playroom_color_loop
+        state: 'on'
+    # restart: an off command lands on all four bulbs at once, so several
+    # triggers fire within a few hundred ms. Only the last run needs to finish.
+    mode: restart
+    actions:
+      - action: script.turn_off
+        target:
+          entity_id: script.playroom_color_loop
+      # Let the loop's in-flight parallel light.turn_on calls land before the
+      # sweep, otherwise a late write re-lights a bulb behind us. The loop's
+      # writes carry transition: 2.5, so give them room to complete.
+      - delay:
+          seconds: 3
+      - action: light.turn_off
+        target:
+          entity_id:
+            - light.playroom_1
+            - light.playroom_2
+            - light.playroom_3
+            - light.playroom_4
+        data:
+          transition: 1

--- a/packages/sonoff_button_office.yaml
+++ b/packages/sonoff_button_office.yaml
@@ -76,6 +76,13 @@
 # applying. Transitioning into any flicker scene calls script.turn_on so the
 # apply script fires-and-forgets — it never waits on the infinite loop.
 #
+# Off from outside this package (Alexa, dashboard, companion app, Assist) does
+# NOT go through the handlers above, so it never stops the driver — a plain
+# light.turn_off is overwritten by the next tick and the lamps carry on
+# flickering. The `office_flicker_external_off_guard` automation at the bottom
+# of this file closes that: any lamp going off while the loop runs kills the
+# loop and re-sweeps the room off.
+#
 # The driver is also self-extending: HA's `repeat: while:` is capped at 10000
 # iterations per block; at the tick's delay draws (fire scenes average
 # ~420 ms calm-dominated, rainbows ~290 ms) each branch hits that cap after
@@ -522,3 +529,60 @@ automation:
           value: 1
       - action: script.office_sonoff_apply_scene
     mode: single
+
+  - id: office_flicker_external_off_guard
+    alias: 'Office: external off stops the flicker loop'
+    description: >-
+      Makes "turn off the office lights" work from outside the ZEN77 paddle and
+      the Sonoff button. Both of those handlers call script.turn_off on the
+      candle loop before turning the lamps off; Alexa, the dashboard, the
+      companion app and Assist all call plain light.turn_off, which the loop
+      overwrites on its next tick (90-700 ms later). The lamps then appear to
+      ignore the off command and keep flickering. This guard watches for a
+      lamp going off while the loop is running, kills the loop, and re-issues
+      the off so any tick already in flight is cleaned up.
+    triggers:
+      # corner_lamp is deliberately absent: while a meeting is active the
+      # meeting indicator owns it (packages/meeting_indicator.yaml) and turns
+      # it off on its own schedule, which is not an office-off request.
+      - trigger: state
+        entity_id:
+          - light.bookcase_lamp
+          - light.door_lamp
+          - light.desk_lamp_2
+          - light.desk_lamp_2_2
+          - light.table_lamp
+        from: 'on'
+        to: 'off'
+    conditions:
+      # The loop only ever writes light.turn_on — its deepest gutter frame is
+      # 30% brightness, never off — so an on→off transition while it runs can
+      # only have come from something outside the loop.
+      - condition: state
+        entity_id: script.office_sonoff_candle_loop
+        state: 'on'
+    variables:
+      # Same lamp set the ZEN77 / Sonoff off handlers use: corner_lamp stays
+      # out while a meeting owns it.
+      office_lamps: >-
+        {% set lamps = ['light.bookcase_lamp', 'light.door_lamp',
+          'light.desk_lamp_2', 'light.desk_lamp_2_2', 'light.table_lamp'] %}
+        {{ lamps if is_state('light.meeting_light', 'on')
+           else lamps + ['light.corner_lamp'] }}
+    # restart: an off command lands on all six lamps at once, so several
+    # triggers fire within a few hundred ms. Only the last run needs to finish.
+    mode: restart
+    actions:
+      - action: script.turn_off
+        target:
+          entity_id: script.office_sonoff_candle_loop
+      # Let the six parallel branches' in-flight light.turn_on calls land
+      # before the sweep, otherwise a late tick re-lights a lamp behind us.
+      - delay:
+          seconds: 1
+      - action: light.turn_off
+        target:
+          entity_id: '{{ office_lamps }}'
+      # The counter is deliberately left where it is, matching the paddle/button
+      # off handlers. With the lamps off, the next up-tap sees
+      # binary_sensor.office_lights_on == off and resets it to scene 1 anyway.


### PR DESCRIPTION
Turning the office lights off by voice left them flickering. The lamps went dark for a frame and lit again immediately, and the off command appeared to be ignored.

## Cause

`script.office_sonoff_candle_loop` drives the office flicker scenes (counter 4-9) as six parallel branches, each issuing a `light.turn_on` per lamp every 90-700 ms. Its only exit condition is `counter.office_sonoff_scene <= 3`. The two handlers that stop it — the ZEN77 down-tap and the Sonoff double/long-press — call `script.turn_off` on the loop *before* turning the lamps off.

Nothing outside this package does that. Alexa, the dashboard, the companion app and Assist all issue a plain `light.turn_off`, which lands correctly and is then overwritten by the next tick a few hundred milliseconds later. The result is a race the loop wins several times a second, which reads as flicker rather than as a failed command.

`script.playroom_color_loop` has the same gap. It writes `light.turn_on` with `hs_color` to all four bulbs every 2.5 s — enough to re-light a bulb that was just turned off — and its loop condition is `{{ true }}`, so it has no counter to fall back on. Only the tap dial's Button 4 stops it.

## Change

One guard automation per room. Each triggers on a lamp going `on` -> `off` while its driver script is running, stops the driver, waits for in-flight writes to land, and re-issues the off. Every off path now works — voice, dashboard, app, Assist — without touching the paddle, button or dial logic.

The `on` -> `off` transition is a safe signal for external intent in both rooms: the office loop's deepest gutter frame is 30% brightness and the play room loop never writes brightness at all, so neither driver can produce an `off` itself.

Details worth noting for review:

- **`corner_lamp` is excluded from the office trigger.** While a meeting is active the meeting indicator owns that lamp and turns it off on its own schedule, which is not an office-off request. The off *action* reuses the same `office_lamps` variable as the existing handlers, so `corner_lamp` also stays out of the sweep during a meeting.
- **`mode: restart`** on both — an off command hits every lamp in the room at once, so several triggers fire in quick succession and only the last run needs to complete.
- **The settle delay before the sweep** (1 s office, 3 s play room) covers writes already in flight when the driver is stopped. The play room gets longer because its writes carry `transition: 2.5`.
- **The office scene counter is deliberately left where it is**, matching the existing off handlers. With the lamps off, the next up-tap sees `binary_sensor.office_lights_on == off` and resets to scene 1 regardless.
- The Hue **native** colorloop effect (play room Button 4 long) needs no guard — it runs on the bulbs, so HA sends nothing to fight an off command.

Package header comments in both files are updated to document the external-off path alongside the existing binding docs.

## Deploy note

Both changed files are under `packages/`, which `gitops-sync.sh` routes to a full HA Core restart rather than a targeted reload.