### PR TITLE
Adopt the shared docs-check workflow

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,24 @@
+# ============================================================================
+# docs-check — relative markdown link resolution
+# ============================================================================
+# Thin wrapper around lentago/shared-workflows/docs-check.yml.
+#
+# Deliberately NOT path-filtered: this is built to serve as a required status
+# check, and a required check whose workflow never triggers is held "Expected"
+# forever, deadlocking every non-matching PR (the hard rule in
+# fleet-ops/required-checks.json). The checker is cheap and skips fast when no
+# markdown changed.
+#
+# Origin: lentago/.github#57 — docs-only PRs merged having asserted nothing,
+# and renames/removals are the fleet's most common cause of broken links.
+# ============================================================================
+
+name: docs-check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  docs-check:
+    uses: lentago/shared-workflows/.github/workflows/docs-check.yml@main


### PR DESCRIPTION
Adopts the reusable `docs-check` workflow from lentago/shared-workflows#28, which resolves relative markdown links across the repo's git-tracked markdown and fails on genuinely broken ones.

The motivation is lentago/.github#57: documentation is most of what the fleet ships, and renames and removals — its most common change class — are exactly what silently break relative links. The evidence there was a broken image on a public README that survived a deliberate rename audit, because nothing verified it.

The workflow is deliberately not path-filtered. It is built to serve as a required status check, and a required check whose workflow never triggers is held "Expected" forever and deadlocks every non-matching PR, per the standing rule in `fleet-ops/required-checks.json`. The checker is cheap and skips fast when no markdown changed.

Two link classes are skipped by rule rather than by hand-maintained ignore lists — the two that accounted for 237 of the 240 raw failures in the fleet-wide scan: site-absolute router routes, which an Astro/Starlight router resolves at build time, and links that escape the repo root, which is GitHub's `../../issues/N` navigation convention and can never point at a tracked file. This repo needs no additional `ignore` entries: it was scanned with the checker before this PR was opened and reports clean.

Part of a fleet-wide rollout; the matching `required-checks.json` mapping follows as a separate change in the `.github` meta-repo once the context name is observed off a live check-run.